### PR TITLE
fix(ci): skip sparse tests when fastembed (hybrid extra) absent

### DIFF
--- a/carta/embed/tests/test_sparse.py
+++ b/carta/embed/tests/test_sparse.py
@@ -1,3 +1,10 @@
+import pytest
+
+# These tests exercise the real fastembed BM25 model, which ships in the optional
+# `[hybrid]` extra. Skip cleanly when it is not installed (e.g. base CI) rather
+# than failing — mirrors the optional-dependency handling in test_colpali.py.
+pytest.importorskip("fastembed", reason="hybrid extra (fastembed) not installed")
+
 from carta.embed.sparse import embed_sparse_document, embed_sparse_query, SparseVec
 
 


### PR DESCRIPTION
## Summary
PR #14's `test_sparse.py` calls the real fastembed BM25 model (in the optional `[hybrid]` extra), which base CI doesn't install — so those 2 tests failed with `ModuleNotFoundError` on all Python versions while the other 576 passed. This guards the module with `pytest.importorskip("fastembed")`, matching the existing optional-dependency pattern used for colpali.

## Test plan
- [x] With fastembed installed: `test_sparse.py` → 2 passed.
- [x] With fastembed blocked (import hook): module → 1 skipped, not failed.
- [x] `test_rerank.py` already passes in base CI (it monkeypatches the scorer, never importing fastembed).

Optional follow-up (not in this PR): add `pip install -e ".[hybrid]"` to the CI workflow so the hybrid path is actually exercised in CI rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)