### PR TITLE
fix(search): over-fetch candidate_pool before reranking

### DIFF
--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1011,6 +1011,11 @@ def _hybrid_query_collection(client, coll_name, query, dense_vec, top_n,
     Fetches `prefetch_limit` candidates from each of the dense and sparse
     indexes, then fuses them with Reciprocal Rank Fusion and returns the
     top `top_n` results.
+
+    `top_n` controls the Qdrant fusion `limit` (i.e. how many fused results
+    to return).  When reranking is enabled, callers should pass `fetch_limit`
+    (= candidate_pool) here so that the reranker has a wide enough pool to
+    promote lower-ranked relevant documents.
     """
     sv = embed_sparse_query(query, model_name=bm25_model)
     return client.query_points(
@@ -1045,7 +1050,16 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
 
     top_n = cfg.get("search", {}).get("top_n", 5)
     repo_root = Path(find_config()).parent
-    
+
+    # Compute effective retrieval depth.
+    # When reranking is enabled, fetch candidate_pool docs per collection so
+    # the cross-encoder has a wide enough pool to promote lower-ranked relevant
+    # documents.  When reranking is off, fetch exactly top_n (unchanged).
+    rr_cfg = cfg.get("search", {}).get("rerank", {})
+    rerank_enabled = rr_cfg.get("enabled", False)
+    candidate_pool = rr_cfg.get("candidate_pool", 30)
+    fetch_limit = max(candidate_pool, top_n) if rerank_enabled else top_n
+
     # Get all collections to search
     try:
         collections = get_search_collections(cfg, "repo")
@@ -1092,7 +1106,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
                         collection_name=coll_name,
                         query=query_vector_list,
                         using="colpali",
-                        limit=top_n,
+                        limit=fetch_limit,
                         with_payload=True,
                     )
                     
@@ -1118,9 +1132,11 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
                 is_hybrid = collection_is_hybrid(client, coll_name)
 
                 if hybrid_cfg.get("enabled", False) and is_hybrid:
-                    # Hybrid BM25+dense with RRF fusion
+                    # Hybrid BM25+dense with RRF fusion.
+                    # Pass fetch_limit as the fusion limit so the reranker
+                    # receives a full candidate_pool rather than just top_n.
                     response = _hybrid_query_collection(
-                        client, coll_name, query, query_vec, top_n,
+                        client, coll_name, query, query_vec, fetch_limit,
                         prefetch_limit=hybrid_cfg.get("prefetch_limit", 40),
                         bm25_model=hybrid_cfg.get("bm25_model", "Qdrant/bm25"),
                     )
@@ -1130,7 +1146,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
                         collection_name=coll_name,
                         query=query_vec,
                         using=DENSE_VECTOR_NAME,
-                        limit=top_n,
+                        limit=fetch_limit,
                         with_payload=True,
                     )
                 else:
@@ -1138,7 +1154,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
                     response = client.query_points(
                         collection_name=coll_name,
                         query=query_vec,
-                        limit=top_n,
+                        limit=fetch_limit,
                         with_payload=True,
                     )
                 
@@ -1168,10 +1184,9 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
     all_results.sort(key=lambda x: x["score"], reverse=True)
 
     # Optional second-stage cross-encoder reranking (opt-in via search.rerank.enabled)
-    rr_cfg = cfg.get("search", {}).get("rerank", {})
-    if rr_cfg.get("enabled", False) and all_results:
+    if rerank_enabled and all_results:
         from carta.search.rerank import rerank_hits
-        pool = all_results[: rr_cfg.get("candidate_pool", 30)]
+        pool = all_results[:candidate_pool]
         # rerank_hits reads chunk text from key "text"; run_search stores it as "excerpt"
         for h in pool:
             h["text"] = h.get("excerpt", "")

--- a/carta/embed/tests/test_hybrid_query.py
+++ b/carta/embed/tests/test_hybrid_query.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from carta.embed import pipeline
 
 
@@ -24,3 +24,181 @@ def test_hybrid_query_uses_prefetch_and_rrf(monkeypatch):
     assert "prefetch" in captured
     assert len(captured["prefetch"]) == 2
     assert captured["limit"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Over-fetch / rerank integration tests
+# ---------------------------------------------------------------------------
+
+def _make_run_search_cfg(*, top_n=5, rerank_enabled=False, candidate_pool=30,
+                          hybrid_enabled=False):
+    """Return a minimal carta config dict for run_search tests."""
+    return {
+        "project_name": "test_proj",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {
+            "ollama_url": "http://localhost:11434",
+            "ollama_model": "nomic-embed-text",
+            "colpali_enabled": False,
+        },
+        "search": {
+            "top_n": top_n,
+            "hybrid": {"enabled": hybrid_enabled, "prefetch_limit": 40,
+                       "bm25_model": "Qdrant/bm25"},
+            "rerank": {"enabled": rerank_enabled, "candidate_pool": candidate_pool,
+                       "model": "BAAI/bge-reranker-base"},
+        },
+    }
+
+
+def _fake_points(n, base_score=0.8):
+    """Return n fake ScoredPoint-like MagicMocks."""
+    points = []
+    for i in range(n):
+        p = MagicMock()
+        p.score = base_score - i * 0.01
+        p.payload = {"file_path": f"doc{i}.md", "text": f"chunk {i}"}
+        points.append(p)
+    return points
+
+
+def _patch_run_search_deps(monkeypatch, *, captured_limits,
+                            n_points_per_collection=30, is_hybrid=False):
+    """Monkeypatch the external dependencies of run_search.
+
+    captured_limits: a list that will be appended with each `limit` kwarg
+    seen by any query_points call (or _hybrid_query_collection call).
+    """
+    # Patch find_config so Path(find_config()).parent resolves without hitting disk
+    monkeypatch.setattr(pipeline, "find_config", lambda: "/fake/.carta/config.yaml")
+
+    # Patch get_search_collections to return one text collection
+    import carta.search.scoped as scoped_mod
+    monkeypatch.setattr(scoped_mod, "get_search_collections",
+                        lambda cfg, scope: ["test_proj_doc"])
+
+    # Patch get_embedding to avoid Ollama calls
+    monkeypatch.setattr(pipeline, "get_embedding",
+                        lambda *a, **k: [0.0] * 768)
+
+    # Patch collection_is_hybrid
+    monkeypatch.setattr(pipeline, "collection_is_hybrid",
+                        lambda client, coll: is_hybrid)
+
+    # Build a fake Qdrant response with n_points_per_collection points
+    fake_resp = MagicMock()
+    fake_resp.points = _fake_points(n_points_per_collection)
+
+    # Patch QdrantClient — capture every query_points limit arg
+    class FakeQdrantClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def query_points(self, **kwargs):
+            captured_limits.append(kwargs.get("limit"))
+            return fake_resp
+
+    monkeypatch.setattr(pipeline, "QdrantClient", FakeQdrantClient)
+
+    # Patch _hybrid_query_collection to capture its limit arg too
+    original_hybrid = pipeline._hybrid_query_collection
+
+    def capturing_hybrid(client, coll_name, query, dense_vec, top_n,
+                         prefetch_limit, bm25_model):
+        captured_limits.append(top_n)
+        return fake_resp
+
+    monkeypatch.setattr(pipeline, "_hybrid_query_collection", capturing_hybrid)
+
+
+def test_run_search_overfetch_when_rerank_enabled(monkeypatch):
+    """With rerank enabled, retrieval should use limit=candidate_pool (30), not top_n (5)."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=30, is_hybrid=False)
+
+    # Stub out rerank_hits so no cross-encoder model loads
+    import carta.search.rerank as rr_mod
+    monkeypatch.setattr(rr_mod, "_scores",
+                        lambda query, texts, model_name: [0.5] * len(texts))
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=True, candidate_pool=30)
+    results = pipeline.run_search("serial bridge baud", cfg)
+
+    # Every collection query must have used fetch_limit=30, not top_n=5
+    assert captured_limits, "No query_points calls were captured"
+    for lim in captured_limits:
+        assert lim == 30, (
+            f"Expected fetch limit 30 (candidate_pool) when rerank enabled, got {lim}"
+        )
+
+    # Final result must be truncated to top_n
+    assert len(results) <= 5
+
+
+def test_run_search_no_overfetch_when_rerank_disabled(monkeypatch):
+    """With rerank disabled, retrieval should use limit=top_n (5) — no change."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=5, is_hybrid=False)
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=False, candidate_pool=30)
+    results = pipeline.run_search("serial bridge baud", cfg)
+
+    assert captured_limits, "No query_points calls were captured"
+    for lim in captured_limits:
+        assert lim == 5, (
+            f"Expected fetch limit 5 (top_n) when rerank disabled, got {lim}"
+        )
+
+    assert len(results) <= 5
+
+
+def test_run_search_hybrid_overfetch_when_rerank_enabled(monkeypatch):
+    """With hybrid search + rerank enabled, _hybrid_query_collection gets fetch_limit=30."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=30, is_hybrid=True)
+
+    import carta.search.rerank as rr_mod
+    monkeypatch.setattr(rr_mod, "_scores",
+                        lambda query, texts, model_name: [0.5] * len(texts))
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=True, candidate_pool=30,
+                                hybrid_enabled=True)
+    results = pipeline.run_search("serial bridge baud", cfg)
+
+    assert captured_limits, "No _hybrid_query_collection calls were captured"
+    for lim in captured_limits:
+        assert lim == 30, (
+            f"Expected hybrid fetch limit 30 (candidate_pool) when rerank enabled, got {lim}"
+        )
+    assert len(results) <= 5
+
+
+def test_run_search_final_truncation_rerank_on(monkeypatch):
+    """Result count must equal top_n even when candidate_pool > top_n."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=30, is_hybrid=False)
+
+    import carta.search.rerank as rr_mod
+    monkeypatch.setattr(rr_mod, "_scores",
+                        lambda query, texts, model_name: list(range(len(texts))))
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=True, candidate_pool=30)
+    results = pipeline.run_search("q", cfg)
+
+    assert len(results) == 5
+
+
+def test_run_search_final_truncation_rerank_off(monkeypatch):
+    """Result count must equal top_n when rerank is off."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=5, is_hybrid=False)
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=False)
+    results = pipeline.run_search("q", cfg)
+
+    assert len(results) <= 5


### PR DESCRIPTION
## Summary

- **Bug**: `run_search` fetched only `top_n` (e.g. 5) results per collection before handing off to the cross-encoder reranker. The reranker was only ever reordering the top-5 — documents ranked 6–30 in retrieval could never be promoted, defeating the purpose of reranking and leaving recall flat.
- **Fix**: Compute `fetch_limit = max(candidate_pool, top_n)` when `search.rerank.enabled` is true, and use it as the `limit` for every per-collection query (colpali, hybrid BM25+RRF, named-dense fallback, legacy-dense). The rerank block slices `all_results[:candidate_pool]`, reranks, then truncates to `top_n` — same as before.
- **Non-breaking**: when rerank is off, `fetch_limit == top_n`, so all query calls are unchanged.

## How `fetch_limit` is threaded

`fetch_limit` is computed once near the top of `run_search` (alongside `top_n`), after reading `rr_cfg`:

```python
rr_cfg = cfg.get("search", {}).get("rerank", {})
rerank_enabled = rr_cfg.get("enabled", False)
candidate_pool = rr_cfg.get("candidate_pool", 30)
fetch_limit = max(candidate_pool, top_n) if rerank_enabled else top_n
```

It replaces every `limit=top_n` in the per-collection loop:
- ColPali `query_points(..., limit=fetch_limit)`
- `_hybrid_query_collection(..., fetch_limit, ...)` — the `top_n` positional arg becomes the fusion limit
- Named-dense `query_points(..., limit=fetch_limit)`
- Legacy-dense `query_points(..., limit=fetch_limit)`

The duplicate `rr_cfg` lookup in the rerank block was removed; `rerank_enabled` and `candidate_pool` are reused directly.

## Test plan

- `test_run_search_overfetch_when_rerank_enabled` — asserts every `query_points` call sees `limit=30` (candidate_pool) when rerank ON
- `test_run_search_no_overfetch_when_rerank_disabled` — asserts `limit=5` (top_n) when rerank OFF
- `test_run_search_hybrid_overfetch_when_rerank_enabled` — same assertion for the hybrid path
- `test_run_search_final_truncation_rerank_on` — result count == top_n after rerank
- `test_run_search_final_truncation_rerank_off` — result count <= top_n without rerank
- All 3 pre-existing tests (`test_hybrid_query_uses_prefetch_and_rrf`, `test_rerank_reorders_by_cross_encoder_score`, `test_rerank_truncates_to_top_n`) remain green
- Full suite: **618 passed, 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)