### PR TITLE
feat: install Carta skills during carta init

### DIFF
--- a/carta/cli.py
+++ b/carta/cli.py
@@ -237,7 +237,7 @@ def _check_path_conflict() -> None:
 def cmd_init(args):
     _check_path_conflict()
     from carta.install.bootstrap import run_bootstrap
-    run_bootstrap(Path.cwd())
+    run_bootstrap(Path.cwd(), skip_skills=getattr(args, "skip_skills", False))
     _notify_if_update()
 
 def cmd_doctor(args):
@@ -330,7 +330,12 @@ def main():
     parser.add_argument("--version", action="version", version=f"carta {__version__}")
     sub = parser.add_subparsers(dest="command")
 
-    sub.add_parser("init")
+    init_p = sub.add_parser("init", help="Initialize Carta in the current project")
+    init_p.add_argument(
+        "--skip-skills",
+        action="store_true",
+        help="Do not install Carta skills to ~/.claude/skills or .claude/skills",
+    )
     sub.add_parser("scan")
     sub.add_parser("embed")
 

--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -113,7 +113,7 @@ def _install_skills(choice: str, project_root: Path) -> tuple[int, int, str]:
     return (copied, already, display)
 
 
-def run_bootstrap(project_root: Path) -> None:
+def run_bootstrap(project_root: Path, *, skip_skills: bool = False) -> None:
     """Bootstrap Carta in a project with comprehensive preflight checks."""
     # Phase 0: Run comprehensive preflight checks
     from carta.install.preflight import PreflightChecker
@@ -213,6 +213,30 @@ def run_bootstrap(project_root: Path) -> None:
 
     _append_claude_md(project_root, project_name)
     _create_agents_md(project_root, project_name)
+
+    if not skip_skills:
+        if _is_interactive():
+            sk_choice = _prompt_skills_choice()
+            if sk_choice != "S":
+                copied, already, display = _install_skills(sk_choice, project_root)
+                if display and (copied > 0 or already > 0):
+                    msg_parts = []
+                    if copied:
+                        msg_parts.append(f"{copied} installed")
+                    if already:
+                        msg_parts.append(f"{already} already present")
+                    print(f"\n✓ Carta skills at {display}: {', '.join(msg_parts)}")
+                    print("  (Reload Claude Code to activate)")
+        else:
+            copied, already, display = _install_skills("G", project_root)
+            if display and (copied > 0 or already > 0):
+                msg_parts = []
+                if copied:
+                    msg_parts.append(f"{copied} installed")
+                if already:
+                    msg_parts.append(f"{already} already present")
+                print(f"\n✓ Carta skills at {display}: {', '.join(msg_parts)}")
+                print("  (Reload Claude Code to activate)")
 
     colls = f"{project_name}_doc, {project_name}_session, {project_name}_quirk"
     if collections_ok:

--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -36,6 +36,83 @@ def _prompt_user(message: str, default: bool = True) -> bool:
         return response in ("y", "yes", "true")
 
 
+def _skills_source_dir(project_root: Path) -> Path:
+    """Directory containing Carta skill markdown files shipped with the repo checkout."""
+    return project_root / "docs" / "superpowers" / "skills"
+
+
+def _skills_destination_root(choice: str, project_root: Path) -> Path:
+    """Root directory for Claude Code skills: global ~/.claude/skills or project .claude/skills."""
+    if choice == "G":
+        return Path.home() / ".claude" / "skills"
+    if choice == "P":
+        return project_root / ".claude" / "skills"
+    raise ValueError(f"Invalid skills choice: {choice!r}")
+
+
+def _prompt_skills_choice() -> str:
+    """Interactive G/P/S for skill installation. Default G."""
+    if not _is_interactive():
+        return "G"
+    try:
+        print("Install Carta skills? [G]lobal/[P]roject/[S]kip [G]: ", end="", flush=True)
+        line = input().strip().lower()
+    except (EOFError, OSError):
+        return "G"
+    if not line or line in ("g", "global"):
+        return "G"
+    if line in ("p", "project"):
+        return "P"
+    if line in ("s", "skip"):
+        return "S"
+    return "G"
+
+
+def _install_skills(choice: str, project_root: Path) -> tuple[int, int, str]:
+    """Copy each docs/superpowers/skills/*.md into Claude skill layout. Idempotent per file.
+
+    Returns:
+        (copied_count, already_present_count, display_path): new copies, skips because file
+        already existed, and a short path for messages (e.g. ~/.claude/skills or .claude/skills).
+        display_path is "" if nothing to report (missing source / empty dir).
+    """
+    source_dir = _skills_source_dir(project_root)
+    if not source_dir.is_dir():
+        print(
+            f"  Warning: skill sources not found ({source_dir}); skipping skill install.",
+            file=sys.stderr,
+        )
+        return (0, 0, "")
+
+    dest_root = _skills_destination_root(choice, project_root)
+    md_files = sorted(source_dir.glob("*.md"))
+    if not md_files:
+        print(f"  Warning: no .md files in {source_dir}; skipping skill install.", file=sys.stderr)
+        return (0, 0, "")
+
+    copied = 0
+    already = 0
+    for src in md_files:
+        stem = src.stem
+        dest_dir = dest_root / stem
+        dest_file = dest_dir / f"{stem}.md"
+        if dest_file.is_file():
+            already += 1
+            continue
+        try:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest_file)
+            copied += 1
+        except OSError as e:
+            print(f"  Warning: could not install skill {stem}: {e}", file=sys.stderr)
+
+    if choice == "G":
+        display = "~/.claude/skills"
+    else:
+        display = ".claude/skills"
+    return (copied, already, display)
+
+
 def run_bootstrap(project_root: Path) -> None:
     """Bootstrap Carta in a project with comprehensive preflight checks."""
     # Phase 0: Run comprehensive preflight checks

--- a/carta/install/tests/test_bootstrap.py
+++ b/carta/install/tests/test_bootstrap.py
@@ -261,10 +261,3 @@ def test_remove_plugin_cache_assertion_on_residue(tmp_path, capsys):
     assert result is False
     captured = capsys.readouterr()
     assert "plugin cache residue" in captured.err
-
-
-def test_install_skills_removed():
-    """_install_skills() must not exist — replaced by _remove_plugin_cache()."""
-    import carta.install.bootstrap as bootstrap_module
-    assert not hasattr(bootstrap_module, "_install_skills"), \
-        "_install_skills should have been removed; use _remove_plugin_cache() instead"

--- a/carta/install/tests/test_skills.py
+++ b/carta/install/tests/test_skills.py
@@ -1,0 +1,99 @@
+"""Tests for Carta Claude skill installation during bootstrap."""
+from pathlib import Path
+
+from carta.install.bootstrap import (
+    _install_skills,
+    _skills_destination_root,
+    _skills_source_dir,
+)
+
+
+def test_skills_source_dir_layout(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    d = _skills_source_dir(root)
+    assert d == root / "docs" / "superpowers" / "skills"
+
+
+def test_skills_destination_global(monkeypatch, tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr("carta.install.bootstrap.Path.home", lambda: fake_home)
+    p = _skills_destination_root("G", Path("/tmp/unused-for-global"))
+    assert p == fake_home / ".claude" / "skills"
+
+
+def test_skills_destination_project(tmp_path):
+    p = _skills_destination_root("P", tmp_path)
+    assert p == tmp_path / ".claude" / "skills"
+
+
+def test_install_skills_copies_to_global(tmp_path, monkeypatch):
+    """Copies each *.md into ~/.claude/skills/{stem}/{stem}.md when choice is G."""
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    src = project / "docs" / "superpowers" / "skills"
+    src.mkdir(parents=True)
+    (src / "audit-embed.md").write_text("---\nname: audit-embed\n---\nbody\n")
+
+    monkeypatch.setattr("carta.install.bootstrap.Path.home", lambda: home)
+
+    copied, already, display = _install_skills("G", project)
+    assert display == "~/.claude/skills"
+    dest = home / ".claude" / "skills" / "audit-embed" / "audit-embed.md"
+    assert dest.is_file()
+    assert "body" in dest.read_text()
+    assert copied == 1 and already == 0
+
+
+def test_install_skills_project_scope(tmp_path):
+    project = tmp_path / "proj"
+    src = project / "docs" / "superpowers" / "skills"
+    src.mkdir(parents=True)
+    (src / "carta-workflow.md").write_text("---\nname: carta-workflow\n---\n")
+
+    copied, already, display = _install_skills("P", project)
+    assert display == ".claude/skills"
+    dest = project / ".claude" / "skills" / "carta-workflow" / "carta-workflow.md"
+    assert dest.is_file()
+    assert copied == 1 and already == 0
+
+
+def test_install_skills_idempotent_skip_existing(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    src = project / "docs" / "superpowers" / "skills"
+    src.mkdir(parents=True)
+    (src / "audit-embed.md").write_text("new")
+    dest_dir = home / ".claude" / "skills" / "audit-embed"
+    dest_dir.mkdir(parents=True)
+    existing = dest_dir / "audit-embed.md"
+    existing.write_text("old")
+
+    monkeypatch.setattr("carta.install.bootstrap.Path.home", lambda: home)
+
+    copied, already, _ = _install_skills("G", project)
+    assert existing.read_text() == "old"
+    assert copied == 0 and already == 1
+
+
+def test_install_skills_missing_source_warns(tmp_path, capsys):
+    project = tmp_path / "proj"
+    project.mkdir()
+    copied, already, display = _install_skills("G", project)
+    assert copied == 0 and already == 0
+    assert display == ""
+    err = capsys.readouterr().err
+    assert "skill sources not found" in err
+
+
+def test_install_skills_empty_dir_warns(tmp_path, capsys):
+    project = tmp_path / "proj"
+    src = project / "docs" / "superpowers" / "skills"
+    src.mkdir(parents=True)
+    copied, already, display = _install_skills("G", project)
+    assert copied == 0 and already == 0
+    assert display == ""
+    assert "no .md files" in capsys.readouterr().err

--- a/docs/superpowers/skills/audit-embed.md
+++ b/docs/superpowers/skills/audit-embed.md
@@ -1,0 +1,18 @@
+---
+name: audit-embed
+description: Run and interpret Carta audit reports for embed pipeline consistency
+---
+
+# Carta audit and embed
+
+Use this skill when the user runs `carta audit`, reviews `audit-report.json`, or needs to reconcile sidecars with Qdrant.
+
+## When to use
+
+- After `carta embed` or before a release, to find orphaned chunks, stale sidecars, or hash drift.
+- When interpreting categories in the JSON report (see project docs).
+
+## Commands
+
+- `carta audit` — write structured report (default `audit-report.json` in repo root).
+- `carta embed` — re-embed changed files after fixes.

--- a/docs/superpowers/skills/carta-repair.md
+++ b/docs/superpowers/skills/carta-repair.md
@@ -1,0 +1,8 @@
+---
+name: carta-repair
+description: Interactive repair of audit findings (reserved for future carta repair flows)
+---
+
+# Carta repair (stub)
+
+Reserved for future interactive repair workflows. Until then, use **audit-embed** and manual fixes from the audit report.

--- a/docs/superpowers/skills/carta-workflow.md
+++ b/docs/superpowers/skills/carta-workflow.md
@@ -1,0 +1,8 @@
+---
+name: carta-workflow
+description: General Carta workflow — scan, embed, search, and session memory
+---
+
+# Carta workflow
+
+Guidance for `/doc-audit`, `/doc-embed`, `/doc-search`, and session memory using project config in `.carta/config.yaml`.

--- a/docs/superpowers/specs/2026-04-07-skill-installation-design.md
+++ b/docs/superpowers/specs/2026-04-07-skill-installation-design.md
@@ -1,0 +1,169 @@
+---
+title: Skill Installation for Carta Init
+date: 2026-04-07
+status: implemented
+---
+
+# Skill Installation Design
+
+## Overview
+
+Extend `carta init` to install Carta skills to Claude Code, giving users structured guidance on when/how to use Carta audit, search, and embedding workflows.
+
+Skills are stored in the repo (`docs/superpowers/skills/`) and installed to either global scope (`~/.claude/skills/`) or project scope (`.claude/skills/` at the repo root) at user choice.
+
+## Requirements
+
+- Prompt during `carta init`: "Install Carta skills? [G]lobal/[P]roject/[S]kip"
+- Copy all `.md` files from `docs/superpowers/skills/*` to destination
+- Handle conflicts gracefully (skip existing, don't overwrite)
+- Support three skills initially: `audit-embed`, `carta-workflow`, `carta-repair`
+- Allow `--skip-skills` flag to skip installation entirely
+- Idempotent (running `carta init` twice doesn't error)
+
+## Architecture
+
+### Skill Storage in Repo
+
+Skills live in `docs/superpowers/skills/` as individual Markdown files:
+- `docs/superpowers/skills/audit-embed.md` — audit report interpretation and usage
+- `docs/superpowers/skills/carta-workflow.md` — general Carta workflow guidance
+- `docs/superpowers/skills/carta-repair.md` — interactive repair flow (future)
+
+Each file has YAML frontmatter:
+```yaml
+---
+name: audit-embed
+description: Run and interpret Carta audit reports for data consistency
+---
+```
+
+### Installation Destinations
+
+**Global scope:** `~/.claude/skills/`
+```
+~/.claude/skills/
+  ├─ audit-embed/
+  │  └─ audit-embed.md
+  ├─ carta-workflow/
+  │  └─ carta-workflow.md
+  └─ carta-repair/
+     └─ carta-repair.md
+```
+
+**Project scope:** `.claude/skills/` (same layout as global; lives beside other project Claude Code config)
+
+```
+.claude/skills/
+  ├─ audit-embed/
+  │  └─ audit-embed.md
+  ├─ carta-workflow/
+  │  └─ carta-workflow.md
+  └─ carta-repair/
+     └─ carta-repair.md
+```
+
+Whether to commit `.claude/skills/` is a project choice (many teams commit `.claude/` for shared agent settings).
+
+### Installation Flow
+
+**Prompt (interactive only):**
+```
+Install Carta skills? [G]lobal/[P]roject/[S]kip [G]: 
+```
+
+- `G`: Install to `~/.claude/skills/` (shared across all projects on machine)
+- `P`: Install to `.claude/skills/` (this repo only; Claude Code’s project skill location)
+- `S`: Skip (user installs manually or defers)
+
+**Default:** `G` (global is recommended, easier to maintain)
+
+**Non-interactive mode:** Defaults to global if not running in a terminal.
+
+**Output:**
+```
+✓ Installed 3 Carta skills to ~/.claude/skills/
+  (Reload Claude Code to activate)
+```
+
+Or if project scope:
+```
+✓ Installed 3 Carta skills to .claude/skills/
+  (Reload Claude Code to activate)
+```
+
+### Implementation Details
+
+**Location:** `carta/install/bootstrap.py`
+
+**New function:** `_install_skills(choice: str, repo_root: Path, project_root: Path)`
+- Scans `docs/superpowers/skills/` for all `.md` files
+- Creates destination dirs (e.g., `~/.claude/skills/audit-embed/` or `{project_root}/.claude/skills/audit-embed/`)
+- Copies each `.md` file preserving name
+- Returns count of installed skills
+
+**Integration point:** In `run_bootstrap()`, after config creation and hook registration:
+```python
+if _is_interactive():
+    choice = _prompt_user_skills()  # Prompt G/P/S
+    if choice != "S":
+        _install_skills(choice, repo_root, project_root)
+else:
+    # Non-interactive: default to global (silent)
+    _install_skills("G", repo_root, project_root)
+```
+
+**Idempotency:**
+- Check if destination dir exists before copying
+- If skill already present, skip (no error, just count as installed)
+- Allows re-running `carta init` safely
+
+**CLI flag (optional for v1):**
+- `--skip-skills` flag to bypass prompt and skip installation
+- Useful for automation/testing
+
+### Error Handling
+
+- **Source dir missing:** Warn but don't fail (allow graceful degradation if repo is incomplete)
+- **Destination permission denied:** Warn and skip that skill; continue with others
+- **Non-interactive + no destination perms:** Warn and continue (don't block init)
+
+### Testing
+
+**Unit tests:**
+- `test_install_skills_global()` — mock global dest dir, verify copy
+- `test_install_skills_project()` — mock project dest dir, verify copy
+- `test_install_skills_skip()` — verify no-op when skipped
+- `test_install_skills_idempotent()` — verify second run doesn't error
+
+**Integration test:**
+- Full init with skill installation (mock filesystem)
+
+### Files to Create/Modify
+
+**New files:**
+- `docs/superpowers/skills/audit-embed.md` (existing content from plan)
+- `docs/superpowers/skills/carta-workflow.md` (new)
+- `docs/superpowers/skills/carta-repair.md` (new, stub for future)
+- `carta/install/tests/test_skills.py` (unit tests)
+
+**Modified files:**
+- `carta/install/bootstrap.py` — add `_install_skills()` and prompt logic
+- `carta/cli.py` — add `--skip-skills` flag to `carta init` (optional)
+
+## Success Criteria
+
+✓ Skills install to user-selected scope (global or project)
+✓ Non-interactive mode defaults to global without prompting
+✓ Installation is idempotent (re-running init doesn't break)
+✓ Users can skip installation with prompt or flag
+✓ All 3 initial skills copy successfully
+✓ Claude Code picks up skills after reload (user-verified)
+✓ Tests cover all code paths
+
+## Future Extensions
+
+- **Skill versioning:** Track installed skill versions, warn on mismatches
+- **Repair flow:** `carta repair --interactive` with Claude guidance
+- **Auto-update:** Check for newer skill versions on startup
+- **Custom skills:** Allow projects to define additional local skills under `.claude/skills/` (or document conventions alongside Carta-installed files)


### PR DESCRIPTION
## Summary

Extend `carta init` to copy Carta skill markdown from `docs/superpowers/skills/` into Claude Code skill locations:

- **Global:** `~/.claude/skills/{name}/{name}.md`
- **Project:** `.claude/skills/{name}/{name}.md`

Interactive prompt: **[G]lobal / [P]roject / [S]kip** (default G). Non-interactive runs install globally without prompting. Existing skill files are left unchanged (idempotent).

## CLI

- `carta init --skip-skills` — skip skill installation (automation/CI).

## Tests

- New `carta/install/tests/test_skills.py` for copy, project scope, idempotency, and missing/empty source.
- Removed obsolete test that asserted `_install_skills` must not exist.

## Docs

- Design spec `docs/superpowers/specs/2026-04-07-skill-installation-design.md` marked implemented.
- Implementation plan: `docs/superpowers/plans/2026-04-07-skill-installation.md` (reference).

## Verification

- `pytest` — full suite passing locally.


Made with [Cursor](https://cursor.com)