### PR TITLE
perf(embed,vision): parallelize page vision + chunk embedding

### DIFF
--- a/carta/config.py
+++ b/carta/config.py
@@ -37,6 +37,8 @@ DEFAULTS = {
         "vision_flattened_min_yield": 50,  # GLM-OCR chars below this → LLaVA fallback
         "vision_max_images_per_page": 4,   # cap LLaVA calls per page (largest first)
         "vision_image_min_area_fraction": 0.05,  # images smaller than 5% of page area are decorative
+        "vision_workers": 4,               # parallel vision/OCR HTTP calls per PDF (1 = serial)
+        "embedding_workers": 8,            # parallel text-embedding HTTP calls (1 = serial)
         "file_timeout_s": 600,  # seconds allowed per file; raise for large/dense PDFs
         "chunking": {
             "max_tokens": 800,

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -1,5 +1,6 @@
 """Ollama embedding and Qdrant upsert for carta embed."""
 
+import concurrent.futures
 import hashlib
 import uuid
 
@@ -110,66 +111,81 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
         Number of points upserted.
     """
     coll_name = collection_name(cfg, "doc")
-    ollama_url = cfg["embed"]["ollama_url"]
-    model = cfg["embed"]["ollama_model"]
+    embed_cfg = cfg["embed"]
+    ollama_url = embed_cfg["ollama_url"]
+    model = embed_cfg["ollama_model"]
+    workers = max(1, int(embed_cfg.get("embedding_workers", 8)))
 
     if client is None:
         qdrant_url = cfg["qdrant_url"]
         client = QdrantClient(url=qdrant_url, timeout=5)
     ensure_collection(client, coll_name)
 
+    def build_point(chunk: dict, vec: list[float]) -> PointStruct:
+        payload = {k: v for k, v in chunk.items() if k != "text"}
+        payload["text"] = chunk["text"]
+        payload["doc_generation"] = chunk.get("doc_generation", 1)
+        payload["stale_as_of"] = None
+        payload["superseded_at"] = None
+        payload["orphaned_at"] = None
+        payload["sidecar_id"] = chunk.get("sidecar_id", "")
+        payload["chunk_source_hash"] = chunk.get("chunk_source_hash", "")
+
+        if chunk.get("doc_generation") is not None:
+            point_id = _point_id_versioned(
+                chunk["slug"], chunk["chunk_index"], chunk["doc_generation"]
+            )
+        else:
+            point_id = _point_id(chunk["slug"], chunk["chunk_index"])
+        return PointStruct(id=point_id, vector=vec, payload=payload)
+
+    def flush(batch: list[PointStruct]) -> int:
+        if not batch:
+            return 0
+        try:
+            client.upsert(collection_name=coll_name, points=batch)
+            return len(batch)
+        except Exception as e:
+            print(f"Warning: batch upsert failed — {e}", flush=True)
+            return 0
+
     upserted = 0
     batch: list[PointStruct] = []
 
-    for chunk in chunks:
-        chunk_id = f"{chunk.get('slug', '?')}[{chunk.get('chunk_index', '?')}]"
-        try:
-            vec = get_embedding(chunk["text"], ollama_url=ollama_url, model=model)
-            payload = {k: v for k, v in chunk.items() if k != "text"}
-            payload["text"] = chunk["text"]
-
-            # Add lifecycle fields to payload (Plan 999.1-02)
-            payload["doc_generation"] = chunk.get("doc_generation", 1)
-            payload["stale_as_of"] = None
-            payload["superseded_at"] = None
-            payload["orphaned_at"] = None
-            payload["sidecar_id"] = chunk.get("sidecar_id", "")
-            payload["chunk_source_hash"] = chunk.get("chunk_source_hash", "")
-
-            # Use versioned ID if doc_generation present, else fall back to legacy ID
-            if chunk.get("doc_generation") is not None:
-                point_id = _point_id_versioned(
-                    chunk["slug"], chunk["chunk_index"], chunk["doc_generation"]
-                )
-            else:
-                point_id = _point_id(chunk["slug"], chunk["chunk_index"])
-
-            point = PointStruct(
-                id=point_id,
-                vector=vec,
-                payload=payload,
-            )
-            batch.append(point)
-        except Exception as e:
-            print(f"Warning: skipping chunk {chunk_id} — {e}", flush=True)
-            continue
-
-        if len(batch) >= BATCH_SIZE:
+    if workers == 1:
+        for chunk in chunks:
+            chunk_id = f"{chunk.get('slug', '?')}[{chunk.get('chunk_index', '?')}]"
             try:
-                client.upsert(collection_name=coll_name, points=batch)
-                upserted += len(batch)
+                vec = get_embedding(chunk["text"], ollama_url=ollama_url, model=model)
+                batch.append(build_point(chunk, vec))
             except Exception as e:
-                print(f"Warning: batch upsert failed — {e}", flush=True)
-            batch = []
+                print(f"Warning: skipping chunk {chunk_id} — {e}", flush=True)
+                continue
+            if len(batch) >= BATCH_SIZE:
+                upserted += flush(batch)
+                batch = []
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix="carta-embed"
+        ) as ex:
+            future_to_chunk = {
+                ex.submit(get_embedding, c["text"], ollama_url=ollama_url, model=model): c
+                for c in chunks
+            }
+            for fut in concurrent.futures.as_completed(future_to_chunk):
+                chunk = future_to_chunk[fut]
+                chunk_id = f"{chunk.get('slug', '?')}[{chunk.get('chunk_index', '?')}]"
+                try:
+                    vec = fut.result()
+                    batch.append(build_point(chunk, vec))
+                except Exception as e:
+                    print(f"Warning: skipping chunk {chunk_id} — {e}", flush=True)
+                    continue
+                if len(batch) >= BATCH_SIZE:
+                    upserted += flush(batch)
+                    batch = []
 
-    # Flush remaining points
-    if batch:
-        try:
-            client.upsert(collection_name=coll_name, points=batch)
-            upserted += len(batch)
-        except Exception as e:
-            print(f"Warning: batch upsert failed — {e}", flush=True)
-
+    upserted += flush(batch)
     return upserted
 
 

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -481,6 +481,44 @@ def test_upsert_chunks_uses_cfg_ollama_url(mock_embed, mock_qdrant_cls):
     assert kwargs.get("ollama_url") == "http://custom-ollama:11434"
 
 
+@patch("carta.embed.embed.QdrantClient")
+@patch("carta.embed.embed.get_embedding")
+def test_upsert_chunks_serial_when_workers_is_1(mock_embed, mock_qdrant_cls):
+    """embedding_workers=1 must use serial path and embed every chunk in order."""
+    seen_order: list[int] = []
+
+    def embed_side_effect(text, **kwargs):
+        seen_order.append(int(text.split()[-1]))
+        return [0.1] * 768
+
+    mock_embed.side_effect = embed_side_effect
+    mock_client = MagicMock()
+    mock_client.collection_exists.return_value = True
+    mock_qdrant_cls.return_value = mock_client
+
+    cfg = {**MINIMAL_CFG, "embed": {**MINIMAL_CFG["embed"], "embedding_workers": 1}}
+    count = upsert_chunks(_make_chunks(5), cfg)
+
+    assert count == 5
+    assert seen_order == [0, 1, 2, 3, 4]  # serial path preserves submit order
+
+
+@patch("carta.embed.embed.QdrantClient")
+@patch("carta.embed.embed.get_embedding")
+def test_upsert_chunks_parallel_embeds_all_chunks(mock_embed, mock_qdrant_cls):
+    """embedding_workers>1 must call get_embedding for every chunk (any order)."""
+    mock_embed.return_value = [0.1] * 768
+    mock_client = MagicMock()
+    mock_client.collection_exists.return_value = True
+    mock_qdrant_cls.return_value = mock_client
+
+    cfg = {**MINIMAL_CFG, "embed": {**MINIMAL_CFG["embed"], "embedding_workers": 4}}
+    count = upsert_chunks(_make_chunks(10), cfg)
+
+    assert count == 10
+    assert mock_embed.call_count == 10
+
+
 # ---------------------------------------------------------------------------
 # pipeline.py — is_lfs_pointer
 # ---------------------------------------------------------------------------

--- a/carta/vision/router.py
+++ b/carta/vision/router.py
@@ -4,6 +4,7 @@ Routes each PDF page to the appropriate extraction strategy based on
 PageAnalyzer classification. PURE_TEXT pages produce zero model calls.
 """
 import base64
+import concurrent.futures
 import json
 import sys
 import threading
@@ -60,7 +61,12 @@ class SmartRouter:
         self.ollama_url: str = embed.get("ollama_url", "http://localhost:11434")
         self.flattened_min_yield: int = embed.get("vision_flattened_min_yield", 50)
         self.max_images_per_page: int = embed.get("vision_max_images_per_page", 4)
+        self.vision_workers: int = max(1, int(embed.get("vision_workers", 4)))
         self.analyzer = PageAnalyzer(cfg)
+        # PyMuPDF (fitz) is not thread-safe. Workers must serialize all fitz
+        # operations through this lock; Ollama HTTP calls run unlocked so they
+        # can overlap across worker threads.
+        self._fitz_lock = threading.Lock()
 
     def extract_pdf(
         self,
@@ -92,24 +98,61 @@ class SmartRouter:
                 )
                 return []
 
-            results = []
             total_pages = len(doc)
+
+            page_specs: list[tuple[int, Any, PageProfile]] = []
             for page_num, page in enumerate(doc, start=1):
                 if cancel_event is not None and cancel_event.is_set():
                     break
-                profile = self.analyzer.analyze(page)
+                with self._fitz_lock:
+                    profile = self.analyzer.analyze(page)
+                page_specs.append((page_num, page, profile))
+
+            results_by_page: dict[int, list[dict]] = {}
+
+            def route_one(spec):
+                page_num, page, profile = spec
+                if cancel_event is not None and cancel_event.is_set():
+                    return None
                 chunks = self._route(page, page_num, profile, doc)
-                results.extend(chunks)
-                if progress_callback:
-                    try:
-                        char_count = sum(len(c.get("text", "")) for c in chunks)
-                        model_used = chunks[0]["model_used"] if chunks else "skip"
-                        page_class = profile.page_class.name.lower()
-                        progress_callback(page_num, total_pages, page_class, model_used, char_count)
-                    except Exception:
-                        pass
+                return page_num, profile, chunks
+
+            def fire_progress(page_num, profile, chunks):
+                if not progress_callback:
+                    return
+                try:
+                    char_count = sum(len(c.get("text", "")) for c in chunks)
+                    model_used = chunks[0]["model_used"] if chunks else "skip"
+                    page_class = profile.page_class.name.lower()
+                    progress_callback(page_num, total_pages, page_class, model_used, char_count)
+                except Exception:
+                    pass
+
+            if self.vision_workers <= 1 or len(page_specs) <= 1:
+                for spec in page_specs:
+                    result = route_one(spec)
+                    if result is None:
+                        break
+                    p, profile, chunks = result
+                    results_by_page[p] = chunks
+                    fire_progress(p, profile, chunks)
+            else:
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=self.vision_workers,
+                    thread_name_prefix="carta-vision",
+                ) as ex:
+                    futures = [ex.submit(route_one, s) for s in page_specs]
+                    for fut in concurrent.futures.as_completed(futures):
+                        result = fut.result()
+                        if result is None:
+                            continue
+                        p, profile, chunks = result
+                        results_by_page[p] = chunks
+                        fire_progress(p, profile, chunks)
+
             doc.close()
-            return results
+
+            return [c for p in sorted(results_by_page) for c in results_by_page[p]]
 
     def _route(
         self, page: Any, page_num: int, profile: PageProfile, doc: Any
@@ -123,8 +166,9 @@ class SmartRouter:
         return self._route_flattened(page, page_num)
 
     def _route_structured(self, page: Any, page_num: int) -> list[dict]:
-        pix = page.get_pixmap(dpi=150)
-        png_bytes = pix.tobytes("png")
+        with self._fitz_lock:
+            pix = page.get_pixmap(dpi=150)
+            png_bytes = pix.tobytes("png")
         try:
             text = self._call_ollama_vision(
                 png_bytes, model=self.ocr_model, prompt=GLM_OCR_PROMPT
@@ -140,7 +184,8 @@ class SmartRouter:
     def _route_text_with_images(
         self, page: Any, page_num: int, profile: PageProfile, doc: Any
     ) -> list[dict]:
-        crops = self._extract_image_crops(page, doc)
+        with self._fitz_lock:
+            crops = self._extract_image_crops(page, doc)
         chunks = []
         if crops:
             for idx, png_bytes in crops:
@@ -158,8 +203,9 @@ class SmartRouter:
                     )
         else:
             # Caption fallback: likely a vector graphic not listed by get_images()
-            pix = page.get_pixmap(dpi=150)
-            png_bytes = pix.tobytes("png")
+            with self._fitz_lock:
+                pix = page.get_pixmap(dpi=150)
+                png_bytes = pix.tobytes("png")
             try:
                 text = self._call_ollama_vision(
                     png_bytes, model=self.vision_model, prompt=LLAVA_PROMPT
@@ -175,8 +221,9 @@ class SmartRouter:
         return chunks
 
     def _route_flattened(self, page: Any, page_num: int) -> list[dict]:
-        pix = page.get_pixmap(dpi=150)
-        png_bytes = pix.tobytes("png")
+        with self._fitz_lock:
+            pix = page.get_pixmap(dpi=150)
+            png_bytes = pix.tobytes("png")
         try:
             ocr_text = self._call_ollama_vision(
                 png_bytes, model=self.ocr_model, prompt=GLM_OCR_PROMPT

--- a/carta/vision/tests/test_router.py
+++ b/carta/vision/tests/test_router.py
@@ -426,3 +426,99 @@ class TestExtractPdfProgressCallback:
                 # Must not raise
                 result = router.extract_pdf(MagicMock(), progress_callback=bad_cb)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Parallel page extraction (vision_workers > 1)
+# ---------------------------------------------------------------------------
+
+class TestParallelExtraction:
+    def test_workers_1_processes_all_pages_serially(self):
+        """vision_workers=1 must still call _route for every page."""
+        router = SmartRouter(_cfg(vision_workers=1))
+        profile = _profile(PageClass.STRUCTURED_TEXT)
+        pages = [MagicMock(name=f"p{i}") for i in range(5)]
+        chunks_seen = []
+
+        def fake_route(page, page_num, profile, doc):
+            chunks_seen.append(page_num)
+            return [{"doc_type": "image_description", "page_num": page_num,
+                     "image_index": 0, "text": f"page {page_num}", "model_used": "glm-ocr",
+                     "page_class": "structured_text", "content_type": "structured_text"}]
+
+        with patch.object(router, "analyzer") as mock_analyzer, \
+             patch.object(router, "_route", side_effect=fake_route):
+            mock_analyzer.analyze.return_value = profile
+            with patch("carta.vision.router.fitz") as mock_fitz:
+                doc = MagicMock()
+                doc.__iter__ = MagicMock(return_value=iter(pages))
+                doc.__len__ = MagicMock(return_value=len(pages))
+                mock_fitz.open.return_value = doc
+                results = router.extract_pdf(MagicMock())
+
+        assert sorted(chunks_seen) == [1, 2, 3, 4, 5]
+        # Results must come back in page order regardless of completion order
+        assert [r["page_num"] for r in results] == [1, 2, 3, 4, 5]
+
+    def test_workers_4_processes_all_pages_and_preserves_order(self):
+        """vision_workers=4 must call _route once per page; results returned in page order."""
+        router = SmartRouter(_cfg(vision_workers=4))
+        profile = _profile(PageClass.STRUCTURED_TEXT)
+        pages = [MagicMock(name=f"p{i}") for i in range(8)]
+        seen = set()
+        seen_lock = __import__("threading").Lock()
+
+        def fake_route(page, page_num, profile, doc):
+            with seen_lock:
+                seen.add(page_num)
+            return [{"doc_type": "image_description", "page_num": page_num,
+                     "image_index": 0, "text": f"page {page_num}", "model_used": "glm-ocr",
+                     "page_class": "structured_text", "content_type": "structured_text"}]
+
+        with patch.object(router, "analyzer") as mock_analyzer, \
+             patch.object(router, "_route", side_effect=fake_route):
+            mock_analyzer.analyze.return_value = profile
+            with patch("carta.vision.router.fitz") as mock_fitz:
+                doc = MagicMock()
+                doc.__iter__ = MagicMock(return_value=iter(pages))
+                doc.__len__ = MagicMock(return_value=len(pages))
+                mock_fitz.open.return_value = doc
+                results = router.extract_pdf(MagicMock())
+
+        assert seen == {1, 2, 3, 4, 5, 6, 7, 8}
+        assert [r["page_num"] for r in results] == [1, 2, 3, 4, 5, 6, 7, 8]
+
+    def test_parallel_calls_overlap_in_time(self):
+        """vision_workers=4 must execute _route concurrently, not serially."""
+        import threading
+        import time
+
+        router = SmartRouter(_cfg(vision_workers=4))
+        profile = _profile(PageClass.STRUCTURED_TEXT)
+        pages = [MagicMock(name=f"p{i}") for i in range(4)]
+
+        in_flight = 0
+        peak_in_flight = 0
+        lock = threading.Lock()
+
+        def slow_route(page, page_num, profile, doc):
+            nonlocal in_flight, peak_in_flight
+            with lock:
+                in_flight += 1
+                peak_in_flight = max(peak_in_flight, in_flight)
+            time.sleep(0.05)
+            with lock:
+                in_flight -= 1
+            return []
+
+        with patch.object(router, "analyzer") as mock_analyzer, \
+             patch.object(router, "_route", side_effect=slow_route):
+            mock_analyzer.analyze.return_value = profile
+            with patch("carta.vision.router.fitz") as mock_fitz:
+                doc = MagicMock()
+                doc.__iter__ = MagicMock(return_value=iter(pages))
+                doc.__len__ = MagicMock(return_value=len(pages))
+                mock_fitz.open.return_value = doc
+                router.extract_pdf(MagicMock())
+
+        assert peak_in_flight >= 2, f"expected concurrent _route calls, got peak={peak_in_flight}"


### PR DESCRIPTION
## Summary

Two stacked serial bottlenecks in `carta embed` were dominating wall time:
- Every PDF page made 1–2 sequential Ollama vision calls (30–60s each)
- Every text chunk made a separate sequential embedding call

Both are I/O-bound HTTP work that parallelizes cleanly.

### Vision — `carta/vision/router.py`
- `SmartRouter.extract_pdf` now classifies pages serially under a `fitz` lock (PyMuPDF is not thread-safe), then dispatches `_route` calls to a `ThreadPoolExecutor` sized by `embed.vision_workers`.
- Each `_route_*` method acquires `self._fitz_lock` only around fitz ops (pixmap render, crop extraction) and runs the Ollama HTTP call unlocked, so calls overlap across workers.
- `vision_workers <= 1` and single-page docs short-circuit to the serial path.

### Embedding — `carta/embed/embed.py`
- `upsert_chunks` submits all `get_embedding` calls to a `ThreadPoolExecutor` sized by `embed.embedding_workers` and accumulates points via `as_completed`.
- Qdrant upserts still happen on the main thread, batched at `BATCH_SIZE=32`.
- `embedding_workers=1` preserves the existing serial path.

### Config defaults — `carta/config.py`
- `embed.vision_workers: 4`
- `embed.embedding_workers: 8`

Both accept `1` to disable parallelism on memory-constrained machines. Effective vision parallelism also requires `OLLAMA_NUM_PARALLEL` to be set on the Ollama server side (env var, not a code change).

## Expected impact

Patent PDF runs in the original report (e.g. `US12296900B2.pdf` at 637s) should drop ~3-4× given 4 vision workers and an Ollama server with matching `OLLAMA_NUM_PARALLEL`. Text-only embed runs (markdown, no vision) should drop substantially as well — `nomic-embed-text` is fast, the gain comes from removing per-chunk RTT.

## Test plan

- [x] `pytest` — 545 passed, 1 skipped (was 540 before; +5 new tests)
- [x] New: `test_upsert_chunks_serial_when_workers_is_1` — confirms ordered serial path under `embedding_workers=1`
- [x] New: `test_upsert_chunks_parallel_embeds_all_chunks` — confirms every chunk embedded under parallel
- [x] New: `test_workers_1_processes_all_pages_serially` — coverage + page-order preservation
- [x] New: `test_workers_4_processes_all_pages_and_preserves_order` — same under 4 workers
- [x] New: `test_parallel_calls_overlap_in_time` — peak-in-flight ≥ 2 verifies actual concurrency
- [ ] Manual smoke: re-run the failing patent PDF set used in the original report
- [ ] Verify on smaller machines: confirm `vision_workers=1, embedding_workers=1` matches v0.4.3 behavior exactly

## Follow-ups (not in this PR)

- Model swap: `llava:latest` → `qwen2.5vl:7b` (separate small PR per the discussion thread)
- `--workers` CLI override for ad-hoc tuning without editing `config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)