### PR TITLE
fix(embed,vision): mid-PDF resume + daemon-thread watchdog

### DIFF
--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1,6 +1,5 @@
 """Top-level pipeline orchestration for carta embed."""
 
-import concurrent.futures
 import json
 import os
 import shutil
@@ -78,6 +77,16 @@ def _summarize_vision_strategies(events: list[dict]) -> dict[str, int]:
         m = e.get("model_used", "unknown")
         counts[m] = counts.get(m, 0) + 1
     return counts
+
+
+def _vision_checkpoint_path(repo_root: Path, slug: str) -> Path:
+    """Path used to persist mid-PDF vision-extraction progress for resume.
+
+    Cleared on full file completion; left in place when a run is interrupted
+    (timeout, error, ^C) so the next ``carta embed`` can pick up where it
+    stopped instead of redoing every already-OCR'd page.
+    """
+    return repo_root / ".carta" / "checkpoints" / f"{slug}.json"
 
 
 def _write_perf_log_entry(path: Optional[Path], entry: dict) -> None:
@@ -284,11 +293,13 @@ def _embed_one_file(
         # Use intelligent extraction with GLM-OCR/LLaVA routing (Phase 999.4)
         if progress:
             progress.step("extracting image descriptions")
+        checkpoint_path = _vision_checkpoint_path(repo_root, slug)
         try:
             from carta.vision.router import extract_image_descriptions_intelligent
             img_descs = extract_image_descriptions_intelligent(
                 file_path, cfg, progress_callback=_vision_callback,
                 cancel_event=cancel_event,
+                checkpoint_path=checkpoint_path,
             )
             image_count = len(img_descs)
 
@@ -371,6 +382,15 @@ def _embed_one_file(
         }
     
     sidecar_updates["_vision_events"] = _page_events
+
+    # File fully embedded — clear any per-page resume checkpoint.
+    if file_path.suffix == ".pdf":
+        cp = _vision_checkpoint_path(repo_root, slug)
+        try:
+            cp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
     return count + image_chunk_count, sidecar_updates
 
 
@@ -821,36 +841,34 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
             print(f"  [{idx}/{total}] Embedding: {file_path.name} ...", flush=True)
         t0 = time.monotonic()
 
+        # Per-file watchdog: a daemon thread runs the work; main thread waits
+        # up to file_timeout_s. Daemon thread dies cleanly at interpreter exit,
+        # avoiding the "cannot schedule new futures after interpreter shutdown"
+        # races a ThreadPoolExecutor-based watchdog left behind on timeout.
         cancel_event = threading.Event()
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(
-            _embed_one_file,
-            file_path, file_info, cfg, client, repo_root,
-            max_tokens, overlap_fraction, verbose, progress,
-            cancel_event,
+        result_holder: dict = {}
+
+        def _worker():
+            try:
+                result_holder["value"] = _embed_one_file(
+                    file_path, file_info, cfg, client, repo_root,
+                    max_tokens, overlap_fraction, verbose, progress,
+                    cancel_event,
+                )
+            except BaseException as exc:
+                result_holder["error"] = exc
+
+        worker = threading.Thread(
+            target=_worker, daemon=True, name=f"carta-embed-{file_path.name}"
         )
-        try:
-            count, sidecar_updates = future.result(timeout=file_timeout_s)
-            executor.shutdown(wait=False)
-            vision_events = sidecar_updates.pop("_vision_events", [])
-            _update_sidecar(sc_path, sidecar_updates)
-            elapsed = time.monotonic() - t0
-            if progress:
-                progress.done(chunks=count, elapsed=elapsed)
-                if vision_events:
-                    progress.vision_done(vision_events)
-            elif verbose:
-                print(f"  [{idx}/{total}] OK: {file_path.name} — {count} chunk(s) in {elapsed:.1f}s", flush=True)
-            summary["embedded"] += 1
-            _write_perf_log_entry(perf_log_path, {
-                **perf_context, "file": rel_file, "status": "ok",
-                "chunks": count, "elapsed_s": round(elapsed, 2),
-                "vision_strategies": _summarize_vision_strategies(vision_events),
-            })
-        except concurrent.futures.TimeoutError:
+        worker.start()
+        worker.join(timeout=file_timeout_s)
+        elapsed = time.monotonic() - t0
+
+        if worker.is_alive():
+            # Timeout — signal cancel and move on. Daemon thread will be killed
+            # at process exit; we do not block here.
             cancel_event.set()
-            executor.shutdown(wait=False)
-            elapsed = time.monotonic() - t0
             if progress:
                 progress.skip(f"timeout after {file_timeout_s}s")
             elif verbose:
@@ -869,21 +887,35 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
                 "chunks": 0, "elapsed_s": round(elapsed, 2),
                 "timeout_s": file_timeout_s,
             })
-        except Exception as e:
-            cancel_event.set()
-            executor.shutdown(wait=False)
-            elapsed = time.monotonic() - t0
+        elif "error" in result_holder:
+            exc = result_holder["error"]
             if progress:
-                progress.error(str(e))
+                progress.error(str(exc))
             print(
-                f"  [{idx}/{total}] ERROR: {file_path.name} ({elapsed:.1f}s): {e}",
+                f"  [{idx}/{total}] ERROR: {file_path.name} ({elapsed:.1f}s): {exc}",
                 file=sys.stderr, flush=True,
             )
-            summary["errors"].append(f"Error processing {file_path.name}: {e}")
+            summary["errors"].append(f"Error processing {file_path.name}: {exc}")
             _write_perf_log_entry(perf_log_path, {
                 **perf_context, "file": rel_file, "status": "error",
                 "chunks": 0, "elapsed_s": round(elapsed, 2),
-                "error": str(e)[:200],
+                "error": str(exc)[:200],
+            })
+        else:
+            count, sidecar_updates = result_holder["value"]
+            vision_events = sidecar_updates.pop("_vision_events", [])
+            _update_sidecar(sc_path, sidecar_updates)
+            if progress:
+                progress.done(chunks=count, elapsed=elapsed)
+                if vision_events:
+                    progress.vision_done(vision_events)
+            elif verbose:
+                print(f"  [{idx}/{total}] OK: {file_path.name} — {count} chunk(s) in {elapsed:.1f}s", flush=True)
+            summary["embedded"] += 1
+            _write_perf_log_entry(perf_log_path, {
+                **perf_context, "file": rel_file, "status": "ok",
+                "chunks": count, "elapsed_s": round(elapsed, 2),
+                "vision_strategies": _summarize_vision_strategies(vision_events),
             })
 
     # Emit stale alert after embed loop

--- a/carta/vision/router.py
+++ b/carta/vision/router.py
@@ -6,8 +6,11 @@ PageAnalyzer classification. PURE_TEXT pages produce zero model calls.
 import base64
 import concurrent.futures
 import json
+import os
 import sys
+import tempfile
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -20,6 +23,85 @@ except ImportError:
 
 from carta.mupdf_util import mupdf_quiet
 from carta.vision.classifier import PageAnalyzer, PageClass, PageProfile
+
+
+_CHECKPOINT_SCHEMA_VERSION = 1
+
+
+def load_vision_checkpoint(
+    path: Optional[Path],
+    vision_model: str,
+    ocr_model: str,
+) -> dict[int, list[dict]]:
+    """Read completed-page chunks from a checkpoint file.
+
+    Returns ``{page_num: [chunk, ...]}`` for pages already processed in a prior
+    run. Returns an empty dict if the file is missing, unreadable, the schema
+    version doesn't match, or the configured models have changed since the
+    checkpoint was written (in which case the stale checkpoint is removed).
+    """
+    if path is None or not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if data.get("schema_version") != _CHECKPOINT_SCHEMA_VERSION:
+        return {}
+    if data.get("vision_model") != vision_model or data.get("ocr_model") != ocr_model:
+        # Model swap invalidates prior partial work.
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return {}
+    out: dict[int, list[dict]] = {}
+    for entry in data.get("completed_pages", []):
+        page_num = entry.get("page_num")
+        chunks = entry.get("chunks", [])
+        if isinstance(page_num, int) and isinstance(chunks, list):
+            out[page_num] = chunks
+    return out
+
+
+def save_vision_checkpoint(
+    path: Optional[Path],
+    file_path: Path,
+    vision_model: str,
+    ocr_model: str,
+    completed_chunks: list[dict],
+) -> None:
+    """Atomically persist the running list of completed-page chunks.
+
+    Writes to a sibling tempfile then renames into place so a partial write
+    can never corrupt a checkpoint mid-run. Logging errors (disk full, etc.)
+    are intentionally swallowed — checkpointing is best-effort.
+    """
+    if path is None:
+        return
+    payload = {
+        "schema_version": _CHECKPOINT_SCHEMA_VERSION,
+        "file_path": str(file_path),
+        "vision_model": vision_model,
+        "ocr_model": ocr_model,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "completed_pages": completed_chunks,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass
 
 
 GLM_OCR_PROMPT = """Extract all text content from this document page.
@@ -73,6 +155,7 @@ class SmartRouter:
         pdf_path: Path,
         progress_callback: Optional[Any] = None,
         cancel_event: Optional[threading.Event] = None,
+        checkpoint_path: Optional[Path] = None,
     ) -> list[dict]:
         """Extract vision chunks from all pages of a PDF.
 
@@ -82,6 +165,10 @@ class SmartRouter:
                                page_class: "pure_text"|"structured_text"|"text_with_images"|"flattened"
                                model_used: "skip" for PURE_TEXT, otherwise the model name (e.g. "glm-ocr", "llava")
                                char_count: total chars extracted for this page; 0 for skipped pages.
+            checkpoint_path: Optional path to a JSON file persisting per-page progress
+                             so a re-run can resume mid-PDF. The file is updated after
+                             each page completes; the caller is responsible for deleting
+                             it once the file is fully embedded.
 
         Returns:
             List of chunk dicts compatible with pipeline.py expectations.
@@ -100,15 +187,44 @@ class SmartRouter:
 
             total_pages = len(doc)
 
+            # Load resume state. completed[page_num] -> list of chunks already done.
+            completed = load_vision_checkpoint(
+                checkpoint_path, self.vision_model, self.ocr_model
+            )
+            checkpoint_lock = threading.Lock()
+
+            def persist_checkpoint():
+                """Snapshot ``completed`` to disk (caller holds checkpoint_lock)."""
+                save_vision_checkpoint(
+                    checkpoint_path,
+                    pdf_path,
+                    self.vision_model,
+                    self.ocr_model,
+                    [{"page_num": p, "chunks": completed[p]} for p in sorted(completed)],
+                )
+
             page_specs: list[tuple[int, Any, PageProfile]] = []
             for page_num, page in enumerate(doc, start=1):
                 if cancel_event is not None and cancel_event.is_set():
                     break
+                if page_num in completed:
+                    # Resumed page — skip fitz analysis too; we already have chunks.
+                    continue
                 with self._fitz_lock:
                     profile = self.analyzer.analyze(page)
                 page_specs.append((page_num, page, profile))
 
-            results_by_page: dict[int, list[dict]] = {}
+            if completed and progress_callback:
+                # Tell the caller about resumed pages so the perf log + UI reflect them.
+                for p in sorted(completed):
+                    chunks = completed[p]
+                    try:
+                        char_count = sum(len(c.get("text", "")) for c in chunks)
+                        model_used = chunks[0]["model_used"] if chunks else "skip"
+                        page_class = chunks[0].get("page_class", "pure_text") if chunks else "pure_text"
+                        progress_callback(p, total_pages, page_class, model_used, char_count)
+                    except Exception:
+                        pass
 
             def route_one(spec):
                 page_num, page, profile = spec
@@ -117,16 +233,18 @@ class SmartRouter:
                 chunks = self._route(page, page_num, profile, doc)
                 return page_num, profile, chunks
 
-            def fire_progress(page_num, profile, chunks):
-                if not progress_callback:
-                    return
-                try:
-                    char_count = sum(len(c.get("text", "")) for c in chunks)
-                    model_used = chunks[0]["model_used"] if chunks else "skip"
-                    page_class = profile.page_class.name.lower()
-                    progress_callback(page_num, total_pages, page_class, model_used, char_count)
-                except Exception:
-                    pass
+            def record_page(page_num, profile, chunks):
+                with checkpoint_lock:
+                    completed[page_num] = chunks
+                    persist_checkpoint()
+                if progress_callback:
+                    try:
+                        char_count = sum(len(c.get("text", "")) for c in chunks)
+                        model_used = chunks[0]["model_used"] if chunks else "skip"
+                        page_class = profile.page_class.name.lower()
+                        progress_callback(page_num, total_pages, page_class, model_used, char_count)
+                    except Exception:
+                        pass
 
             if self.vision_workers <= 1 or len(page_specs) <= 1:
                 for spec in page_specs:
@@ -134,8 +252,7 @@ class SmartRouter:
                     if result is None:
                         break
                     p, profile, chunks = result
-                    results_by_page[p] = chunks
-                    fire_progress(p, profile, chunks)
+                    record_page(p, profile, chunks)
             else:
                 with concurrent.futures.ThreadPoolExecutor(
                     max_workers=self.vision_workers,
@@ -147,12 +264,11 @@ class SmartRouter:
                         if result is None:
                             continue
                         p, profile, chunks = result
-                        results_by_page[p] = chunks
-                        fire_progress(p, profile, chunks)
+                        record_page(p, profile, chunks)
 
             doc.close()
 
-            return [c for p in sorted(results_by_page) for c in results_by_page[p]]
+            return [c for p in sorted(completed) for c in completed[p]]
 
     def _route(
         self, page: Any, page_num: int, profile: PageProfile, doc: Any
@@ -347,6 +463,7 @@ def extract_image_descriptions_intelligent(
     cfg: dict,
     progress_callback: Optional[Any] = None,
     cancel_event: Optional[threading.Event] = None,
+    checkpoint_path: Optional[Path] = None,
 ) -> list[dict]:
     """Extract image descriptions from PDF using smart page routing.
 
@@ -361,10 +478,16 @@ def extract_image_descriptions_intelligent(
                            model_used: "skip" for PURE_TEXT, otherwise the model name (e.g. "glm-ocr", "llava")
                            char_count: total chars extracted for this page; 0 for skipped pages.
         cancel_event: Optional threading.Event; if set, stops page iteration early.
+        checkpoint_path: Optional path for per-page resume state (see SmartRouter.extract_pdf).
 
     Returns:
         List of dicts with keys: doc_type, page_num, image_index, text,
         model_used, page_class.
     """
     router = SmartRouter(cfg)
-    return router.extract_pdf(pdf_path, progress_callback, cancel_event)
+    return router.extract_pdf(
+        pdf_path,
+        progress_callback=progress_callback,
+        cancel_event=cancel_event,
+        checkpoint_path=checkpoint_path,
+    )

--- a/carta/vision/tests/test_router.py
+++ b/carta/vision/tests/test_router.py
@@ -522,3 +522,128 @@ class TestParallelExtraction:
                 router.extract_pdf(MagicMock())
 
         assert peak_in_flight >= 2, f"expected concurrent _route calls, got peak={peak_in_flight}"
+
+
+# ---------------------------------------------------------------------------
+# Vision checkpoint helpers + per-page resume
+# ---------------------------------------------------------------------------
+
+class TestCheckpointHelpers:
+    def test_load_returns_empty_when_path_is_none(self):
+        from carta.vision.router import load_vision_checkpoint
+        assert load_vision_checkpoint(None, "vm", "om") == {}
+
+    def test_load_returns_empty_when_file_missing(self, tmp_path):
+        from carta.vision.router import load_vision_checkpoint
+        assert load_vision_checkpoint(tmp_path / "nope.json", "vm", "om") == {}
+
+    def test_load_returns_empty_on_corrupt_file(self, tmp_path):
+        from carta.vision.router import load_vision_checkpoint
+        p = tmp_path / "cp.json"
+        p.write_text("{not-json")
+        assert load_vision_checkpoint(p, "vm", "om") == {}
+
+    def test_load_drops_stale_checkpoint_on_model_swap(self, tmp_path):
+        from carta.vision.router import save_vision_checkpoint, load_vision_checkpoint
+        p = tmp_path / "cp.json"
+        save_vision_checkpoint(p, Path("/x.pdf"), "old-vision", "old-ocr",
+                               [{"page_num": 1, "chunks": [{"text": "x"}]}])
+        # Reload with different model — checkpoint is invalidated and removed.
+        out = load_vision_checkpoint(p, "new-vision", "old-ocr")
+        assert out == {}
+        assert not p.exists()
+
+    def test_save_then_load_roundtrip(self, tmp_path):
+        from carta.vision.router import save_vision_checkpoint, load_vision_checkpoint
+        p = tmp_path / "cp.json"
+        chunks = [{"text": "page 1 text", "model_used": "glm-ocr"}]
+        save_vision_checkpoint(p, Path("/x.pdf"), "qwen2.5vl:7b", "glm-ocr:latest",
+                               [{"page_num": 1, "chunks": chunks}])
+        out = load_vision_checkpoint(p, "qwen2.5vl:7b", "glm-ocr:latest")
+        assert out == {1: chunks}
+
+    def test_save_is_atomic_no_temp_files_left(self, tmp_path):
+        from carta.vision.router import save_vision_checkpoint
+        p = tmp_path / "cp.json"
+        save_vision_checkpoint(p, Path("/x.pdf"), "v", "o",
+                               [{"page_num": 1, "chunks": []}])
+        # Only the final file should exist; tempfiles must be renamed away.
+        assert sorted(x.name for x in tmp_path.iterdir()) == ["cp.json"]
+
+
+class TestExtractPdfResume:
+    def test_resume_skips_pages_in_checkpoint(self, tmp_path):
+        from carta.vision.router import SmartRouter, save_vision_checkpoint
+
+        router = SmartRouter(_cfg(ollama_vision_model="qwen2.5vl:7b",
+                                  ocr_model="glm-ocr:latest"))
+        cp = tmp_path / "cp.json"
+        prior = [
+            {"doc_type": "image_description", "page_num": 1, "image_index": 0,
+             "text": "cached p1", "model_used": "glm-ocr",
+             "page_class": "structured_text", "content_type": "structured_text"},
+        ]
+        save_vision_checkpoint(cp, Path("/x.pdf"), "qwen2.5vl:7b", "glm-ocr:latest",
+                               [{"page_num": 1, "chunks": prior}])
+
+        new_chunk = {"doc_type": "image_description", "page_num": 2, "image_index": 0,
+                     "text": "fresh p2", "model_used": "glm-ocr",
+                     "page_class": "structured_text", "content_type": "structured_text"}
+
+        page1 = MagicMock(name="p1")
+        page2 = MagicMock(name="p2")
+        profile = _profile(PageClass.STRUCTURED_TEXT)
+        route_calls = []
+
+        def fake_route(page, page_num, profile, doc):
+            route_calls.append(page_num)
+            return [new_chunk] if page_num == 2 else []
+
+        with patch.object(router, "analyzer") as mock_analyzer, \
+             patch.object(router, "_route", side_effect=fake_route):
+            mock_analyzer.analyze.return_value = profile
+            with patch("carta.vision.router.fitz") as mock_fitz:
+                doc = MagicMock()
+                doc.__iter__ = MagicMock(return_value=iter([page1, page2]))
+                doc.__len__ = MagicMock(return_value=2)
+                mock_fitz.open.return_value = doc
+                results = router.extract_pdf(Path("/x.pdf"), checkpoint_path=cp)
+
+        # Page 1 was loaded from checkpoint; only page 2 was re-routed.
+        assert route_calls == [2]
+        # Output preserves both pages in order.
+        assert [r["page_num"] for r in results] == [1, 2]
+        assert results[0]["text"] == "cached p1"
+        assert results[1]["text"] == "fresh p2"
+
+    def test_checkpoint_is_updated_after_each_page(self, tmp_path):
+        from carta.vision.router import SmartRouter, load_vision_checkpoint
+
+        router = SmartRouter(_cfg(ollama_vision_model="qwen2.5vl:7b",
+                                  ocr_model="glm-ocr:latest",
+                                  vision_workers=1))
+        cp = tmp_path / "cp.json"
+        page1 = MagicMock(name="p1")
+        page2 = MagicMock(name="p2")
+        profile = _profile(PageClass.STRUCTURED_TEXT)
+
+        def fake_route(page, page_num, profile, doc):
+            return [{"doc_type": "image_description", "page_num": page_num,
+                     "image_index": 0, "text": f"page {page_num}",
+                     "model_used": "glm-ocr",
+                     "page_class": "structured_text",
+                     "content_type": "structured_text"}]
+
+        with patch.object(router, "analyzer") as mock_analyzer, \
+             patch.object(router, "_route", side_effect=fake_route):
+            mock_analyzer.analyze.return_value = profile
+            with patch("carta.vision.router.fitz") as mock_fitz:
+                doc = MagicMock()
+                doc.__iter__ = MagicMock(return_value=iter([page1, page2]))
+                doc.__len__ = MagicMock(return_value=2)
+                mock_fitz.open.return_value = doc
+                router.extract_pdf(Path("/x.pdf"), checkpoint_path=cp)
+
+        # After successful extraction, both pages are recorded in checkpoint.
+        out = load_vision_checkpoint(cp, "qwen2.5vl:7b", "glm-ocr:latest")
+        assert sorted(out.keys()) == [1, 2]


### PR DESCRIPTION
## Summary

Two fixes addressing the timeout/cancel issues on the 475-page datasheet embed.

### 1. Mid-PDF resume via JSON checkpoint files

`.carta/checkpoints/<slug>.json` persists per-page vision-extraction progress. After each page completes, the file is atomically rewritten (tempfile + `os.replace`). On a re-run, completed pages are skipped — no more re-OCR'ing 200 pages because page 201 timed out.

- **Atomic writes**: tempfile + rename, no risk of corruption
- **Model-swap invalidation**: checkpoint auto-busts when `vision_model` or `ocr_model` change since last save
- **Auto-cleared on success**: the file is unlinked once the sidecar reaches `embedded`
- **No new config**: feature is on by default; the file lives under `.carta/` (already gitignored on most projects)

### 2. Daemon-thread watchdog (eliminates "cannot schedule new futures")

The per-file watchdog in `run_embed` switched from `ThreadPoolExecutor(max_workers=1)` to a daemon `threading.Thread` + `Event.wait()`. The previous code called `executor.shutdown(wait=False)` on timeout, which doesn't stop the in-flight worker — it kept running while the main thread reached the summary and Python began interpreter shutdown, then later tried to submit a future and hit the "cannot schedule new futures after interpreter shutdown" error after the run already printed its summary. Daemon threads die cleanly at interpreter exit; cancel_event still tells the inner work to stop early when it can.

## Test plan

- [x] `pytest` — 568 passed (+8 new tests)
- [x] Checkpoint round-trip (save → load returns identical chunks)
- [x] Stale-checkpoint invalidation on model swap (file removed)
- [x] Corrupt-file robustness (load returns `{}`)
- [x] Atomic write — no leftover tempfiles after save
- [x] Resume skips pages already in checkpoint and only re-routes missing ones
- [x] Successful `extract_pdf` updates checkpoint after each page

## Impact

Big patent / datasheet runs become resumable. A timeout on page 300 of 475 means the next `carta embed` starts at page 301, not page 1. Combined with `--timeout 9000` for these heavy PDFs, large-document embeds become tractable.

The watchdog refactor is invisible to callers — just removes the post-summary spurious warning and lets `^C` exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)