### PR TITLE
chore(embed): upgrade default VLM to qwen3-vl:8b

### DIFF
--- a/carta/config.py
+++ b/carta/config.py
@@ -37,7 +37,7 @@ DEFAULTS = {
         "audio_path": "docs/audio/",
         "ollama_url": "http://localhost:11434",
         "ollama_model": "nomic-embed-text:latest",
-        "ollama_vision_model": "qwen2.5vl:7b",
+        "ollama_vision_model": "qwen3-vl:8b",  # requires Ollama >=0.12.7
         "ocr_model": "glm-ocr:latest",  # NEW: for text/table extraction
         "classification": {  # NEW: content classification thresholds
             "text_threshold": 0.70,


### PR DESCRIPTION
## Summary
Upgrades the default vision model from `qwen2.5vl:7b` to `qwen3-vl:8b` per the mid-2026 model-currency audit. Qwen3-VL is the newer Ollama-pullable successor — document/chart/OCR-focused, OCR coverage 10→32 languages, improved robustness. This is a near drop-in change (only the model string), gated on **Ollama ≥ 0.12.7** to serve `qwen3-vl`.

Vision extraction only runs on `carta embed --force`, so existing embedded corpora are unaffected until deliberately re-embedded.

## Test plan
- [x] `test_config.py` passes (14); no test pins the vision tag.
- [ ] Real check: `ollama pull qwen3-vl:8b` then a `carta embed --force` on a datasheet-heavy doc to confirm vision routing works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)