### PR TITLE
fix: skip decorative images (logos) in page classifier

### DIFF
--- a/carta/config.py
+++ b/carta/config.py
@@ -36,6 +36,7 @@ DEFAULTS = {
         "vision_text_max_chars": 600,      # above → captions are cross-refs, skip
         "vision_flattened_min_yield": 50,  # GLM-OCR chars below this → LLaVA fallback
         "vision_max_images_per_page": 4,   # cap LLaVA calls per page (largest first)
+        "vision_image_min_area_fraction": 0.05,  # images smaller than 5% of page area are decorative
         "chunking": {
             "max_tokens": 800,
             "overlap_fraction": 0.15,

--- a/carta/vision/classifier.py
+++ b/carta/vision/classifier.py
@@ -53,6 +53,7 @@ class PageAnalyzer:
         embed = cfg.get("embed", {})
         self.text_min: int = embed.get("vision_text_min_chars", 150)
         self.text_max: int = embed.get("vision_text_max_chars", 600)
+        self.image_min_area_fraction: float = embed.get("vision_image_min_area_fraction", 0.05)
 
     def analyze(self, page: Any) -> PageProfile:
         """Return a PageProfile for *page*.
@@ -65,7 +66,7 @@ class PageAnalyzer:
         """
         text = page.get_text().strip()
         text_length = len(text)
-        has_images = bool(page.get_images())
+        has_images = self._has_significant_images(page)
         has_tables = self._detect_tables(page)
         has_captions = bool(FIGURE_CAPTION_RE.search(text))
         page_class = self._classify(text_length, has_images, has_tables, has_captions)
@@ -91,6 +92,41 @@ class PageAnalyzer:
         if has_images or (has_captions and text_length < self.text_max):
             return PageClass.TEXT_WITH_IMAGES
         return PageClass.PURE_TEXT
+
+    def _has_significant_images(self, page: Any) -> bool:
+        """Return True if the page has at least one image above the minimum area threshold.
+
+        Tiny decorative images (logos, watermarks, icons) are excluded.
+        Falls back to True if page geometry is unavailable, so real diagrams are never missed.
+
+        Args:
+            page: PyMuPDF fitz.Page object.
+
+        Returns:
+            bool.
+        """
+        images = page.get_images()
+        if not images:
+            return False
+        try:
+            r = page.rect
+            page_area = abs(r.width * r.height)
+        except Exception:
+            return True  # Can't measure page size — treat all images as significant
+        if page_area == 0:
+            return bool(images)
+        min_area = page_area * self.image_min_area_fraction
+        for img in images:
+            xref = img[0]
+            try:
+                rects = page.get_image_rects(xref)
+                if rects:
+                    ir = rects[0]
+                    if abs(ir.width * ir.height) >= min_area:
+                        return True
+            except Exception:
+                return True  # Can't measure image size — treat as significant
+        return False
 
     def _detect_tables(self, page: Any) -> bool:
         """Detect table structures via column-alignment heuristic."""

--- a/carta/vision/tests/test_classifier.py
+++ b/carta/vision/tests/test_classifier.py
@@ -9,8 +9,32 @@ from carta.vision.classifier import PageAnalyzer, PageClass, PageProfile, FIGURE
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_page(text: str = "", images: list = None, blocks: list = None) -> MagicMock:
-    """Build a minimal mock fitz Page for PageAnalyzer.analyze()."""
+def _mock_rect(x0: float, y0: float, x1: float, y1: float):
+    """Return a minimal rect-like object with width and height."""
+    r = MagicMock()
+    r.width = x1 - x0
+    r.height = y1 - y0
+    return r
+
+
+def _make_page(
+    text: str = "",
+    images: list = None,
+    blocks: list = None,
+    page_rect=None,
+    image_rects: dict = None,
+) -> MagicMock:
+    """Build a minimal mock fitz Page for PageAnalyzer.analyze().
+
+    Args:
+        text: text returned by page.get_text().
+        images: list of image tuples (first element is xref int).
+        blocks: list of block tuples for "blocks" fmt.
+        page_rect: mock rect with .width/.height; defaults to A4 (595×842).
+        image_rects: dict mapping xref → rect-like object for get_image_rects().
+                     Missing xrefs return []. Provide large rects for "real" images,
+                     small rects for logos/decorative images.
+    """
     page = MagicMock()
 
     def _get_text(fmt: str = "text", **kw):
@@ -20,6 +44,20 @@ def _make_page(text: str = "", images: list = None, blocks: list = None) -> Magi
 
     page.get_text.side_effect = _get_text
     page.get_images.return_value = images or []
+
+    # Default A4 page rect (595 × 842 points)
+    if page_rect is None:
+        page_rect = _mock_rect(0, 0, 595, 842)
+    page.rect = page_rect
+
+    # Image rect lookup
+    _image_rects = image_rects or {}
+
+    def _get_image_rects(xref):
+        return [_image_rects[xref]] if xref in _image_rects else []
+
+    page.get_image_rects.side_effect = _get_image_rects
+
     return page
 
 
@@ -81,24 +119,43 @@ class TestPageClassStructuredText:
         assert profile.has_tables
 
     def test_tables_take_priority_over_images(self):
-        """STRUCTURED_TEXT wins when both table and image signals present."""
+        """STRUCTURED_TEXT wins when both table and significant image signals present."""
         analyzer = PageAnalyzer({})
         page = _make_page(
             text="x" * 200,
             images=[(1, 0, 100, 100, 8, 0, 0)],
             blocks=_table_blocks(),
+            image_rects={1: _mock_rect(0, 0, 200, 200)},
         )
         assert analyzer.analyze(page).page_class == PageClass.STRUCTURED_TEXT
 
 
 class TestPageClassTextWithImages:
     def test_embedded_image_triggers(self):
-        """text ≥ MIN + embedded image → TEXT_WITH_IMAGES."""
+        """text ≥ MIN + significant embedded image → TEXT_WITH_IMAGES."""
         analyzer = PageAnalyzer({})
-        page = _make_page(text="x" * 200, images=[(1, 0, 100, 100, 8, 0, 0)])
+        # Image covers 200×200 pts = 40,000 sq pts; 5% of A4 = 25,065 sq pts → significant
+        page = _make_page(
+            text="x" * 200,
+            images=[(1, 0, 100, 100, 8, 0, 0)],
+            image_rects={1: _mock_rect(0, 0, 200, 200)},
+        )
         profile = analyzer.analyze(page)
         assert profile.page_class == PageClass.TEXT_WITH_IMAGES
         assert profile.has_images
+
+    def test_tiny_logo_with_long_text_is_pure_text(self):
+        """Company logo (tiny image) + long text → PURE_TEXT, not TEXT_WITH_IMAGES."""
+        analyzer = PageAnalyzer({})
+        # Logo covers 72×36 pts = 2,592 sq pts; well below 5% threshold of ~25,065
+        page = _make_page(
+            text="x" * 200,
+            images=[(1, 0, 100, 100, 8, 0, 0)],
+            image_rects={1: _mock_rect(0, 0, 72, 36)},
+        )
+        profile = analyzer.analyze(page)
+        assert not profile.has_images
+        assert profile.page_class == PageClass.PURE_TEXT
 
     def test_caption_below_text_max_triggers(self):
         """Caption + 300 chars (< 600 MAX) + no images → TEXT_WITH_IMAGES."""


### PR DESCRIPTION
## Summary

- Pages with a small header logo (e.g. company logo in top-left) were being classified as `TEXT_WITH_IMAGES` and triggering a full LLaVA call on a 1% logo crop — 2+ minutes wasted per page
- Root cause: `PageAnalyzer.analyze()` used `bool(page.get_images())` which fires for *any* embedded image regardless of size
- Fix: new `_has_significant_images()` checks that at least one image covers ≥ 5% of the page area before routing to `TEXT_WITH_IMAGES`; falls back to `True` (safe) when geometry is unavailable so real diagrams are never missed

## Test plan

- [x] `test_tiny_logo_with_long_text_is_pure_text` — new regression test: 72×36pt logo + long text → `PURE_TEXT`
- [x] `test_embedded_image_triggers` — updated: 200×200pt image (>5% of A4) still routes to `TEXT_WITH_IMAGES`
- [x] All 83 vision tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)