### PR TITLE
feat: graph-walk search (carta search --hops N)

### DIFF
--- a/carta/cli.py
+++ b/carta/cli.py
@@ -204,6 +204,22 @@ def cmd_search(args):
         return
     for r in results:
         print(f"[{r['score']:.2f}] {r['source']} — {r['excerpt']}")
+
+    # Graph-walk expansion via --hops
+    hops = getattr(args, "hops", 0)
+    if hops > 0:
+        from carta.search.graph import build_related_graph, walk_hops
+        repo_root = cfg_path.parent.parent
+        docs_root_rel = cfg.get("docs_root", "docs/").rstrip("/")
+        graph = build_related_graph(repo_root, repo_root / docs_root_rel)
+        seeds = [r["source"] for r in results if r.get("source")]
+        hop_results = walk_hops(seeds, graph, hops)
+        if hop_results:
+            print()
+            print(f"\U0001f310 Related via graph ({hops}-hop expansion):")
+            for h in hop_results:
+                print(f"  [{h['hop']}-hop] {h['doc']}  (via {h['via']})")
+
     _notify_if_update(cfg_path, cfg)
 
 def cmd_update(args):
@@ -391,8 +407,18 @@ def main():
     doctor_p.add_argument("--verbose", "-v", action="store_true", help="Show detailed output")
     doctor_p.add_argument("--json", action="store_true", help="Output in JSON format")
     
-    search_p = sub.add_parser("search")
+    search_p = sub.add_parser("search", help="Semantic search over embedded documents")
     search_p.add_argument("query", nargs="+")
+    search_p.add_argument(
+        "--hops",
+        type=int,
+        default=0,
+        metavar="N",
+        help=(
+            "After returning semantic results, also return docs linked via related: "
+            "within N hops of each result (default: 0 = no graph expansion)"
+        ),
+    )
 
     update_p = sub.add_parser("update", help="Update carta to the latest version")
     update_p.add_argument("--check", action="store_true", help="Show available version without upgrading")

--- a/carta/search/graph.py
+++ b/carta/search/graph.py
@@ -1,0 +1,91 @@
+"""Graph-walk utilities for hop-based related: document traversal.
+
+Provides BFS/DFS over the ``related:`` frontmatter graph so that ``carta search``
+can surface contextually adjacent documents within N hops of the initial semantic
+search results.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from carta.scanner.scanner import parse_frontmatter
+
+
+def build_related_graph(repo_root: Path, docs_root: Optional[Path] = None) -> dict[str, list[str]]:
+    """Parse all markdown docs under docs_root and return the related: adjacency list.
+
+    Args:
+        repo_root: Repository root path.
+        docs_root: Subtree to scan.  Defaults to ``repo_root/docs``.
+
+    Returns:
+        Dict mapping ``str(relative_path)`` → list of related paths (strings,
+        as they appear in frontmatter — may or may not exist on disk).
+    """
+    if docs_root is None:
+        docs_root = repo_root / "docs"
+    graph: dict[str, list[str]] = {}
+    if not docs_root.exists():
+        return graph
+    for md_path in docs_root.rglob("*.md"):
+        if ".git" in md_path.parts:
+            continue
+        rel = str(md_path.relative_to(repo_root))
+        fm = parse_frontmatter(md_path)
+        graph[rel] = list(fm.get("related") or []) if fm else []
+    return graph
+
+
+def walk_hops(
+    seeds: list[str],
+    graph: dict[str, list[str]],
+    hops: int,
+) -> list[dict]:
+    """BFS expansion of seed documents through the related: graph.
+
+    Starting from each document in *seeds*, expand outward up to *hops* steps
+    through the ``related:`` adjacency list.  Documents already present in
+    *seeds* are included only if they are independently reachable via a hop.
+
+    Args:
+        seeds: Relative paths of the initial (semantic-search) result documents.
+        graph: Adjacency list from :func:`build_related_graph`.
+        hops: Maximum number of traversal steps (0 = no expansion).
+
+    Returns:
+        List of dicts ordered by ascending hop distance then path::
+
+            [
+                {"doc": "docs/CAN/TOPOLOGY.md", "hop": 1, "via": "docs/CAN/MESSAGE_FLOW.md"},
+                ...
+            ]
+
+        Only documents that are **not** already in *seeds* are returned.
+    """
+    if hops <= 0:
+        return []
+
+    seed_set = set(seeds)
+    visited: set[str] = set(seeds)
+    # frontier: list of (doc_path, hop_distance, via_path)
+    frontier: list[tuple[str, int, str]] = []
+
+    for seed in seeds:
+        for neighbour in graph.get(seed, []):
+            if neighbour not in visited:
+                frontier.append((neighbour, 1, seed))
+                visited.add(neighbour)
+
+    results: list[dict] = []
+    while frontier:
+        doc, hop, via = frontier.pop(0)
+        if doc not in seed_set:
+            results.append({"doc": doc, "hop": hop, "via": via})
+        if hop < hops:
+            for neighbour in graph.get(doc, []):
+                if neighbour not in visited:
+                    frontier.append((neighbour, hop + 1, doc))
+                    visited.add(neighbour)
+
+    results.sort(key=lambda x: (x["hop"], x["doc"]))
+    return results

--- a/carta/tests/test_graph_walk.py
+++ b/carta/tests/test_graph_walk.py
@@ -1,0 +1,186 @@
+"""Tests for carta.search.graph — graph-walk hop expansion."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from carta.search.graph import build_related_graph, walk_hops
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_doc(path: Path, related: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---", "related:"]
+    for r in related:
+        lines.append(f"  - {r}")
+    lines += ["last_reviewed: 2026-03-18", "---", "# Doc\n"]
+    path.write_text("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# build_related_graph
+# ---------------------------------------------------------------------------
+
+def test_build_related_graph_basic(tmp_path):
+    docs = tmp_path / "docs" / "CAN"
+    docs.mkdir(parents=True)
+    _write_doc(docs / "MESSAGE_FLOW.md", ["docs/CAN/TOPOLOGY.md", "docs/CAN/SAFETY.md"])
+    _write_doc(docs / "TOPOLOGY.md", ["docs/CAN/MESSAGE_FLOW.md"])
+    _write_doc(docs / "SAFETY.md", [])
+
+    graph = build_related_graph(tmp_path)
+
+    assert "docs/CAN/MESSAGE_FLOW.md" in graph
+    assert "docs/CAN/TOPOLOGY.md" in graph["docs/CAN/MESSAGE_FLOW.md"]
+    assert "docs/CAN/SAFETY.md" in graph["docs/CAN/MESSAGE_FLOW.md"]
+    assert "docs/CAN/MESSAGE_FLOW.md" in graph["docs/CAN/TOPOLOGY.md"]
+    assert graph["docs/CAN/SAFETY.md"] == []
+
+
+def test_build_related_graph_no_frontmatter(tmp_path):
+    """Docs without frontmatter should appear in graph with empty adjacency."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "BARE.md").write_text("# Bare doc — no frontmatter\n")
+
+    graph = build_related_graph(tmp_path)
+    assert "docs/BARE.md" in graph
+    assert graph["docs/BARE.md"] == []
+
+
+def test_build_related_graph_missing_docs_root(tmp_path):
+    """Returns empty graph when docs_root doesn't exist."""
+    graph = build_related_graph(tmp_path, tmp_path / "nonexistent")
+    assert graph == {}
+
+
+# ---------------------------------------------------------------------------
+# walk_hops
+# ---------------------------------------------------------------------------
+
+def test_walk_hops_zero(tmp_path):
+    """hops=0 should always return an empty list."""
+    graph = {
+        "docs/A.md": ["docs/B.md"],
+        "docs/B.md": [],
+    }
+    assert walk_hops(["docs/A.md"], graph, hops=0) == []
+
+
+def test_walk_hops_one(tmp_path):
+    """hops=1 should return direct neighbours not already in seeds."""
+    graph = {
+        "docs/A.md": ["docs/B.md", "docs/C.md"],
+        "docs/B.md": ["docs/D.md"],
+        "docs/C.md": [],
+        "docs/D.md": [],
+    }
+    results = walk_hops(["docs/A.md"], graph, hops=1)
+    docs = [r["doc"] for r in results]
+    assert "docs/B.md" in docs
+    assert "docs/C.md" in docs
+    assert "docs/D.md" not in docs  # 2 hops away
+
+
+def test_walk_hops_two(tmp_path):
+    """hops=2 should reach docs/D.md via docs/A.md → docs/B.md → docs/D.md."""
+    graph = {
+        "docs/A.md": ["docs/B.md"],
+        "docs/B.md": ["docs/D.md"],
+        "docs/D.md": [],
+    }
+    results = walk_hops(["docs/A.md"], graph, hops=2)
+    docs = [r["doc"] for r in results]
+    assert "docs/B.md" in docs
+    assert "docs/D.md" in docs
+
+    d_entry = next(r for r in results if r["doc"] == "docs/D.md")
+    assert d_entry["hop"] == 2
+    assert d_entry["via"] == "docs/B.md"
+
+
+def test_walk_hops_no_duplicates(tmp_path):
+    """A doc reachable via multiple paths should appear only once (first encounter)."""
+    graph = {
+        "docs/A.md": ["docs/B.md", "docs/C.md"],
+        "docs/B.md": ["docs/D.md"],
+        "docs/C.md": ["docs/D.md"],
+        "docs/D.md": [],
+    }
+    results = walk_hops(["docs/A.md"], graph, hops=2)
+    docs = [r["doc"] for r in results]
+    assert docs.count("docs/D.md") == 1
+
+
+def test_walk_hops_seeds_excluded_from_results(tmp_path):
+    """Seed documents should not appear in the hop results."""
+    graph = {
+        "docs/A.md": ["docs/B.md"],
+        "docs/B.md": ["docs/A.md"],  # back-link to seed
+    }
+    results = walk_hops(["docs/A.md"], graph, hops=1)
+    docs = [r["doc"] for r in results]
+    assert "docs/A.md" not in docs
+    assert "docs/B.md" in docs
+
+
+def test_walk_hops_multiple_seeds(tmp_path):
+    """Multiple seeds should expand their neighbourhoods correctly."""
+    graph = {
+        "docs/A.md": ["docs/C.md"],
+        "docs/B.md": ["docs/D.md"],
+        "docs/C.md": [],
+        "docs/D.md": [],
+    }
+    results = walk_hops(["docs/A.md", "docs/B.md"], graph, hops=1)
+    docs = [r["doc"] for r in results]
+    assert "docs/C.md" in docs
+    assert "docs/D.md" in docs
+
+
+def test_walk_hops_cycle_safe(tmp_path):
+    """Cyclic related: graphs should not cause infinite loops."""
+    graph = {
+        "docs/A.md": ["docs/B.md"],
+        "docs/B.md": ["docs/C.md"],
+        "docs/C.md": ["docs/A.md"],
+    }
+    # Should terminate without error
+    results = walk_hops(["docs/A.md"], graph, hops=5)
+    docs = [r["doc"] for r in results]
+    assert "docs/B.md" in docs
+    assert "docs/C.md" in docs
+    assert docs.count("docs/A.md") == 0  # seed excluded
+
+
+def test_walk_hops_result_structure(tmp_path):
+    """Each result dict must have doc, hop, and via keys."""
+    graph = {
+        "docs/A.md": ["docs/B.md"],
+        "docs/B.md": [],
+    }
+    results = walk_hops(["docs/A.md"], graph, hops=1)
+    assert len(results) == 1
+    r = results[0]
+    assert set(r.keys()) >= {"doc", "hop", "via"}
+    assert r["hop"] == 1
+    assert r["via"] == "docs/A.md"
+
+
+def test_walk_hops_end_to_end(tmp_path):
+    """Integration: build graph from real files then walk hops."""
+    docs = tmp_path / "docs" / "CAN"
+    docs.mkdir(parents=True)
+    _write_doc(docs / "MESSAGE_FLOW.md", ["docs/CAN/TOPOLOGY.md"])
+    _write_doc(docs / "TOPOLOGY.md", ["docs/CAN/SAFETY.md"])
+    _write_doc(docs / "SAFETY.md", [])
+
+    graph = build_related_graph(tmp_path)
+    results = walk_hops(["docs/CAN/MESSAGE_FLOW.md"], graph, hops=2)
+    docs_reached = [r["doc"] for r in results]
+
+    assert "docs/CAN/TOPOLOGY.md" in docs_reached  # hop 1
+    assert "docs/CAN/SAFETY.md" in docs_reached    # hop 2


### PR DESCRIPTION
## Motivation (ET-embed use case)

`ET-embed` has a dense hardware/firmware docs graph with well-defined subsystem clusters (CAN bus, PCB, TELEMETRY, devcontainer). When an agent runs `carta search "CAN topology"`, it gets the top semantic hit (`docs/CAN/TOPOLOGY.md`) but misses `MESSAGE_FLOW.md`, `SAFETY-MCU-MESSAGES.md`, and other docs that are semantically adjacent via `related:` edges but don't score highly enough in the semantic search alone.

**AUDIT-012** shows 26 stale related edges — most affecting the CAN and TELEMETRY subsystems. An agent that can walk the graph automatically after a semantic query would discover the full subsystem context without needing multiple search round-trips. This is especially useful for the ET-embed MCP server where each tool call is bounded.

From `.carta/config.yaml`:
```yaml
proactive_recall:
  high_threshold: 0.85
```
A `--hops 2` walk from any high-confidence semantic result would automatically pull in the subsystem docs that fall below 0.85 but are structurally linked.

## Implementation

**New module `carta/search/graph.py`:**

- `build_related_graph(repo_root, docs_root)` — parses YAML frontmatter for every `.md` file under `docs_root` and returns a `dict[str, list[str]]` adjacency list.

- `walk_hops(seeds, graph, hops)` — BFS expansion. Returns a list of `{"doc": str, "hop": int, "via": str}` dicts for all docs reachable within `hops` steps from any seed. Properties:
  - Cycle-safe (visited set prevents infinite loops)
  - Deduplicates across multiple seeds (first encounter wins)
  - Seeds excluded from results
  - Sorted by (hop, doc) for stable output

**`carta/cli.py`:**
- New `--hops N` argument on `carta search` (default: 0, no expansion)
- After printing semantic results, calls `build_related_graph` + `walk_hops` and prints hop results:

```
🌐 Related via graph (2-hop expansion):
  [1-hop] docs/CAN/MESSAGE_FLOW.md  (via docs/CAN/TOPOLOGY.md)
  [2-hop] docs/CAN/SAFETY.md        (via docs/CAN/MESSAGE_FLOW.md)
```

No changes to the Qdrant schema or collection naming.

## Test summary

12 new tests in `carta/tests/test_graph_walk.py`:

| Test | Description |
|------|-------------|
| `test_build_related_graph_basic` | Adjacency list built correctly from frontmatter |
| `test_build_related_graph_no_frontmatter` | Docs without frontmatter → empty adjacency |
| `test_build_related_graph_missing_docs_root` | Returns {} when docs_root doesn't exist |
| `test_walk_hops_zero` | hops=0 always returns [] |
| `test_walk_hops_one` | Direct neighbours returned; depth-2 docs excluded |
| `test_walk_hops_two` | 2-hop traversal reaches depth-2 docs with correct via |
| `test_walk_hops_no_duplicates` | Doc reachable via 2 paths appears once |
| `test_walk_hops_seeds_excluded_from_results` | Back-links to seeds not surfaced |
| `test_walk_hops_multiple_seeds` | Independent seed expansions merged |
| `test_walk_hops_cycle_safe` | Cyclic graph terminates without loop |
| `test_walk_hops_result_structure` | Each result has doc, hop, via keys |
| `test_walk_hops_end_to_end` | Full: build graph from files then walk |

All 264 existing tests continue to pass.