### PR TITLE
feat: bidirectional related link validation

### DIFF
--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -143,6 +143,56 @@ def check_broken_related(doc_path: Path, frontmatter: dict, repo_root: Path) -> 
     return issues
 
 
+def check_one_way_links(
+    doc_path: Path,
+    frontmatter: dict,
+    docs_with_frontmatter: dict,
+    repo_root: Path,
+) -> list:
+    """Flag related: entries that are not reciprocated by the target document.
+
+    When doc A lists doc B in its related: field, this check verifies that
+    doc B also lists doc A in its own related: field.  If the back-link is
+    absent a ``one_way_link`` warning is emitted for doc A so that humans (or
+    agents) know the graph edge is not bidirectional.
+
+    Only docs that *exist* and have parseable frontmatter are checked — broken
+    or missing-frontmatter targets are already flagged by other checks.
+
+    Args:
+        doc_path: Absolute path of the document being checked.
+        frontmatter: Parsed frontmatter dict for doc_path.
+        docs_with_frontmatter: Mapping of ``str(relative_path)`` → frontmatter
+            dict (or None) for every tracked document in the repo.
+        repo_root: Repository root used to compute relative paths.
+
+    Returns:
+        List of issue dicts with type ``one_way_link``.
+    """
+    issues = []
+    rel_doc = str(doc_path.relative_to(repo_root))
+    for rel_path in frontmatter.get("related") or []:
+        target = repo_root / rel_path
+        if not target.exists():
+            continue  # already handled by check_broken_related
+        target_fm = docs_with_frontmatter.get(rel_path)
+        if target_fm is None:
+            continue  # target has no frontmatter — not a structural error here
+        back_links = [str(r) for r in (target_fm.get("related") or [])]
+        if rel_doc not in back_links:
+            issues.append({
+                "type": "one_way_link",
+                "severity": "warning",
+                "doc": rel_doc,
+                "detail": (
+                    f"{rel_doc} lists '{rel_path}' in related:, "
+                    f"but '{rel_path}' does not list {rel_doc} back"
+                ),
+                "related_file": rel_path,
+            })
+    return issues
+
+
 def check_missing_frontmatter(doc_path: Path, frontmatter) -> Optional[dict]:
     """Return an issue if a tracked doc has no frontmatter."""
     if frontmatter is None:
@@ -249,7 +299,6 @@ def check_related_drift(doc_path: Path, frontmatter: dict, repo_root: Path) -> l
                 "related_git_hash": None,
             })
     return issues
-
 
 def build_inverted_index(docs_with_frontmatter: dict) -> dict:
     """Build inverted index: related_path -> set of docs that list it in related:."""
@@ -681,6 +730,7 @@ def run_scan(
         if prototype:
             issues.append(prototype)
         issues.extend(check_broken_related(doc_path, fm, repo_root))
+        issues.extend(check_one_way_links(doc_path, fm, frontmatters, repo_root))
         issues.extend(check_stale_last_reviewed(doc_path, fm, threshold, ref_date))
         issues.extend(check_related_drift(doc_path, fm, repo_root))
         orphan = check_orphaned_doc(doc_path, fm, inverted_index, repo_root)

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -565,3 +565,135 @@ def test_check_embed_transcript_unprocessed_has_summary(tmp_path):
     cfg = _minimal_cfg(tmp_path)
     issues = check_embed_transcript_unprocessed(tmp_path, cfg)
     assert len(issues) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_one_way_links
+# ---------------------------------------------------------------------------
+
+from carta.scanner.scanner import check_one_way_links
+
+
+def test_one_way_link_detected(tmp_path):
+    """A -> B where B does not list A back should emit one_way_link."""
+    (tmp_path / "docs" / "CAN").mkdir(parents=True)
+    doc_a = tmp_path / "docs" / "CAN" / "MESSAGE_FLOW.md"
+    doc_b = tmp_path / "docs" / "CAN" / "TOPOLOGY.md"
+    doc_a.write_text("# A\n")
+    doc_b.write_text("# B\n")
+
+    fm_a = {"related": ["docs/CAN/TOPOLOGY.md"], "last_reviewed": "2026-03-01"}
+    # B has frontmatter but does NOT back-link to A
+    fm_b = {"related": [], "last_reviewed": "2026-03-01"}
+    docs_fm = {
+        "docs/CAN/MESSAGE_FLOW.md": fm_a,
+        "docs/CAN/TOPOLOGY.md": fm_b,
+    }
+
+    issues = check_one_way_links(doc_a, fm_a, docs_fm, tmp_path)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "one_way_link"
+    assert issues[0]["severity"] == "warning"
+    assert "TOPOLOGY.md" in issues[0]["detail"]
+    assert issues[0]["related_file"] == "docs/CAN/TOPOLOGY.md"
+
+
+def test_bidirectional_link_no_issue(tmp_path):
+    """A -> B and B -> A: no one_way_link should be emitted."""
+    (tmp_path / "docs" / "CAN").mkdir(parents=True)
+    doc_a = tmp_path / "docs" / "CAN" / "MESSAGE_FLOW.md"
+    doc_b = tmp_path / "docs" / "CAN" / "TOPOLOGY.md"
+    doc_a.write_text("# A\n")
+    doc_b.write_text("# B\n")
+
+    fm_a = {"related": ["docs/CAN/TOPOLOGY.md"]}
+    fm_b = {"related": ["docs/CAN/MESSAGE_FLOW.md"]}
+    docs_fm = {
+        "docs/CAN/MESSAGE_FLOW.md": fm_a,
+        "docs/CAN/TOPOLOGY.md": fm_b,
+    }
+
+    issues = check_one_way_links(doc_a, fm_a, docs_fm, tmp_path)
+    assert issues == []
+
+
+def test_one_way_link_skips_nonexistent_target(tmp_path):
+    """Broken related entries (file missing) should be skipped — check_broken_related handles them."""
+    (tmp_path / "docs").mkdir(parents=True)
+    doc_a = tmp_path / "docs" / "ARCH.md"
+    doc_a.write_text("# A\n")
+
+    fm_a = {"related": ["docs/NONEXISTENT.md"]}
+    docs_fm = {"docs/ARCH.md": fm_a}
+
+    issues = check_one_way_links(doc_a, fm_a, docs_fm, tmp_path)
+    assert issues == []
+
+
+def test_one_way_link_skips_target_without_frontmatter(tmp_path):
+    """Target without parseable frontmatter is skipped (not a bidirectionality error)."""
+    (tmp_path / "docs" / "CAN").mkdir(parents=True)
+    doc_a = tmp_path / "docs" / "CAN" / "MESSAGE_FLOW.md"
+    doc_b = tmp_path / "docs" / "CAN" / "TOPOLOGY.md"
+    doc_a.write_text("# A\n")
+    doc_b.write_text("# B — no frontmatter\n")
+
+    fm_a = {"related": ["docs/CAN/TOPOLOGY.md"]}
+    docs_fm = {
+        "docs/CAN/MESSAGE_FLOW.md": fm_a,
+        "docs/CAN/TOPOLOGY.md": None,  # no frontmatter
+    }
+
+    issues = check_one_way_links(doc_a, fm_a, docs_fm, tmp_path)
+    assert issues == []
+
+
+def test_one_way_link_multiple_targets(tmp_path):
+    """Doc with two related entries where only one is reciprocated."""
+    (tmp_path / "docs" / "CAN").mkdir(parents=True)
+    for name in ["SOURCE.md", "RECIPROCAL.md", "ONE_WAY.md"]:
+        (tmp_path / "docs" / "CAN" / name).write_text("# doc\n")
+
+    fm_source = {"related": ["docs/CAN/RECIPROCAL.md", "docs/CAN/ONE_WAY.md"]}
+    fm_recip = {"related": ["docs/CAN/SOURCE.md"]}  # back-links correctly
+    fm_one_way = {"related": []}                     # no back-link
+
+    docs_fm = {
+        "docs/CAN/SOURCE.md": fm_source,
+        "docs/CAN/RECIPROCAL.md": fm_recip,
+        "docs/CAN/ONE_WAY.md": fm_one_way,
+    }
+
+    issues = check_one_way_links(
+        tmp_path / "docs" / "CAN" / "SOURCE.md", fm_source, docs_fm, tmp_path
+    )
+    assert len(issues) == 1
+    assert "ONE_WAY.md" in issues[0]["related_file"]
+
+
+def test_run_scan_includes_one_way_link(tmp_path):
+    """Integration: run_scan emits one_way_link issues when back-links are missing."""
+    from unittest.mock import patch
+
+    (tmp_path / "docs" / "CAN").mkdir(parents=True)
+    (tmp_path / "docs" / "CAN" / "MESSAGE_FLOW.md").write_text(
+        "---\nrelated:\n  - docs/CAN/TOPOLOGY.md\nlast_reviewed: 2026-03-18\n---\n# A\n"
+    )
+    (tmp_path / "docs" / "CAN" / "TOPOLOGY.md").write_text(
+        "---\nrelated: []\nlast_reviewed: 2026-03-18\n---\n# B\n"
+    )
+
+    cfg = {
+        "docs_root": "docs/",
+        "excluded_paths": [],
+        "stale_threshold_days": 30,
+    }
+    output_path = tmp_path / "scan-results.json"
+
+    with patch("carta.scanner.scanner.get_current_git_hash", return_value="abc123"), \
+         patch("carta.scanner.scanner.get_file_last_commit_date", return_value=None):
+        result = run_scan(tmp_path, cfg, output_path, reference_date=date(2026, 3, 18))
+
+    one_way = [i for i in result["issues"] if i["type"] == "one_way_link"]
+    assert len(one_way) >= 1
+    assert any("TOPOLOGY.md" in i["detail"] for i in one_way)


### PR DESCRIPTION
## Motivation (ET-embed use case)

`ET-embed/AUDIT_REPORT.md` **AUDIT-012** tracks 26 `stale_related` edges across 15+ docs. Investigation of the ET-embed graph reveals that many of those edges are *one-directional*: `docs/CAN/MESSAGE_FLOW.md` lists `docs/CAN/TOPOLOGY.md` in its `related:` field, but `TOPOLOGY.md` does not list `MESSAGE_FLOW.md` back. This means:

- Agents traversing the graph (e.g. via `carta search --hops N` — Target 3) miss half the reachable docs.
- The orphan detector (`check_orphaned_doc`) can falsely clear a doc that's referenced only from a root-level file outside `docs/`.
- Humans reviewing the audit report can't tell whether a link is intentionally asymmetric or a maintenance gap.

## Implementation

**New function:** `check_one_way_links(doc_path, frontmatter, docs_with_frontmatter, repo_root)` in `carta/scanner/scanner.py`.

Logic:
1. For each `related:` entry in doc A that resolves to an existing file:
2. Look up that file's frontmatter in the `docs_with_frontmatter` mapping (built once per scan).
3. If the target has no frontmatter, skip (not a bidirectionality error — already flagged by `missing_frontmatter`).
4. If the target's `related:` list does not contain doc A's relative path, emit a `one_way_link` warning.

**Wiring:** called from `run_scan()` immediately after `check_broken_related()` for every tracked doc with frontmatter. No new I/O; reuses the `frontmatters` dict already built during the scan pass.

**Issue type:** `one_way_link`, severity `warning`, fields: `doc`, `detail`, `related_file`.

## Test summary

6 new tests in `carta/scanner/tests/test_scanner.py`:

| Test | Description |
|------|-------------|
| `test_one_way_link_detected` | A→B where B has empty related: emits one_way_link |
| `test_bidirectional_link_no_issue` | A→B and B→A: no issue |
| `test_one_way_link_skips_nonexistent_target` | Broken targets deferred to check_broken_related |
| `test_one_way_link_skips_target_without_frontmatter` | No-frontmatter targets skipped |
| `test_one_way_link_multiple_targets` | Only the non-reciprocating target is flagged |
| `test_run_scan_includes_one_way_link` | Integration: run_scan emits the issue |

All 264 existing tests continue to pass.