### PR TITLE
feat(embed): two-pass visual embedding (fast text + deferred ColPali/OCR drain)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,5 @@ to override the per-page routing heuristic: `auto` (default) | `ocr` | `vision` 
 Set `vision_call_timeout_s` if Ollama calls time out on dense pages (default: 300 s).
 
 See the "Scoping heavy visual models" section in README.md for full config reference.
+
+**Two-pass visual embedding:** image-heavy PDF pages are processed in two passes — run `carta embed` first (fast text; queues visual pages), then `carta embed --visual` (slow, resumable: OCR text + ColPali). Scope visual work with `colpali_scoped_paths`. The `--visual` pass requires the `[visual]` extra (`pip install 'carta-cc[visual]'`); if absent it exits cleanly with install guidance.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,70 @@ embed:
   colpali_model: "vidore/colqwen2.5-v0.2"
 ```
 
+### Two-pass visual embedding
+
+Running glm-ocr and ColPali inline during a normal `carta embed` adds minutes per image-heavy page and blocks the fast text-extraction pass. The two-pass workflow separates these concerns:
+
+**Pass 1 — fast text:**
+
+```bash
+carta embed
+```
+
+Extracts text from all files as normal. Pages classified as `TEXT_WITH_IMAGES` or `FLATTENED` are recorded in the sidecar's `visual_pending` list instead of being processed inline. At the end of the run, Carta prints a nudge:
+
+```
+Visual queue: 42 page(s) across 18 file(s) await visual embedding. Run carta embed --visual to process them.
+```
+
+**Pass 2 — slow, resumable visual processing:**
+
+```bash
+carta embed --visual
+```
+
+Drains the visual queue. For each pending page it runs:
+1. glm-ocr text extraction → ingested into the hybrid text index
+2. ColPali page-image embedding → stored in the `_visual` collection
+
+Each page is checkpointed (`visual_pending → visual_done`) as it completes, so the pass is resumable — interrupt at any time and re-run; only unfinished pages are retried.
+
+**Typical workflow:**
+
+```bash
+carta embed              # fast text; queues image-heavy pages, prints the nudge
+carta embed --visual     # slow, resumable: OCR text + ColPali for queued pages
+```
+
+**Configuration:**
+
+```yaml
+embed:
+  two_pass_visual: true      # default true — set false to revert to inline visual processing
+  visual_timeout_s: 3600     # per-file timeout for the --visual pass (default: 3600 s)
+```
+
+**Requirements for `--visual`:**
+
+The `--visual` pass requires the optional `[visual]` extra (torch + transformers for ColPali):
+
+```bash
+pip install 'carta-cc[visual]'
+```
+
+If the extra is absent, `carta embed --visual` prints install guidance and exits cleanly — the text corpus is unaffected.
+
+> **Python version note:** torch wheels may not be available for all Python versions. If installation fails, try a Python 3.12 venv: `python3.12 -m venv .venv && source .venv/bin/activate && pip install 'carta-cc[visual]'`
+
+**Scoping and memory:**
+
+Use `colpali_scoped_paths` (see above) to restrict which directories receive visual treatment. To avoid memory pressure from glm-ocr and ColPali loading simultaneously, set the Ollama concurrency limit before running the visual pass:
+
+```bash
+export OLLAMA_MAX_LOADED_MODELS=1
+carta embed --visual
+```
+
 ---
 
 ## Issue lifecycle

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -194,6 +194,7 @@ def cmd_embed(args):
         cfg.setdefault("embed", {})["file_timeout_s"] = timeout_override
 
     # --visual: slow pass-2 drainer — OCR text + ColPali per pending page, then exit.
+    # `is True` (not `if args.visual`) — rejects truthy MagicMocks in tests.
     if getattr(args, "visual", False) is True:
         from carta.embed.pipeline import run_visual_embed
         repo_root = cfg_path.parent.parent

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -193,6 +193,22 @@ def cmd_embed(args):
     if timeout_override is not None:
         cfg.setdefault("embed", {})["file_timeout_s"] = timeout_override
 
+    # --visual: slow pass-2 drainer — OCR text + ColPali per pending page, then exit.
+    if getattr(args, "visual", False) is True:
+        from carta.embed.pipeline import run_visual_embed
+        repo_root = cfg_path.parent.parent
+        summary = run_visual_embed(repo_root, cfg, verbose=True)
+        status = summary.get("status", "")
+        if status == "visual_unavailable":
+            sys.exit(1)
+        print(
+            f"carta embed --visual: {summary['pages_embedded']} page(s) embedded, "
+            f"{summary['pages_failed']} failed, across {summary['files']} file(s).",
+            flush=True,
+        )
+        _notify_if_update(cfg_path, cfg)
+        sys.exit(1 if summary["pages_failed"] else 0)
+
     # Suggest a vision_workers value that fits this machine's RAM (interactive only).
     cfg = _maybe_tune_workers(cfg, skip=getattr(args, "no_tune", False))
 
@@ -516,6 +532,11 @@ def main():
         "--no-tune",
         action="store_true",
         help="Skip the RAM-based vision_workers tuning prompt.",
+    )
+    embed_p.add_argument(
+        "--visual",
+        action="store_true",
+        help="Run the slow visual pass: drain visual_pending pages (OCR text + ColPali).",
     )
 
     audit_p = sub.add_parser(

--- a/carta/config.py
+++ b/carta/config.py
@@ -69,6 +69,8 @@ DEFAULTS = {
         "colpali_sidecar_path": ".carta/visual_cache/",  # where to store page PNGs
         "colpali_scoped_paths": [],  # restrict ColPali to these repo-relative globs/dirs; [] = all PDFs
         "vision_call_timeout_s": 300,  # seconds per Ollama vision/OCR call (was hardcoded 120)
+        "two_pass_visual": True,    # pass-1 marks image-heavy pages; pass-2 (--visual) drains them
+        "visual_timeout_s": 3600,   # generous per-file timeout for the slow visual pass (0 = unbounded)
     },
     "proactive_recall": {
         "high_threshold": 0.85,

--- a/carta/embed/parse.py
+++ b/carta/embed/parse.py
@@ -3,8 +3,37 @@
 import re
 import yaml
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import fitz  # pymupdf — hard dependency; import at module level
 
 from carta.mupdf_util import mupdf_quiet
+
+if TYPE_CHECKING:
+    from carta.vision.classifier import PageClass
+
+
+def _extract_page_text(page: fitz.Page) -> tuple[list[str], list[str]]:
+    """Extract (text_parts, headings) from a single fitz.Page using the dict mode."""
+    blocks = page.get_text("dict")["blocks"]
+    text_parts: list[str] = []
+    headings: list[str] = []
+    for block in blocks:
+        if block.get("type") != 0:
+            continue
+        for line in block.get("lines", []):
+            line_text = ""
+            max_size = 0
+            for span in line.get("spans", []):
+                line_text += span["text"]
+                max_size = max(max_size, span["size"])
+            line_text = line_text.strip()
+            if not line_text:
+                continue
+            text_parts.append(line_text)
+            if max_size >= 13:
+                headings.append(line_text)
+    return text_parts, headings
 
 
 def extract_pdf_text(pdf_path: Path) -> list[dict]:
@@ -13,41 +42,51 @@ def extract_pdf_text(pdf_path: Path) -> list[dict]:
     Each dict: {"page": int, "text": str, "headings": list[str]}
     Headings are detected via font-size heuristic (>= 13pt).
     """
-    import fitz  # pymupdf
-
     with mupdf_quiet():
-        doc = fitz.open(str(pdf_path))
-        pages = []
-
-        for page_num, page in enumerate(doc, start=1):
-            blocks = page.get_text("dict")["blocks"]
-            text_parts = []
-            headings = []
-
-            for block in blocks:
-                if block.get("type") != 0:
-                    continue
-                for line in block.get("lines", []):
-                    line_text = ""
-                    max_size = 0
-                    for span in line.get("spans", []):
-                        line_text += span["text"]
-                        max_size = max(max_size, span["size"])
-                    line_text = line_text.strip()
-                    if not line_text:
-                        continue
-                    text_parts.append(line_text)
-                    if max_size >= 13:
-                        headings.append(line_text)
-
-            pages.append({
-                "page": page_num,
-                "text": "\n".join(text_parts),
-                "headings": headings,
-            })
-
-        doc.close()
+        with fitz.open(str(pdf_path)) as doc:
+            pages = []
+            for page_num, page in enumerate(doc, start=1):
+                text_parts, headings = _extract_page_text(page)
+                pages.append({
+                    "page": page_num,
+                    "text": "\n".join(text_parts),
+                    "headings": headings,
+                })
     return pages
+
+
+def extract_pdf_text_and_classify(
+    pdf_path: Path,
+    analyzer: "PageAnalyzer",  # type: ignore[name-defined]  # noqa: F821
+) -> tuple[list[dict], list["PageClass"]]:
+    """Extract text AND classify each page in a single fitz.open pass.
+
+    Equivalent to calling extract_pdf_text then classifying pages separately,
+    but opens the PDF only once.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        analyzer: A PageAnalyzer instance used to classify each page.
+
+    Returns:
+        Tuple of (pages, page_classes) where:
+          - pages: same format as extract_pdf_text — list of
+            {"page": int, "text": str, "headings": list[str]}
+          - page_classes: list of PageClass values (0-indexed, parallel to pages)
+    """
+    with mupdf_quiet():
+        with fitz.open(str(pdf_path)) as doc:
+            pages = []
+            page_classes = []
+            for page_num, page in enumerate(doc, start=1):
+                text_parts, headings = _extract_page_text(page)
+                pages.append({
+                    "page": page_num,
+                    "text": "\n".join(text_parts),
+                    "headings": headings,
+                })
+                page_classes.append(analyzer.analyze(page).page_class)
+    return pages, page_classes
 
 
 def _strip_frontmatter(text: str) -> tuple[str, dict]:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -31,7 +31,8 @@ from carta.embed.embed import (
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
 from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert
-from carta.embed.visual_queue import add_pending_pages, VISUAL_PENDING_KEY, queue_summary, format_summary_line
+from carta.embed.visual_queue import add_pending_pages, move_to_done, VISUAL_PENDING_KEY, VISUAL_DONE_KEY, queue_summary, format_summary_line
+from carta.embed.colpali import is_colpali_available
 from carta.vision.classifier import PageClass, PageAnalyzer
 
 _IMAGE_HEAVY = {PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED}
@@ -712,6 +713,194 @@ def _embed_visual_pages_colpali(
             flush=True,
         )
         raise
+
+
+def _discover_visual_pending(repo_root: Path) -> list[tuple]:
+    """Return [(sidecar_path, sidecar_dict)] for sidecars with non-empty visual_pending."""
+    out = []
+    sidecars_dir = repo_root / ".carta" / "sidecars"
+    if not sidecars_dir.is_dir():
+        return out
+    for sc_path in sidecars_dir.rglob("*.embed-meta.yaml"):
+        sc = read_sidecar(sc_path)
+        if sc and (sc.get(VISUAL_PENDING_KEY) or []):
+            out.append((sc_path, sc))
+    return out
+
+
+def _visual_embed_one_page(
+    sidecar: dict,
+    page: int,
+    cfg: dict,
+    client,
+    repo_root: Path,
+    verbose: bool = False,
+) -> bool:
+    """OCR text + ColPali for a single 1-indexed page. Raise on failure.
+
+    (a) glm-ocr text for the page via SmartRouter → upsert_chunks (hybrid text index).
+    (b) ColPali for the page via ColPaliEmbedder.embed_pdf_pages(page_nums=[page])
+        → upsert_visual_pages (_visual collection).
+
+    Raises on any failure so the caller leaves the page in visual_pending.
+    """
+    from carta.vision.router import SmartRouter
+    from carta.embed.colpali import ColPaliEmbedder
+
+    try:
+        import fitz as _fitz
+    except ImportError as e:
+        raise RuntimeError("PyMuPDF (fitz) is required for visual drainer") from e
+
+    current_path = sidecar.get("current_path", "")
+    file_path = repo_root / current_path
+    slug = sidecar.get("slug", file_path.stem)
+    embed_cfg = cfg.get("embed", {}) or {}
+    chunking = cfg.get("embed", {}).get("chunking", {}) or {}
+    max_tokens = chunking.get("max_tokens", 400)
+
+    # ── (a) GLM-OCR text → hybrid text index ─────────────────────────────────
+    router = SmartRouter(cfg)
+    from carta.mupdf_util import mupdf_quiet
+    with mupdf_quiet():
+        try:
+            doc = _fitz.open(str(file_path))
+        except Exception as exc:
+            raise RuntimeError(f"Cannot open PDF {file_path}: {exc}") from exc
+        try:
+            if page < 1 or page > len(doc):
+                raise RuntimeError(
+                    f"Page {page} out of range (PDF has {len(doc)} pages)"
+                )
+            fitz_page = doc[page - 1]
+            profile = router.analyzer.analyze(fitz_page)
+            chunks = router._route(fitz_page, page, profile, doc)
+        finally:
+            doc.close()
+
+    if chunks:
+        image_chunks = []
+        for chunk in chunks:
+            for part_text in _split_vision_text(chunk.get("text", ""), max_tokens):
+                image_chunks.append({
+                    "slug": slug,
+                    "file_path": current_path,
+                    "doc_type": "image_description",
+                    "page_num": page,
+                    "image_index": chunk.get("image_index", 0),
+                    "chunk_index": len(image_chunks),
+                    "text": part_text,
+                    "model_used": chunk.get("model_used", "glm-ocr"),
+                    "content_type": chunk.get("content_type", "visual"),
+                    "source": "visual_drainer",
+                })
+        upsert_chunks(image_chunks, cfg, client=client)
+        if verbose:
+            print(
+                f"    visual: page {page} OCR → {len(image_chunks)} chunk(s)",
+                flush=True,
+            )
+
+    # ── (b) ColPali → _visual collection ─────────────────────────────────────
+    model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
+    device = embed_cfg.get("colpali_device", "cpu")
+    batch_size = embed_cfg.get("colpali_batch_size", 1)
+    cache_dir_raw = embed_cfg.get("colpali_sidecar_path", ".carta/visual_cache/")
+    cache_dir_path = Path(cache_dir_raw)
+    if not cache_dir_path.is_absolute():
+        cache_dir_path = repo_root / cache_dir_path
+
+    embedder = ColPaliEmbedder(
+        model_name=model_name,
+        device=device,
+        batch_size=batch_size,
+        cache_dir=str(cache_dir_path),
+    )
+    page_results = embedder.embed_pdf_pages(file_path, page_nums=[page])
+    if page_results:
+        result = page_results[0]
+        png_path = embedder.save_page_cache(file_path, page, result["png_bytes"])
+        try:
+            png_rel = str(png_path.relative_to(repo_root))
+        except ValueError:
+            png_rel = str(png_path)
+        visual_pages = [{
+            "slug": slug,
+            "file_path": current_path,
+            "page_num": page,
+            "vectors": result["vectors"],
+            "png_path": png_rel,
+            "doc_type": "visual_page",
+            "extraction_model": model_name,
+            "source": "visual_drainer",
+        }]
+        upsert_visual_pages(visual_pages, cfg, client=client)
+        if verbose:
+            print(f"    visual: page {page} ColPali → upserted", flush=True)
+
+    return True
+
+
+def run_visual_embed(
+    repo_root: Path,
+    cfg: dict,
+    verbose: bool = False,
+    progress=None,
+) -> dict:
+    """Drain the visual_pending queue: OCR text + ColPali per page, one at a time.
+
+    Discovers every sidecar with a non-empty ``visual_pending`` list, then for
+    each pending page runs (a) glm-ocr text extraction → hybrid text index and
+    (b) ColPali page-image embedding → ``_visual`` collection.  Each page is
+    checkpointed immediately after success (``visual_pending → visual_done``);
+    a page that errors is left pending for the next run.
+
+    Args:
+        repo_root: Repo root (``Path``).
+        cfg: Carta config dict.
+        verbose: Print per-page progress when True.
+        progress: Optional Progress UI object (unused; reserved for future TUI).
+
+    Returns:
+        Summary dict: ``{"pages_embedded": int, "pages_failed": int, "files": int}``
+        When ColPali is unavailable the dict also contains ``"status": "visual_unavailable"``.
+    """
+    summary: dict = {"pages_embedded": 0, "pages_failed": 0, "files": 0}
+
+    if not is_colpali_available():
+        print(
+            "carta embed --visual: the [visual] extra (torch+transformers) is not "
+            "installed. Install with: pip install 'carta-cc[visual]'  (may require a "
+            "Python 3.12 venv if torch wheels are unavailable for the current "
+            "interpreter).",
+            flush=True,
+        )
+        summary["status"] = "visual_unavailable"
+        return summary
+
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
+    queued = _discover_visual_pending(repo_root)
+    summary["files"] = len(queued)
+
+    for sc_path, sc in queued:
+        for page in list(sc.get(VISUAL_PENDING_KEY, []) or []):
+            try:
+                _visual_embed_one_page(sc, page, cfg, client, repo_root, verbose)
+                move_to_done(sc, page)
+                _update_sidecar(sc_path, {
+                    VISUAL_PENDING_KEY: sc[VISUAL_PENDING_KEY],
+                    VISUAL_DONE_KEY: sc[VISUAL_DONE_KEY],
+                })
+                summary["pages_embedded"] += 1
+            except Exception as e:
+                summary["pages_failed"] += 1
+                print(
+                    f"  visual: page {page} of {sc.get('current_path')} failed: {e} "
+                    f"(left pending)",
+                    flush=True,
+                )
+
+    return summary
 
 
 def _heal_sidecar_current_paths(repo_root: Path, verbose: bool = False) -> int:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -18,7 +18,7 @@ from qdrant_client.models import Filter
 
 from carta import __version__ as _CARTA_VERSION
 from carta.config import collection_name, find_config
-from carta.embed.parse import extract_pdf_text, extract_markdown_text, chunk_text, _estimate_tokens
+from carta.embed.parse import extract_pdf_text, extract_pdf_text_and_classify, extract_markdown_text, chunk_text, _estimate_tokens
 from carta.embed.embed import (
     ensure_collection,
     upsert_chunks,
@@ -301,8 +301,27 @@ def _embed_one_file(
         progress.step(f"extracting {file_path.suffix} text")
     elif verbose:
         print(f"    extracting {file_path.suffix} text...", flush=True)
+    # For PDFs with two_pass_visual enabled, classify pages in the SAME fitz pass as
+    # text extraction — avoid opening the PDF twice.
+    _page_classes_from_extraction: list | None = None  # populated for PDFs when two_pass_visual is on
     if file_path.suffix == ".md":
         pages, frontmatter_meta = extract_markdown_text(file_path)
+    elif file_path.suffix == ".pdf" and cfg.get("embed", {}).get("two_pass_visual", True):
+        try:
+            analyzer = PageAnalyzer(cfg)
+            pages, _page_classes_from_extraction = extract_pdf_text_and_classify(file_path, analyzer)
+        except Exception as _cls_exc:
+            # Classification failed: fall back to text-only extraction and skip inline vision
+            # (fail closed — do not escalate to the heavy VLM path).
+            print(
+                f"Warning: two_pass_visual page classification failed for {file_path}: {_cls_exc}; "
+                f"pages left unclassified — skipping inline vision for this file",
+                file=sys.stderr,
+                flush=True,
+            )
+            pages = extract_pdf_text(file_path)
+            _page_classes_from_extraction = None  # signals: skip both inline vision AND two-pass queue
+        frontmatter_meta = {}
     else:
         pages = extract_pdf_text(file_path)
         frontmatter_meta = {}
@@ -359,32 +378,29 @@ def _embed_one_file(
     _visual_queue_updates: dict = {}  # populated by two_pass_visual pass-1 for PDFs
 
     if file_path.suffix == ".pdf":
-        # Two-pass visual: when enabled, classify pages cheaply and queue image-heavy
-        # ones for deferred visual embedding instead of running inline VLM/ColPali.
-        # Pure-text / structured-text pages still embed as normal today.
-        # Text extraction (extract_pdf_text above) already ran for all pages — no data lost.
+        # Two-pass visual: classify pages cheaply and queue image-heavy ones for deferred
+        # visual embedding instead of running inline VLM/ColPali.
+        # Classification was already performed during text extraction above (single fitz pass).
+        # _page_classes_from_extraction is:
+        #   - a list[PageClass]  → classification succeeded; use two-pass path
+        #   - None               → two_pass_visual is off OR classification failed (fail closed:
+        #                          skip inline vision; no heavy path for this file)
         two_pass_visual = cfg.get("embed", {}).get("two_pass_visual", True)
-        if two_pass_visual:
-            try:
-                import fitz
-                from carta.mupdf_util import mupdf_quiet
-                analyzer = PageAnalyzer(cfg)
-                with mupdf_quiet():
-                    _fitz_doc = fitz.open(str(file_path))
-                    _page_classes = [analyzer.analyze(p).page_class for p in _fitz_doc]
-                    _fitz_doc.close()
-                _visual_queue_updates = _mark_or_collect_visual_pages(_page_classes, cfg)
-            except Exception as _exc:
-                # Fail-open: if classification errors, fall through to inline vision
-                print(
-                    f"Warning: two_pass_visual page classification failed for {file_path}: {_exc}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                two_pass_visual = False
-                _visual_queue_updates = {}
+        # _skip_inline_vision: True when we must NOT fall through to ColPali/VLM.
+        # Set True when two_pass_visual queued pages normally, OR when classification
+        # failed (fail closed — never escalate to the heavy path on error).
+        _skip_inline_vision = False
 
-        if two_pass_visual:
+        if two_pass_visual and _page_classes_from_extraction is not None:
+            _visual_queue_updates = _mark_or_collect_visual_pages(_page_classes_from_extraction, cfg)
+            _skip_inline_vision = True  # two-pass queued; inline path not needed
+        elif two_pass_visual and _page_classes_from_extraction is None:
+            # Classification error was already logged during extraction; fail closed.
+            # Do NOT run the heavy inline vision path for this file.
+            _visual_queue_updates = {}
+            _skip_inline_vision = True
+
+        if two_pass_visual and _page_classes_from_extraction is not None:
             # Skip inline ColPali + VLM entirely — image-heavy pages are queued for pass-2
             if verbose and _visual_queue_updates:
                 pending_pages = _visual_queue_updates.get(VISUAL_PENDING_KEY, [])
@@ -393,11 +409,11 @@ def _embed_one_file(
                     f"for deferred visual embedding",
                     flush=True,
                 )
-        else:
+        elif not two_pass_visual:
             _visual_queue_updates = {}
 
         # Check if ColPali multimodal embedding is enabled (Issue #1)
-        colpali_enabled = (not two_pass_visual) and cfg.get("embed", {}).get("colpali_enabled", False)
+        colpali_enabled = (not _skip_inline_vision) and cfg.get("embed", {}).get("colpali_enabled", False)
 
         # NEW: ColPali multimodal path for visual pages
         if colpali_enabled:
@@ -428,8 +444,8 @@ def _embed_one_file(
                     )
 
         # Use intelligent extraction with GLM-OCR/LLaVA routing (Phase 999.4)
-        # Skipped entirely when two_pass_visual is on — image-heavy pages are queued above.
-        if not two_pass_visual:
+        # Skipped when two_pass_visual queued pages OR when classification failed (fail closed).
+        if not _skip_inline_vision:
             if progress:
                 progress.step("extracting image descriptions")
             checkpoint_path = _vision_checkpoint_path(repo_root, slug)

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -31,7 +31,7 @@ from carta.embed.embed import (
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
 from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert
-from carta.embed.visual_queue import add_pending_pages, VISUAL_PENDING_KEY
+from carta.embed.visual_queue import add_pending_pages, VISUAL_PENDING_KEY, queue_summary, format_summary_line
 from carta.vision.classifier import PageClass, PageAnalyzer
 
 _IMAGE_HEAVY = {PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED}
@@ -1084,6 +1084,20 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
     alert_msg = check_stale_alert(stale_count, total_count, threshold)
     if alert_msg:
         print(alert_msg, flush=True)
+
+    # Emit visual-queue nudge: scan all sidecars for pending visual pages (pass-1 → pass-2)
+    all_sidecar_dicts = []
+    sidecars_root = repo_root / ".carta" / "sidecars"
+    if sidecars_root.exists():
+        for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
+            data = read_sidecar(sc_path)
+            if data is not None:
+                all_sidecar_dicts.append(data)
+    vq_summary = queue_summary(all_sidecar_dicts)
+    vq_line = format_summary_line(vq_summary)
+    if vq_line:
+        print(vq_line, flush=True)
+    summary["visual_queue"] = vq_summary
 
     return summary
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1414,7 +1414,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
                 if not embed_cfg.get("colpali_enabled", False):
                     continue
                     
-                model_name = embed_cfg.get("colpali_model", "vidore/colpali-v1.3-hf")
+                model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
                 device = embed_cfg.get("colpali_device", "cpu")
                 
                 try:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -31,6 +31,30 @@ from carta.embed.embed import (
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
 from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert
+from carta.embed.visual_queue import add_pending_pages, VISUAL_PENDING_KEY
+from carta.vision.classifier import PageClass, PageAnalyzer
+
+_IMAGE_HEAVY = {PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED}
+
+
+def _mark_or_collect_visual_pages(page_classes: list, cfg: dict) -> dict:
+    """Return sidecar updates queuing 1-indexed image-heavy pages when two_pass_visual is on.
+
+    Args:
+        page_classes: List of PageClass values, one per page (0-indexed position = page-1).
+        cfg: Carta config dict. Reads embed.two_pass_visual.
+
+    Returns:
+        Dict with VISUAL_PENDING_KEY → sorted list of 1-indexed page numbers, or {} when
+        two_pass_visual is off or no image-heavy pages exist.
+    """
+    if not cfg.get("embed", {}).get("two_pass_visual", True):
+        return {}
+    pending = [i + 1 for i, pc in enumerate(page_classes) if pc in _IMAGE_HEAVY]
+    updates: dict = {}
+    if pending:
+        add_pending_pages(updates, pending)  # writes updates[VISUAL_PENDING_KEY]
+    return updates
 
 
 _SUPPORTED_EXTENSIONS = [".pdf", ".md"]
@@ -332,10 +356,48 @@ def _embed_one_file(
     image_chunk_count = 0
     vision_metadata = None
     visual_pages_count = 0  # NEW: Count of pages embedded via ColPali
+    _visual_queue_updates: dict = {}  # populated by two_pass_visual pass-1 for PDFs
 
     if file_path.suffix == ".pdf":
+        # Two-pass visual: when enabled, classify pages cheaply and queue image-heavy
+        # ones for deferred visual embedding instead of running inline VLM/ColPali.
+        # Pure-text / structured-text pages still embed as normal today.
+        # Text extraction (extract_pdf_text above) already ran for all pages — no data lost.
+        two_pass_visual = cfg.get("embed", {}).get("two_pass_visual", True)
+        if two_pass_visual:
+            try:
+                import fitz
+                from carta.mupdf_util import mupdf_quiet
+                analyzer = PageAnalyzer(cfg)
+                with mupdf_quiet():
+                    _fitz_doc = fitz.open(str(file_path))
+                    _page_classes = [analyzer.analyze(p).page_class for p in _fitz_doc]
+                    _fitz_doc.close()
+                _visual_queue_updates = _mark_or_collect_visual_pages(_page_classes, cfg)
+            except Exception as _exc:
+                # Fail-open: if classification errors, fall through to inline vision
+                print(
+                    f"Warning: two_pass_visual page classification failed for {file_path}: {_exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                two_pass_visual = False
+                _visual_queue_updates = {}
+
+        if two_pass_visual:
+            # Skip inline ColPali + VLM entirely — image-heavy pages are queued for pass-2
+            if verbose and _visual_queue_updates:
+                pending_pages = _visual_queue_updates.get(VISUAL_PENDING_KEY, [])
+                print(
+                    f"    two_pass_visual: queuing {len(pending_pages)} image-heavy page(s) "
+                    f"for deferred visual embedding",
+                    flush=True,
+                )
+        else:
+            _visual_queue_updates = {}
+
         # Check if ColPali multimodal embedding is enabled (Issue #1)
-        colpali_enabled = cfg.get("embed", {}).get("colpali_enabled", False)
+        colpali_enabled = (not two_pass_visual) and cfg.get("embed", {}).get("colpali_enabled", False)
 
         # NEW: ColPali multimodal path for visual pages
         if colpali_enabled:
@@ -366,74 +428,76 @@ def _embed_one_file(
                     )
 
         # Use intelligent extraction with GLM-OCR/LLaVA routing (Phase 999.4)
-        if progress:
-            progress.step("extracting image descriptions")
-        checkpoint_path = _vision_checkpoint_path(repo_root, slug)
-        try:
-            from carta.vision.router import extract_image_descriptions_intelligent
-            img_descs = extract_image_descriptions_intelligent(
-                file_path, cfg, progress_callback=_vision_callback,
-                cancel_event=cancel_event,
-                checkpoint_path=checkpoint_path,
-            )
-            image_count = len(img_descs)
-
-            if img_descs:
-                image_chunks = []
-                for desc in img_descs:
-                    for part_text in _split_vision_text(desc["text"], max_tokens):
-                        image_chunks.append({
-                            "slug": slug,
-                            "file_path": str(file_path.relative_to(repo_root)),
-                            "doc_type": "image_description",
-                            "page_num": desc["page_num"],
-                            "image_index": desc["image_index"],
-                            "chunk_index": len(raw_chunks) + len(image_chunks),
-                            "text": part_text,
-                            # Phase 999.4: extraction provenance
-                            "model_used": desc.get("model_used", "llava"),
-                            "content_type": desc.get("content_type", "visual"),
-                        })
-                image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
-                if verbose:
-                    print(f"    embedded {image_chunk_count} image description chunk(s)", flush=True)
-
-                # Build vision metadata for sidecar (Phase 999.4-04)
-                vision_metadata = _build_vision_metadata(img_descs)
-        except Exception as exc:
-            # Fail-open: log error but don't block embedding
-            print(
-                f"Warning: intelligent vision extraction failed for {file_path}: {exc}",
-                file=sys.stderr,
-                flush=True
-            )
-            # Fallback to legacy extraction if available
+        # Skipped entirely when two_pass_visual is on — image-heavy pages are queued above.
+        if not two_pass_visual:
+            if progress:
+                progress.step("extracting image descriptions")
+            checkpoint_path = _vision_checkpoint_path(repo_root, slug)
             try:
-                from carta.embed.vision import extract_image_descriptions
-                img_descs = extract_image_descriptions(file_path, cfg)
+                from carta.vision.router import extract_image_descriptions_intelligent
+                img_descs = extract_image_descriptions_intelligent(
+                    file_path, cfg, progress_callback=_vision_callback,
+                    cancel_event=cancel_event,
+                    checkpoint_path=checkpoint_path,
+                )
                 image_count = len(img_descs)
 
                 if img_descs:
                     image_chunks = []
                     for desc in img_descs:
-                        image_chunks.append({
-                            "slug": slug,
-                            "file_path": str(file_path.relative_to(repo_root)),
-                            "doc_type": "image_description",
-                            "page_num": desc["page_num"],
-                            "image_index": desc["image_index"],
-                            "chunk_index": len(raw_chunks) + len(image_chunks),
-                            "text": desc["text"],
-                        })
+                        for part_text in _split_vision_text(desc["text"], max_tokens):
+                            image_chunks.append({
+                                "slug": slug,
+                                "file_path": str(file_path.relative_to(repo_root)),
+                                "doc_type": "image_description",
+                                "page_num": desc["page_num"],
+                                "image_index": desc["image_index"],
+                                "chunk_index": len(raw_chunks) + len(image_chunks),
+                                "text": part_text,
+                                # Phase 999.4: extraction provenance
+                                "model_used": desc.get("model_used", "llava"),
+                                "content_type": desc.get("content_type", "visual"),
+                            })
                     image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                     if verbose:
-                        print(f"    embedded {image_chunk_count} image description chunk(s) (legacy)", flush=True)
-            except Exception as legacy_exc:
+                        print(f"    embedded {image_chunk_count} image description chunk(s)", flush=True)
+
+                    # Build vision metadata for sidecar (Phase 999.4-04)
+                    vision_metadata = _build_vision_metadata(img_descs)
+            except Exception as exc:
+                # Fail-open: log error but don't block embedding
                 print(
-                    f"Warning: legacy vision extraction also failed: {legacy_exc}",
+                    f"Warning: intelligent vision extraction failed for {file_path}: {exc}",
                     file=sys.stderr,
                     flush=True
                 )
+                # Fallback to legacy extraction if available
+                try:
+                    from carta.embed.vision import extract_image_descriptions
+                    img_descs = extract_image_descriptions(file_path, cfg)
+                    image_count = len(img_descs)
+
+                    if img_descs:
+                        image_chunks = []
+                        for desc in img_descs:
+                            image_chunks.append({
+                                "slug": slug,
+                                "file_path": str(file_path.relative_to(repo_root)),
+                                "doc_type": "image_description",
+                                "page_num": desc["page_num"],
+                                "image_index": desc["image_index"],
+                                "chunk_index": len(raw_chunks) + len(image_chunks),
+                                "text": desc["text"],
+                            })
+                        image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
+                        if verbose:
+                            print(f"    embedded {image_chunk_count} image description chunk(s) (legacy)", flush=True)
+                except Exception as legacy_exc:
+                    print(
+                        f"Warning: legacy vision extraction also failed: {legacy_exc}",
+                        file=sys.stderr,
+                        flush=True
+                    )
 
     sidecar_updates = {
         "status": "embedded",
@@ -444,18 +508,22 @@ def _embed_one_file(
         "file_mtime": os.path.getmtime(str(file_path)),
         "visual_pages": visual_pages_count,  # NEW: ColPali visual pages
     }
-    
+
     # Add vision metadata if available (Phase 999.4-04)
     if vision_metadata:
         sidecar_updates["vision"] = vision_metadata
-        
+
     # Add ColPali metadata if visual pages were embedded (Issue #1)
     if visual_pages_count > 0:
         sidecar_updates["colpali"] = {
             "enabled": True,
             "visual_pages_embedded": visual_pages_count,
         }
-    
+
+    # Merge deferred visual-queue updates (two_pass_visual pass-1: visual_pending pages)
+    if _visual_queue_updates:
+        sidecar_updates.update(_visual_queue_updates)
+
     sidecar_updates["_vision_events"] = _page_events
 
     # File fully embedded — clear any per-page resume checkpoint.

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -632,7 +632,7 @@ def _embed_visual_pages_colpali(
 
     # Get ColPali config
     embed_cfg = cfg.get("embed", {})
-    model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0")
+    model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
     device = embed_cfg.get("colpali_device", "cpu")
     batch_size = embed_cfg.get("colpali_batch_size", 1)
     cache_dir = embed_cfg.get("colpali_sidecar_path", ".carta/visual_cache/")
@@ -728,25 +728,48 @@ def _discover_visual_pending(repo_root: Path) -> list[tuple]:
     return out
 
 
+def _visual_chunk_index_pass2(page: int, i: int) -> str:
+    """Return the chunk_index token used for pass-2 visual/OCR text chunks.
+
+    Pass-2 chunks set ``chunk_index`` to this string (e.g. ``"visual:1:0"``).
+    ``upsert_chunks`` then derives the Qdrant point ID via
+    ``_point_id(slug, chunk_index)`` → ``md5("{slug}:visual:{page}:{i}")``.
+
+    This namespace is structurally disjoint from pass-1 text chunks, which
+    always use integer chunk_index values (e.g. ``md5("{slug}:0")``).  An
+    integer can never equal the string ``"visual:{page}:{i}"``, so collision
+    between pass-1 and pass-2 chunks for the same slug is impossible by
+    construction.
+    """
+    return f"visual:{page}:{i}"
+
+
 def _visual_embed_one_page(
     sidecar: dict,
     page: int,
     cfg: dict,
     client,
     repo_root: Path,
+    router,
+    embedder,
     verbose: bool = False,
 ) -> bool:
     """OCR text + ColPali for a single 1-indexed page. Raise on failure.
 
     (a) glm-ocr text for the page via SmartRouter → upsert_chunks (hybrid text index).
+        Pass-2 chunks receive point IDs from _visual_point_id_pass2() so they are
+        disjoint from pass-1 text chunks for the same slug.
     (b) ColPali for the page via ColPaliEmbedder.embed_pdf_pages(page_nums=[page])
         → upsert_visual_pages (_visual collection).
 
+    ``router`` and ``embedder`` are constructed ONCE by run_visual_embed and
+    passed in; this function must NOT re-construct them.
+
+    NOTE: the PDF is opened twice per page (once for OCR, once for ColPali
+    rasterisation) — a known inefficiency acceptable for this slow pass.
+
     Raises on any failure so the caller leaves the page in visual_pending.
     """
-    from carta.vision.router import SmartRouter
-    from carta.embed.colpali import ColPaliEmbedder
-
     try:
         import fitz as _fitz
     except ImportError as e:
@@ -760,7 +783,6 @@ def _visual_embed_one_page(
     max_tokens = chunking.get("max_tokens", 400)
 
     # ── (a) GLM-OCR text → hybrid text index ─────────────────────────────────
-    router = SmartRouter(cfg)
     from carta.mupdf_util import mupdf_quiet
     with mupdf_quiet():
         try:
@@ -782,13 +804,17 @@ def _visual_embed_one_page(
         image_chunks = []
         for chunk in chunks:
             for part_text in _split_vision_text(chunk.get("text", ""), max_tokens):
+                i = len(image_chunks)
                 image_chunks.append({
                     "slug": slug,
                     "file_path": current_path,
                     "doc_type": "image_description",
                     "page_num": page,
                     "image_index": chunk.get("image_index", 0),
-                    "chunk_index": len(image_chunks),
+                    # Use a pass-2-specific chunk_index token so the Qdrant point
+                    # ID (derived by upsert_chunks as md5("{slug}:{chunk_index}"))
+                    # is disjoint from pass-1 text chunks (which use integer indices).
+                    "chunk_index": _visual_chunk_index_pass2(page, i),
                     "text": part_text,
                     "model_used": chunk.get("model_used", "glm-ocr"),
                     "content_type": chunk.get("content_type", "visual"),
@@ -803,19 +829,11 @@ def _visual_embed_one_page(
 
     # ── (b) ColPali → _visual collection ─────────────────────────────────────
     model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
-    device = embed_cfg.get("colpali_device", "cpu")
-    batch_size = embed_cfg.get("colpali_batch_size", 1)
     cache_dir_raw = embed_cfg.get("colpali_sidecar_path", ".carta/visual_cache/")
     cache_dir_path = Path(cache_dir_raw)
     if not cache_dir_path.is_absolute():
         cache_dir_path = repo_root / cache_dir_path
 
-    embedder = ColPaliEmbedder(
-        model_name=model_name,
-        device=device,
-        batch_size=batch_size,
-        cache_dir=str(cache_dir_path),
-    )
     page_results = embedder.embed_pdf_pages(file_path, page_nums=[page])
     if page_results:
         result = page_results[0]
@@ -882,10 +900,29 @@ def run_visual_embed(
     queued = _discover_visual_pending(repo_root)
     summary["files"] = len(queued)
 
+    # Construct router and embedder ONCE for the entire drain — not per page.
+    from carta.vision.router import SmartRouter
+    from carta.embed.colpali import ColPaliEmbedder
+    embed_cfg = cfg.get("embed", {}) or {}
+    model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
+    device = embed_cfg.get("colpali_device", "cpu")
+    batch_size = embed_cfg.get("colpali_batch_size", 1)
+    cache_dir_raw = embed_cfg.get("colpali_sidecar_path", ".carta/visual_cache/")
+    cache_dir_path = Path(cache_dir_raw)
+    if not cache_dir_path.is_absolute():
+        cache_dir_path = repo_root / cache_dir_path
+    router = SmartRouter(cfg)
+    embedder = ColPaliEmbedder(
+        model_name=model_name,
+        device=device,
+        batch_size=batch_size,
+        cache_dir=str(cache_dir_path),
+    )
+
     for sc_path, sc in queued:
         for page in list(sc.get(VISUAL_PENDING_KEY, []) or []):
             try:
-                _visual_embed_one_page(sc, page, cfg, client, repo_root, verbose)
+                _visual_embed_one_page(sc, page, cfg, client, repo_root, router, embedder, verbose)
                 move_to_done(sc, page)
                 _update_sidecar(sc_path, {
                     VISUAL_PENDING_KEY: sc[VISUAL_PENDING_KEY],

--- a/carta/embed/tests/test_pass1_marking.py
+++ b/carta/embed/tests/test_pass1_marking.py
@@ -1,0 +1,23 @@
+from carta.vision.classifier import PageClass
+from carta.embed import pipeline
+from carta.embed.visual_queue import VISUAL_PENDING_KEY
+
+
+def test_mark_collects_image_heavy_pages_when_enabled():
+    cfg = {"embed": {"two_pass_visual": True}}
+    page_classes = [PageClass.PURE_TEXT, PageClass.TEXT_WITH_IMAGES,
+                    PageClass.STRUCTURED_TEXT, PageClass.FLATTENED]
+    updates = pipeline._mark_or_collect_visual_pages(page_classes, cfg)
+    assert updates[VISUAL_PENDING_KEY] == [2, 4]  # 1-indexed image-heavy pages
+
+
+def test_mark_noop_when_disabled():
+    cfg = {"embed": {"two_pass_visual": False}}
+    page_classes = [PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED]
+    assert pipeline._mark_or_collect_visual_pages(page_classes, cfg) == {}
+
+
+def test_mark_noop_when_no_image_heavy_pages():
+    cfg = {"embed": {"two_pass_visual": True}}
+    page_classes = [PageClass.PURE_TEXT, PageClass.STRUCTURED_TEXT]
+    assert pipeline._mark_or_collect_visual_pages(page_classes, cfg) == {}

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -1,6 +1,14 @@
 from unittest.mock import MagicMock
 from carta.embed import pipeline
+from carta.embed.pipeline import _visual_chunk_index_pass2
+from carta.embed.embed import _point_id
 from carta.embed.visual_queue import VISUAL_PENDING_KEY, VISUAL_DONE_KEY
+
+
+def _mock_router_embedder(monkeypatch):
+    """Patch SmartRouter and ColPaliEmbedder so run_visual_embed doesn't need real models."""
+    monkeypatch.setattr("carta.embed.pipeline.SmartRouter", lambda cfg: MagicMock(), raising=False)
+    monkeypatch.setattr("carta.embed.pipeline.ColPaliEmbedder", lambda **k: MagicMock(), raising=False)
 
 
 def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):
@@ -9,9 +17,11 @@ def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):
     written = []
     monkeypatch.setattr(pipeline, "_update_sidecar", lambda sc_path, updates: written.append(dict(updates)))
     monkeypatch.setattr(pipeline, "_visual_embed_one_page",
-                        lambda sidecar, page, cfg, client, repo_root, verbose: True, raising=False)
+                        lambda sidecar, page, cfg, client, repo_root, router, embedder, verbose=False: True,
+                        raising=False)
     monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
     monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    _mock_router_embedder(monkeypatch)
     summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {"visual_timeout_s": 0}})
     assert summary["pages_embedded"] == 2
     assert sc[VISUAL_PENDING_KEY] == [] and sc[VISUAL_DONE_KEY] == [1, 2]
@@ -26,6 +36,7 @@ def test_drainer_leaves_failed_page_pending(monkeypatch, tmp_path):
     monkeypatch.setattr(pipeline, "_visual_embed_one_page", boom, raising=False)
     monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
     monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    _mock_router_embedder(monkeypatch)
     summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
     assert summary["pages_embedded"] == 0
     assert summary["pages_failed"] == 1
@@ -37,3 +48,33 @@ def test_drainer_preflight_when_visual_unavailable(monkeypatch, tmp_path):
     summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
     assert summary.get("status") == "visual_unavailable"
     assert summary["pages_embedded"] == 0
+
+
+def test_pass2_point_ids_disjoint_from_pass1():
+    """Pass-2 visual/OCR chunk IDs must never collide with pass-1 text chunk IDs.
+
+    upsert_chunks derives the Qdrant point ID as _point_id(slug, chunk_index),
+    i.e. md5("{slug}:{chunk_index}").
+
+    Pass-1 uses integer chunk_index values  → md5("{slug}:0"), md5("{slug}:1"), …
+    Pass-2 uses _visual_chunk_index_pass2() → md5("{slug}:visual:{page}:{i}")
+
+    An integer string can never equal "visual:{page}:{i}" so the two namespaces
+    are provably disjoint.  This test confirms the MD5 outputs don't collide in
+    practice across a representative sample.
+    """
+    slug = "my-doc"
+
+    # Pass-1: simulate up to 1000 text chunks (generous upper bound)
+    pass1_ids = {_point_id(slug, ci) for ci in range(1000)}
+
+    # Pass-2: pages 1..5, sub-indices 0..9 each
+    pass2_ids = set()
+    for page in range(6):  # includes page 0 edge case
+        for i in range(10):
+            ci = _visual_chunk_index_pass2(page, i)
+            pass2_ids.add(_point_id(slug, ci))
+
+    assert pass1_ids.isdisjoint(pass2_ids), (
+        "Pass-1 and pass-2 point IDs collide — namespace isolation is broken"
+    )

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+from carta.embed import pipeline
+from carta.embed.visual_queue import VISUAL_PENDING_KEY, VISUAL_DONE_KEY
+
+
+def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):
+    sc = {"current_path": "docs/x.pdf", "slug": "x", VISUAL_PENDING_KEY: [1, 2], VISUAL_DONE_KEY: []}
+    monkeypatch.setattr(pipeline, "_discover_visual_pending", lambda repo_root: [("sc_path", sc)], raising=False)
+    written = []
+    monkeypatch.setattr(pipeline, "_update_sidecar", lambda sc_path, updates: written.append(dict(updates)))
+    monkeypatch.setattr(pipeline, "_visual_embed_one_page",
+                        lambda sidecar, page, cfg, client, repo_root, verbose: True, raising=False)
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {"visual_timeout_s": 0}})
+    assert summary["pages_embedded"] == 2
+    assert sc[VISUAL_PENDING_KEY] == [] and sc[VISUAL_DONE_KEY] == [1, 2]
+
+
+def test_drainer_leaves_failed_page_pending(monkeypatch, tmp_path):
+    sc = {"current_path": "docs/x.pdf", "slug": "x", VISUAL_PENDING_KEY: [1], VISUAL_DONE_KEY: []}
+    monkeypatch.setattr(pipeline, "_discover_visual_pending", lambda r: [("sc", sc)], raising=False)
+    monkeypatch.setattr(pipeline, "_update_sidecar", lambda *a, **k: None)
+    def boom(*a, **k):
+        raise RuntimeError("model crashed")
+    monkeypatch.setattr(pipeline, "_visual_embed_one_page", boom, raising=False)
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
+    assert summary["pages_embedded"] == 0
+    assert summary["pages_failed"] == 1
+    assert sc[VISUAL_PENDING_KEY] == [1]
+
+
+def test_drainer_preflight_when_visual_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: False, raising=False)
+    summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
+    assert summary.get("status") == "visual_unavailable"
+    assert summary["pages_embedded"] == 0

--- a/carta/embed/tests/test_visual_queue.py
+++ b/carta/embed/tests/test_visual_queue.py
@@ -1,0 +1,46 @@
+from carta.embed.visual_queue import (
+    add_pending_pages, move_to_done, queue_summary, format_summary_line,
+    VISUAL_PENDING_KEY, VISUAL_DONE_KEY,
+)
+
+
+def test_add_pending_pages_dedupes_and_sorts():
+    sc = {}
+    add_pending_pages(sc, [3, 1, 1])
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    add_pending_pages(sc, [2, 3])
+    assert sc[VISUAL_PENDING_KEY] == [1, 2, 3]
+
+
+def test_add_pending_pages_excludes_already_done():
+    sc = {VISUAL_DONE_KEY: [2]}
+    add_pending_pages(sc, [1, 2, 3])
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]  # 2 already done, not re-queued
+
+
+def test_move_to_done_transfers_page():
+    sc = {VISUAL_PENDING_KEY: [1, 2, 3], VISUAL_DONE_KEY: []}
+    move_to_done(sc, 2)
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    assert sc[VISUAL_DONE_KEY] == [2]
+    move_to_done(sc, 2)  # idempotent
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    assert sc[VISUAL_DONE_KEY] == [2]
+
+
+def test_queue_summary_counts_files_and_pages():
+    sidecars = [
+        {VISUAL_PENDING_KEY: [1, 2]},
+        {VISUAL_PENDING_KEY: [5]},
+        {VISUAL_PENDING_KEY: []},
+        {},
+    ]
+    assert queue_summary(sidecars) == {"files": 2, "pages": 3}
+
+
+def test_format_summary_line():
+    assert format_summary_line({"files": 18, "pages": 42}) == (
+        "Visual queue: 42 page(s) across 18 file(s) await visual embedding. "
+        "Run `carta embed --visual` to process them."
+    )
+    assert format_summary_line({"files": 0, "pages": 0}) == ""

--- a/carta/embed/tests/test_visual_queue.py
+++ b/carta/embed/tests/test_visual_queue.py
@@ -4,6 +4,22 @@ from carta.embed.visual_queue import (
 )
 
 
+def test_pipeline_imports_queue_summary_and_format_summary_line():
+    """Confirm run_embed imports and uses queue_summary + format_summary_line from pipeline."""
+    import inspect
+    import carta.embed.pipeline as pipeline_mod
+
+    # Both names must be importable from the module (live references, not just names in source)
+    assert callable(pipeline_mod.queue_summary), "queue_summary not imported into pipeline"
+    assert callable(pipeline_mod.format_summary_line), "format_summary_line not imported into pipeline"
+
+    # run_embed must reference queue_summary somewhere in its source
+    source = inspect.getsource(pipeline_mod.run_embed)
+    assert "queue_summary" in source
+    assert "format_summary_line" in source
+    assert "visual_queue" in source
+
+
 def test_add_pending_pages_dedupes_and_sorts():
     sc = {}
     add_pending_pages(sc, [3, 1, 1])

--- a/carta/embed/visual_queue.py
+++ b/carta/embed/visual_queue.py
@@ -1,0 +1,52 @@
+"""Helpers for the deferred visual-embedding queue stored in sidecar state.
+
+A sidecar gains two lists of 1-indexed page numbers:
+  visual_pending: pages awaiting glm-ocr text + ColPali visual embedding
+  visual_done:    pages already visual-embedded
+Per-page transitions make the visual pass resumable/interrupt-safe.
+"""
+from __future__ import annotations
+
+VISUAL_PENDING_KEY = "visual_pending"
+VISUAL_DONE_KEY = "visual_done"
+
+
+def add_pending_pages(sidecar: dict, pages: list[int]) -> None:
+    """Add page numbers to visual_pending (deduped, sorted), excluding already-done."""
+    done = set(sidecar.get(VISUAL_DONE_KEY, []) or [])
+    cur = set(sidecar.get(VISUAL_PENDING_KEY, []) or [])
+    cur.update(p for p in pages if p not in done)
+    sidecar[VISUAL_PENDING_KEY] = sorted(cur)
+
+
+def move_to_done(sidecar: dict, page: int) -> None:
+    """Move one page from visual_pending to visual_done (idempotent)."""
+    sidecar[VISUAL_PENDING_KEY] = [
+        p for p in sidecar.get(VISUAL_PENDING_KEY, []) or [] if p != page
+    ]
+    done = sidecar.get(VISUAL_DONE_KEY, []) or []
+    if page not in done:
+        done = sorted(done + [page])
+    sidecar[VISUAL_DONE_KEY] = done
+
+
+def queue_summary(sidecars: list[dict]) -> dict:
+    """Count files with >=1 pending page and total pending pages."""
+    files = 0
+    pages = 0
+    for sc in sidecars:
+        p = sc.get(VISUAL_PENDING_KEY, []) or []
+        if p:
+            files += 1
+            pages += len(p)
+    return {"files": files, "pages": pages}
+
+
+def format_summary_line(summary: dict) -> str:
+    """Human nudge printed at the end of pass-1; empty string when nothing queued."""
+    if not summary.get("pages"):
+        return ""
+    return (
+        f"Visual queue: {summary['pages']} page(s) across {summary['files']} file(s) "
+        f"await visual embedding. Run `carta embed --visual` to process them."
+    )

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -107,3 +107,10 @@ def test_update_check_can_be_disabled(tmp_path):
     cfg_path.write_text(yaml.dump(config))
     cfg = load_config(cfg_path)
     assert cfg["update_check"] is False
+
+
+def test_two_pass_visual_defaults():
+    from carta.config import DEFAULTS
+    e = DEFAULTS["embed"]
+    assert e["two_pass_visual"] is True
+    assert e["visual_timeout_s"] == 3600

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -477,6 +477,11 @@ class TestVisionIntegration:
         """_embed_one_file calls extract_image_descriptions_intelligent for PDF files."""
         repo_root, cfg = temp_repo
 
+        # Disable two_pass_visual so the inline VLM/vision path is exercised.
+        # (two_pass_visual=True routes image-heavy pages to deferred pass-2 and skips
+        # inline vision entirely — that behaviour is tested in test_pass1_marking.py.)
+        cfg["embed"]["two_pass_visual"] = False
+
         # Create a test PDF file
         docs_dir = repo_root / "docs"
         docs_dir.mkdir()

--- a/docs/superpowers/plans/2026-06-07-two-pass-visual-embedding.md
+++ b/docs/superpowers/plans/2026-06-07-two-pass-visual-embedding.md
@@ -1,0 +1,486 @@
+# Two-Pass Visual Embedding — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `carta embed` extract text fast and *queue* image-heavy PDF pages, then let `carta embed --visual` slowly, resumably drain that queue doing glm-ocr text + ColPali visual embedding per page.
+
+**Architecture:** Pass-1 classifies each PDF page (existing `PageAnalyzer`); image-heavy pages (`TEXT_WITH_IMAGES`/`FLATTENED`) are recorded in the sidecar's `visual_pending` list instead of being embedded inline. Pass-2 (`carta embed --visual`) scans sidecars for `visual_pending`, processes one page at a time with a generous timeout, and checkpoints each page `visual_pending → visual_done` so it's interrupt-safe and resumable.
+
+**Tech Stack:** Python 3.10+, existing Carta pipeline (`carta/embed/pipeline.py`, `carta/embed/induct.py`, `carta/vision/classifier.py`, `carta/embed/colpali.py`), Qdrant, Ollama (glm-ocr), fastembed, optional `[visual]` extra (torch+transformers for ColPali). pytest with Framework Python 3.12: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest`.
+
+Spec: `docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md`.
+
+---
+
+## Current-state anchors (verified)
+- Sidecar I/O: `read_sidecar(sidecar_path)->dict|None`, `write_sidecar(file_path, stub, repo_root)`, `generate_sidecar_stub(...)`, `sidecar_path(file_path, repo_root)` in `carta/embed/induct.py`; `_update_sidecar(sidecar_path, updates)` in `carta/embed/pipeline.py:124`.
+- Discovery pattern: `discover_pending_files(repo_root)` (`pipeline.py:132`) scans `.carta/sidecars/**/*.embed-meta.yaml`.
+- Classifier: `carta/vision/classifier.py` `PageClass` = {PURE_TEXT, STRUCTURED_TEXT, TEXT_WITH_IMAGES, FLATTENED}.
+- Per-file embed: `_embed_one_file(...)` (the inner embed used by both `run_embed` and `run_embed_file`); the per-page vision/OCR work happens here.
+- ColPali: `_embed_visual_pages_colpali(file_path, file_info, cfg, client, repo_root, verbose)` (`pipeline.py:509`); `ColPaliEmbedder.embed_pdf_pages(pdf_path, page_nums=[1-indexed], dpi)` (`colpali.py:275`); `is_colpali_available()` (`colpali.py`).
+- CLI: `cmd_embed(args)` (`cli.py:179`), `embed_p` subparser (`cli.py:554`).
+- Config DEFAULTS: `carta/config.py` `DEFAULTS["embed"]`.
+
+---
+
+## File structure
+
+| File | Create/Modify | Responsibility |
+|------|---------------|----------------|
+| `carta/embed/visual_queue.py` | Create | Pure helpers: mark pages pending, move pending→done, discover queued pages across sidecars, count summary |
+| `carta/embed/tests/test_visual_queue.py` | Create | Unit tests for the queue helpers (no I/O beyond tmp sidecars) |
+| `carta/config.py` | Modify | Add `embed.two_pass_visual` (default true) + `embed.visual_timeout_s` defaults |
+| `carta/embed/pipeline.py` | Modify | Pass-1: mark image-heavy pages instead of inline vision; `run_visual_embed()` drainer; end-of-pass summary |
+| `carta/embed/tests/test_pass1_marking.py` | Create | Pass-1 marks image-heavy pages (mocked classifier) |
+| `carta/embed/tests/test_visual_drainer.py` | Create | Drainer: per-page checkpoint, resume, preflight gating (mocked models) |
+| `carta/cli.py` | Modify | `--visual` flag + dispatch; print end-of-pass summary |
+| `README.md` / `AGENTS.md` | Modify | Document the two-pass workflow |
+
+---
+
+## Task 1: Visual-queue helpers (pure functions)
+
+**Files:**
+- Create: `carta/embed/visual_queue.py`
+- Test: `carta/embed/tests/test_visual_queue.py`
+
+- [ ] **Step 1: Write the failing test** — `carta/embed/tests/test_visual_queue.py`
+```python
+from carta.embed.visual_queue import (
+    add_pending_pages, move_to_done, queue_summary, VISUAL_PENDING_KEY, VISUAL_DONE_KEY,
+)
+
+
+def test_add_pending_pages_dedupes_and_sorts():
+    sc = {}
+    add_pending_pages(sc, [3, 1, 1])
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    add_pending_pages(sc, [2, 3])
+    assert sc[VISUAL_PENDING_KEY] == [1, 2, 3]
+
+
+def test_move_to_done_transfers_page():
+    sc = {VISUAL_PENDING_KEY: [1, 2, 3], VISUAL_DONE_KEY: []}
+    move_to_done(sc, 2)
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    assert sc[VISUAL_DONE_KEY] == [2]
+    # idempotent: moving an already-done page is a no-op
+    move_to_done(sc, 2)
+    assert sc[VISUAL_PENDING_KEY] == [1, 3]
+    assert sc[VISUAL_DONE_KEY] == [2]
+
+
+def test_queue_summary_counts_files_and_pages():
+    sidecars = [
+        {VISUAL_PENDING_KEY: [1, 2]},
+        {VISUAL_PENDING_KEY: [5]},
+        {VISUAL_PENDING_KEY: []},
+        {},
+    ]
+    s = queue_summary(sidecars)
+    assert s == {"files": 2, "pages": 3}
+```
+
+- [ ] **Step 2: Run → fail**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_queue.py -v`
+Expected: FAIL (ModuleNotFoundError: carta.embed.visual_queue).
+
+- [ ] **Step 3: Implement** — `carta/embed/visual_queue.py`
+```python
+"""Helpers for the deferred visual-embedding queue stored in sidecar state.
+
+A sidecar gains two lists of 1-indexed page numbers:
+  visual_pending: pages awaiting glm-ocr text + ColPali visual embedding
+  visual_done:    pages already visual-embedded
+Per-page transitions make the visual pass resumable/interrupt-safe.
+"""
+from __future__ import annotations
+
+VISUAL_PENDING_KEY = "visual_pending"
+VISUAL_DONE_KEY = "visual_done"
+
+
+def add_pending_pages(sidecar: dict, pages: list[int]) -> None:
+    """Add page numbers to visual_pending (deduped, sorted), excluding already-done."""
+    done = set(sidecar.get(VISUAL_DONE_KEY, []) or [])
+    cur = set(sidecar.get(VISUAL_PENDING_KEY, []) or [])
+    cur.update(p for p in pages if p not in done)
+    sidecar[VISUAL_PENDING_KEY] = sorted(cur)
+
+
+def move_to_done(sidecar: dict, page: int) -> None:
+    """Move one page from visual_pending to visual_done (idempotent)."""
+    pending = [p for p in sidecar.get(VISUAL_PENDING_KEY, []) or [] if p != page]
+    sidecar[VISUAL_PENDING_KEY] = pending
+    done = sidecar.get(VISUAL_DONE_KEY, []) or []
+    if page not in done:
+        done = sorted(done + [page])
+    sidecar[VISUAL_DONE_KEY] = done
+
+
+def queue_summary(sidecars: list[dict]) -> dict:
+    """Count files with >=1 pending page and total pending pages."""
+    files = 0
+    pages = 0
+    for sc in sidecars:
+        p = sc.get(VISUAL_PENDING_KEY, []) or []
+        if p:
+            files += 1
+            pages += len(p)
+    return {"files": files, "pages": pages}
+```
+
+- [ ] **Step 4: Run → pass**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_queue.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add carta/embed/visual_queue.py carta/embed/tests/test_visual_queue.py
+git commit -m "feat(embed): visual-queue sidecar helpers (pending/done page transitions)"
+```
+
+---
+
+## Task 2: Config defaults
+
+**Files:**
+- Modify: `carta/config.py` (`DEFAULTS["embed"]`)
+- Test: `carta/tests/test_config.py` (append)
+
+- [ ] **Step 1: Write failing test** — append to `carta/tests/test_config.py`
+```python
+def test_two_pass_visual_defaults():
+    from carta.config import DEFAULTS
+    e = DEFAULTS["embed"]
+    assert e["two_pass_visual"] is True
+    assert e["visual_timeout_s"] == 3600
+```
+
+- [ ] **Step 2: Run → fail**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/tests/test_config.py::test_two_pass_visual_defaults -v`
+Expected: FAIL (KeyError: 'two_pass_visual').
+
+- [ ] **Step 3: Implement** — in `carta/config.py`, add to the `embed` block of `DEFAULTS`:
+```python
+        "two_pass_visual": True,    # pass-1 marks image-heavy pages; pass-2 (--visual) drains them
+        "visual_timeout_s": 3600,   # generous per-file timeout for the slow visual pass (0 = unbounded)
+```
+
+- [ ] **Step 4: Run → pass**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/tests/test_config.py::test_two_pass_visual_defaults -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add carta/config.py carta/tests/test_config.py
+git commit -m "feat(config): two_pass_visual + visual_timeout_s defaults"
+```
+
+---
+
+## Task 3: Pass-1 marks image-heavy pages instead of embedding them inline
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (`_embed_one_file` per-page routing)
+- Test: `carta/embed/tests/test_pass1_marking.py`
+
+**Context to read first:** open `_embed_one_file` in `carta/embed/pipeline.py` and find the per-page loop where `PageClass` is decided and vision/OCR/ColPali is invoked. The change: when `two_pass_visual` is enabled and a page is `TEXT_WITH_IMAGES` or `FLATTENED`, do NOT run the heavy VLM/ColPali for that page; instead collect its page number and (after the loop) call `add_pending_pages` on the sidecar updates dict. Still extract any quick PyMuPDF text for the page (keep existing text extraction). Return the pending page list as part of the sidecar updates so the caller persists it.
+
+- [ ] **Step 1: Write failing test** — `carta/embed/tests/test_pass1_marking.py`
+```python
+from unittest.mock import patch
+from carta.embed import pipeline
+from carta.embed.visual_queue import VISUAL_PENDING_KEY
+
+
+def test_pass1_marks_image_heavy_pages(tmp_path, monkeypatch):
+    """When two_pass_visual is on, image-heavy pages are queued, not vision-embedded."""
+    # Build a fake per-page classification: page 1 pure text, page 2 image-heavy.
+    from carta.vision.classifier import PageClass
+    monkeypatch.setattr(pipeline, "_classify_pages",
+                        lambda *a, **k: [PageClass.PURE_TEXT, PageClass.TEXT_WITH_IMAGES],
+                        raising=False)
+    # Guard: the heavy colpali path must NOT be called during pass-1.
+    called = {"colpali": 0}
+    monkeypatch.setattr(pipeline, "_embed_visual_pages_colpali",
+                        lambda *a, **k: called.__setitem__("colpali", called["colpali"] + 1))
+    cfg = {"embed": {"two_pass_visual": True, "chunking": {}}}
+    updates = pipeline._mark_or_collect_visual_pages(
+        page_classes=[PageClass.PURE_TEXT, PageClass.TEXT_WITH_IMAGES], cfg=cfg)
+    assert updates[VISUAL_PENDING_KEY] == [2]
+    assert called["colpali"] == 0
+```
+
+> NOTE: this test pins a small, testable helper `_mark_or_collect_visual_pages(page_classes, cfg) -> dict`. Factor the "which pages are image-heavy → visual_pending" decision into that helper so it's unit-testable without a real PDF. The integration into `_embed_one_file`'s loop (skipping inline vision for those pages) is verified by the full suite + a manual run; keep the helper as the tested seam.
+
+- [ ] **Step 2: Run → fail**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_pass1_marking.py -v`
+Expected: FAIL (AttributeError: `_mark_or_collect_visual_pages`).
+
+- [ ] **Step 3: Implement**
+Add the helper near the top of `pipeline.py`:
+```python
+from carta.embed.visual_queue import add_pending_pages, VISUAL_PENDING_KEY
+from carta.vision.classifier import PageClass
+
+_IMAGE_HEAVY = {PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED}
+
+
+def _mark_or_collect_visual_pages(page_classes, cfg) -> dict:
+    """Return sidecar updates queuing 1-indexed image-heavy pages when two_pass_visual is on."""
+    if not cfg.get("embed", {}).get("two_pass_visual", True):
+        return {}
+    pending = [i + 1 for i, pc in enumerate(page_classes) if pc in _IMAGE_HEAVY]
+    updates: dict = {}
+    if pending:
+        add_pending_pages(updates, pending)  # writes updates[VISUAL_PENDING_KEY]
+    return updates
+```
+Then, in `_embed_one_file`'s per-page handling: when `two_pass_visual` is enabled, SKIP the inline VLM/ColPali embedding for `TEXT_WITH_IMAGES`/`FLATTENED` pages (still do PyMuPDF text extraction), and merge `_mark_or_collect_visual_pages(...)` into the returned `sidecar_updates`. Adapt to the real loop variable names; the invariant: image-heavy pages get queued, not inline-vision-embedded, when `two_pass_visual` is true. (When `two_pass_visual` is false, behavior is unchanged — inline vision as today.)
+
+- [ ] **Step 4: Run → pass + full suite**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_pass1_marking.py -v && /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest -q`
+Expected: new test PASS; full suite green (existing inline-vision tests still pass because `two_pass_visual` only changes behavior when enabled — if any existing test asserts inline vision with default config, update it to set `two_pass_visual: False` for that scenario, noting why).
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add carta/embed/pipeline.py carta/embed/tests/test_pass1_marking.py
+git commit -m "feat(embed): pass-1 queues image-heavy pages (visual_pending) instead of inline vision"
+```
+
+---
+
+## Task 4: End-of-pass summary nudge
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (`run_embed` end) and/or `carta/cli.py` (`cmd_embed`)
+- Test: covered via `queue_summary` (Task 1) + a CLI smoke check
+
+- [ ] **Step 1: Write failing test** — append to `carta/embed/tests/test_visual_queue.py`
+```python
+from carta.embed.visual_queue import format_summary_line
+
+
+def test_format_summary_line():
+    assert format_summary_line({"files": 18, "pages": 42}) == (
+        "Visual queue: 42 page(s) across 18 file(s) await visual embedding. "
+        "Run `carta embed --visual` to process them."
+    )
+    assert format_summary_line({"files": 0, "pages": 0}) == ""
+```
+
+- [ ] **Step 2: Run → fail**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_queue.py::test_format_summary_line -v`
+Expected: FAIL (ImportError: format_summary_line).
+
+- [ ] **Step 3: Implement** — add to `carta/embed/visual_queue.py`:
+```python
+def format_summary_line(summary: dict) -> str:
+    """Human nudge printed at the end of pass-1; empty string when nothing queued."""
+    if not summary.get("pages"):
+        return ""
+    return (
+        f"Visual queue: {summary['pages']} page(s) across {summary['files']} file(s) "
+        f"await visual embedding. Run `carta embed --visual` to process them."
+    )
+```
+Then in `run_embed` (after the embed loop, before return): build the summary by reading all sidecars (reuse the `discover_*` scan or a small `read_all_sidecars(repo_root)`), call `queue_summary` + `format_summary_line`, and `print(...)` it when non-empty (respect the existing verbose/progress convention).
+
+- [ ] **Step 4: Run → pass**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_queue.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add carta/embed/visual_queue.py carta/embed/tests/test_visual_queue.py carta/embed/pipeline.py
+git commit -m "feat(embed): end-of-pass visual-queue summary nudge"
+```
+
+---
+
+## Task 5: `carta embed --visual` drainer
+
+**Files:**
+- Modify: `carta/cli.py` (`embed_p` subparser + `cmd_embed`)
+- Modify: `carta/embed/pipeline.py` (`run_visual_embed`)
+- Test: `carta/embed/tests/test_visual_drainer.py`
+
+- [ ] **Step 1: Write failing test** — `carta/embed/tests/test_visual_drainer.py`
+```python
+from unittest.mock import MagicMock
+from carta.embed import pipeline
+from carta.embed.visual_queue import VISUAL_PENDING_KEY, VISUAL_DONE_KEY
+
+
+def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):
+    # One sidecar with two pending pages; fake the per-page work to succeed.
+    saved = {"sidecars": [{"current_path": "docs/x.pdf", "slug": "x",
+                           VISUAL_PENDING_KEY: [1, 2], VISUAL_DONE_KEY: []}]}
+    monkeypatch.setattr(pipeline, "_discover_visual_pending",
+                        lambda repo_root: [("sc_path", saved["sidecars"][0])], raising=False)
+    written = {}
+    monkeypatch.setattr(pipeline, "_update_sidecar", lambda sc_path, updates: written.update(updates))
+    monkeypatch.setattr(pipeline, "_visual_embed_one_page",
+                        lambda sc, page, cfg, client, repo_root, verbose: True, raising=False)
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+
+    cfg = {"qdrant_url": "http://localhost:6333", "embed": {"visual_timeout_s": 0}}
+    summary = pipeline.run_visual_embed(tmp_path, cfg)
+    assert summary["pages_embedded"] == 2
+    # both pages moved to done
+    assert written.get(VISUAL_DONE_KEY) == [1, 2]
+    assert written.get(VISUAL_PENDING_KEY) == []
+
+
+def test_drainer_leaves_failed_page_pending(monkeypatch, tmp_path):
+    sc = {"current_path": "docs/x.pdf", "slug": "x", VISUAL_PENDING_KEY: [1], VISUAL_DONE_KEY: []}
+    monkeypatch.setattr(pipeline, "_discover_visual_pending", lambda r: [("sc", sc)], raising=False)
+    monkeypatch.setattr(pipeline, "_update_sidecar", lambda *a, **k: None)
+    def boom(*a, **k):
+        raise RuntimeError("model crashed")
+    monkeypatch.setattr(pipeline, "_visual_embed_one_page", boom, raising=False)
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
+    assert summary["pages_embedded"] == 0
+    assert summary["pages_failed"] == 1
+    assert sc[VISUAL_PENDING_KEY] == [1]  # left pending for retry
+
+
+def test_drainer_preflight_when_visual_unavailable(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: False, raising=False)
+    summary = pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
+    assert summary.get("status") == "visual_unavailable"
+    out = capsys.readouterr().out + capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run → fail**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_drainer.py -v`
+Expected: FAIL (AttributeError: `run_visual_embed`).
+
+- [ ] **Step 3: Implement** in `carta/embed/pipeline.py`:
+```python
+from carta.embed.colpali import is_colpali_available
+from carta.embed.visual_queue import move_to_done, VISUAL_PENDING_KEY, VISUAL_DONE_KEY
+
+
+def _discover_visual_pending(repo_root):
+    """Yield (sidecar_path, sidecar_dict) for sidecars with non-empty visual_pending."""
+    out = []
+    sidecars_dir = repo_root / ".carta" / "sidecars"
+    if not sidecars_dir.is_dir():
+        return out
+    for sc_path in sidecars_dir.rglob("*.embed-meta.yaml"):
+        sc = read_sidecar(sc_path)
+        if sc and (sc.get(VISUAL_PENDING_KEY) or []):
+            out.append((sc_path, sc))
+    return out
+
+
+def _visual_embed_one_page(sidecar, page, cfg, client, repo_root, verbose) -> bool:
+    """OCR text + ColPali for a single 1-indexed page. Returns True on success.
+
+    (a) glm-ocr text for the page -> hybrid text index via the existing text-embed path
+    (b) ColPaliEmbedder.embed_pdf_pages(pdf, page_nums=[page]) -> _visual collection
+    Adapt to the real OCR + visual-upsert helpers; raise on failure so the caller
+    leaves the page pending.
+    """
+    from pathlib import Path
+    pdf_path = (repo_root / sidecar["current_path"]).resolve()
+    # (a) OCR text for this page -> text index. Reuse the router/OCR + upsert path used
+    #     by _embed_one_file, scoped to [page]. (Integration seam — wire to real helpers.)
+    # (b) ColPali for this page -> _visual collection. Reuse _embed_visual_pages_colpali
+    #     machinery but scoped to page_nums=[page] via ColPaliEmbedder.embed_pdf_pages.
+    _embed_visual_pages_colpali(pdf_path, sidecar, cfg, client, repo_root, verbose)  # adapt to page-scoped
+    return True
+
+
+def run_visual_embed(repo_root, cfg: dict, verbose: bool = False, progress=None) -> dict:
+    """Pass-2: drain visual_pending pages (glm-ocr text + ColPali), per-page checkpoint."""
+    summary = {"pages_embedded": 0, "pages_failed": 0, "files": 0}
+    if not is_colpali_available():
+        msg = ("carta embed --visual: the [visual] extra (torch+transformers) is not "
+               "installed. Install with: pip install 'carta-cc[visual]'  (note: may "
+               "require a Python 3.12 venv if torch wheels are unavailable for the "
+               "current interpreter).")
+        print(msg, flush=True)
+        summary["status"] = "visual_unavailable"
+        return summary
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
+    queued = _discover_visual_pending(repo_root)
+    summary["files"] = len(queued)
+    for sc_path, sc in queued:
+        for page in list(sc.get(VISUAL_PENDING_KEY, []) or []):
+            try:
+                _visual_embed_one_page(sc, page, cfg, client, repo_root, verbose)
+                move_to_done(sc, page)
+                _update_sidecar(sc_path, {VISUAL_PENDING_KEY: sc[VISUAL_PENDING_KEY],
+                                          VISUAL_DONE_KEY: sc[VISUAL_DONE_KEY]})
+                summary["pages_embedded"] += 1
+            except Exception as e:  # leave page pending for retry; never drop
+                summary["pages_failed"] += 1
+                print(f"  visual: page {page} of {sc.get('current_path')} failed: {e} "
+                      f"(left pending)", flush=True)
+    return summary
+```
+> INTEGRATION SEAM: `_visual_embed_one_page` must wire (a) the page-scoped glm-ocr text → text-index upsert (reuse the OCR + `upsert_chunks` path `_embed_one_file` uses) and (b) page-scoped ColPali (`ColPaliEmbedder.embed_pdf_pages(pdf, page_nums=[page])` → `_visual` collection upsert). Read `_embed_visual_pages_colpali` and `_embed_one_file` to reuse their helpers scoped to one page. Keep raising on failure.
+
+Then wire the CLI in `carta/cli.py`:
+- Add to `embed_p`: `embed_p.add_argument("--visual", action="store_true", help="Run the slow visual pass: drain visual_pending pages (OCR text + ColPali).")`
+- In `cmd_embed`, near the top: `if getattr(args, "visual", False): from carta.embed.pipeline import run_visual_embed; from carta.config import load_config, find_config; cfg = load_config(find_config()); s = run_visual_embed(find_config().parent.parent, cfg, verbose=True); print(f"visual: embedded {s['pages_embedded']} page(s), {s['pages_failed']} failed across {s['files']} file(s)"); return` (adapt repo_root derivation to how `cmd_embed` already computes it).
+
+- [ ] **Step 4: Run → pass + full suite**
+Run: `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest carta/embed/tests/test_visual_drainer.py -v && /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 -m pytest -q`
+Expected: 3 new tests PASS; full suite green.
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add carta/embed/pipeline.py carta/cli.py carta/embed/tests/test_visual_drainer.py
+git commit -m "feat(embed): carta embed --visual drainer (per-page OCR+ColPali, resumable)"
+```
+
+---
+
+## Task 6: Docs (two-pass workflow)
+
+**Files:**
+- Modify: `README.md` (visual-embedding section), `AGENTS.md`
+
+- [ ] **Step 1: Update README** — under the ColPali/visual section, add a "Two-pass visual embedding" subsection documenting: `carta embed` (fast text + marks image-heavy pages, prints the queue summary) → `carta embed --visual` (slow, resumable drain of OCR text + ColPali). Note `embed.two_pass_visual` (default on), `embed.visual_timeout_s`, the `[visual]` extra requirement (and the possible Python 3.12 venv caveat for torch), `colpali_scoped_paths` to limit which dirs get visual treatment, and `OLLAMA_MAX_LOADED_MODELS` guidance to avoid glm-ocr+ColPali co-residency memory crashes.
+
+- [ ] **Step 2: Update AGENTS.md** — one line: image-heavy PDFs are embedded in two passes; run `carta embed` then `carta embed --visual`; scope visual work with `colpali_scoped_paths`.
+
+- [ ] **Step 3: Commit**
+```bash
+cd /Users/ian/dev/doc-audit-cc
+git add README.md AGENTS.md
+git commit -m "docs: two-pass visual embedding workflow (carta embed + carta embed --visual)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Pass-1 fast text + mark image-heavy → Task 3 ✓ (+ config Task 2).
+- Sidecar-as-queue (`visual_pending`/`visual_done`) → Task 1 ✓.
+- End-of-pass summary nudge → Task 4 ✓.
+- `carta embed --visual` drainer, per-page checkpoint, resumable, leave-pending-on-failure → Task 5 ✓.
+- OCR text + ColPali both per page → Task 5 (`_visual_embed_one_page`) ✓.
+- `[visual]`/torch preflight + guidance (incl. 3.12-venv caveat) → Task 5 ✓.
+- `visual_timeout_s` config → Task 2 ✓.
+- Scoping via `colpali_scoped_paths`, `OLLAMA_MAX_LOADED_MODELS` guidance → docs Task 6 ✓ (scoping reuses shipped #17 behavior in `_embed_visual_pages_colpali`).
+- Tests (marking, queue, drainer checkpoint/resume, preflight) → Tasks 1/3/5 ✓.
+
+**Placeholder scan:** No TBD/TODO. Three explicitly-labelled INTEGRATION SEAMS (pass-1 loop interception in `_embed_one_file`; page-scoped OCR+ColPali in `_visual_embed_one_page`; `cmd_embed` repo_root derivation) are real wiring points against code the plan can't reproduce line-for-line — each names the exact functions to reuse and the invariant to preserve, not vague "handle it" hand-waving.
+
+**Type consistency:** `VISUAL_PENDING_KEY`/`VISUAL_DONE_KEY` defined once in `visual_queue.py`, imported everywhere. `add_pending_pages`/`move_to_done`/`queue_summary`/`format_summary_line` signatures consistent between tests and impl. `run_visual_embed(repo_root, cfg, verbose, progress)` and helpers (`_discover_visual_pending`, `_visual_embed_one_page`) consistent across Task 5 test + impl + CLI call.
+
+**Known build-time decision:** torch in Carta's interpreter vs a dedicated 3.12 subprocess venv — resolve in Task 5 by checking `pip index versions torch` for the active Python; if unavailable, implement the subprocess-venv path for the visual pass and document it. Flagged, not silently assumed.

--- a/docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md
+++ b/docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md
@@ -1,0 +1,102 @@
+# Two-Pass Visual Embedding — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (brainstorm), pending implementation plan
+**Component:** `carta` embed pipeline
+
+## Problem
+
+Carta's single-pass `carta embed` does text extraction, OCR, and (optionally) VLM/ColPali vision all in one synchronous run guarded by a per-file watchdog (`file_timeout_s`, default 600s). On image-heavy PDFs (datasheets) this fails the "embed everything thoroughly" goal:
+
+- The qwen3-vl vision pass is slow and crashed 13× on a real ET-embed run ("model runner unexpectedly stopped — resource limitations"); **96 of ~223 files timed out (>600s) and were skipped.**
+- The per-file watchdog *kills* slow files rather than letting them finish — directly hostile to "slow but complete."
+- Text and heavy-visual work are coupled, so a few slow datasheets block/abort the whole run.
+
+The user's intent: embed everything thoroughly, locally, even if slow — but make the corpus text-searchable quickly, then grind the heavy visual work in the background.
+
+## Goal
+
+Decouple **"searchable fast"** from **"complete eventually"** via two passes:
+1. **Pass-1** (`carta embed`): fast text extraction now; *mark* image-heavy pages for later.
+2. **Pass-2** (`carta embed --visual`): slow, resumable background drain that does OCR text **and** ColPali visual embedding for the marked pages.
+
+Non-goals: changing the markdown/text retrieval path (hybrid BM25+dense is done and unaffected); reranking (separate issue #19); changing the dense embedding model.
+
+## Architecture
+
+### Component 1 — Pass-1: fast text + mark (`carta embed`, modified)
+
+For each PDF page, the existing classifier (`carta/vision/classifier.py` `PageAnalyzer`) runs:
+- **PURE_TEXT / STRUCTURED_TEXT** → extract text now (PyMuPDF, fast) → text index (dense+sparse), exactly as today.
+- **TEXT_WITH_IMAGES / FLATTENED** (image-heavy) → do **not** invoke the heavy VLM/ColPali. Instead:
+  - extract whatever quick PyMuPDF text the page has (so the page is not totally absent from text search), and
+  - record the page number in the sidecar field `visual_pending` (see Component 2).
+
+Because pass-1 no longer performs slow vision work, the `file_timeout_s` watchdog no longer kills datasheets (text extraction is fast). `vision_routing` continues to govern pass-1 text behavior (`auto`/`ocr`/`vision`/`off`); the new marking happens regardless of routing for image-heavy pages.
+
+**End-of-run summary (the nudge):** after a normal `carta embed`, print e.g.
+`Visual queue: 42 page(s) across 18 file(s) await visual embedding. Run \`carta embed --visual\` to process them.`
+This is informational only — pass-2 is never auto-started.
+
+### Component 2 — The queue: sidecar state (no new store)
+
+Reuse Carta's existing per-file sidecar lifecycle. Each sidecar gains:
+- `visual_pending: [int]` — page numbers awaiting visual embedding.
+- `visual_done: [int]` — page numbers already visual-embedded.
+
+The drainer discovers work by scanning sidecars for non-empty `visual_pending` (mirrors `discover_pending_files`/`discover_stale_files`). Per-page state gives **per-page checkpointing** → the visual pass is fully resumable and interrupt-safe.
+
+### Component 3 — Pass-2: slow drain (`carta embed --visual`)
+
+New CLI subflag/mode. Steps:
+1. Discover all sidecars with non-empty `visual_pending`.
+2. Process pages **one at a time** (slow, throttle-aware via `vision_workers`/`embedding_workers`), with a **generous/disabled per-file timeout** (its own config, e.g. `visual_timeout_s`, default high) so multi-page datasheets finish.
+3. Per page:
+   a. **OCR text** (glm-ocr) → hybrid text index (dense+sparse), same point-ID/slug scheme.
+   b. **ColPali** page-image embedding → the project `_visual` collection (multivector, MaxSim).
+4. On success, move the page `visual_pending → visual_done` in the sidecar (checkpoint).
+5. On model crash/timeout for a page: **log and leave the page in `visual_pending`** (retried on the next `--visual` run) — never silently drop.
+
+Scoped by the existing `colpali_scoped_paths` (#17), so the visual pass only touches configured dirs (e.g. `docs/reference/datasheets/`).
+
+### Component 4 — ColPali / torch enablement
+
+- `[visual]` remains an **optional** extra (torch + transformers).
+- `carta embed --visual` runs a **preflight import check**; if torch/transformers/ColPali aren't importable, it prints clear install guidance and exits cleanly (no crash).
+- **Open implementation decision (resolve at build time):** install torch in Carta's own interpreter if wheels exist for it, **else** use a dedicated Python 3.12 venv invoked as a subprocess for the visual pass. (Carta's pipx venv is currently Python 3.14, where torch wheels may be unavailable.) The spec does not pre-commit; the plan will check `pip index`/wheel availability and choose.
+- ColPali model: `vidore/colqwen2-v1.0-hf` (native transformers, no PEFT — confirmed loadable via `ColQwen2ForRetrieval`), `colpali_device: mps` on Apple Silicon. (`colqwen2.5` requires colpali-engine/PEFT — out of scope.)
+
+### Component 5 — Config & error handling
+
+- Reuse existing `colpali_*` keys and `vision_routing`.
+- Add `embed.visual_timeout_s` (per-page/file timeout for pass-2; default generous, e.g. 3600 or 0=unbounded).
+- Document `OLLAMA_MAX_LOADED_MODELS` guidance (avoid glm-ocr + ColPali co-residency memory crashes observed on the real run).
+- Errors are per-page and non-fatal: a failing page stays queued; the drain continues.
+
+### Component 6 — Testing
+
+Unit tests with mocked models:
+- Classifier → `visual_pending` marking (image-heavy pages queued; text pages embedded now).
+- Queue discovery (sidecars with `visual_pending` found; empty ones skipped).
+- Drainer per-page checkpoint (page moves pending→done; a simulated crash leaves it pending; resume picks it up).
+- Preflight gating when `[visual]` absent (clean message, no crash).
+- End-of-pass summary counts.
+
+## Data flow
+
+```
+carta embed (pass-1)
+  PDF page --classifier--> PURE/STRUCTURED_TEXT --> text extract --> text index (now)
+                       \-> TEXT_WITH_IMAGES/FLATTENED --> quick text + mark sidecar.visual_pending[]
+  (end) --> summary: "N pages queued; run carta embed --visual"
+
+carta embed --visual (pass-2, slow, resumable)
+  scan sidecars for visual_pending[]
+    per page: glm-ocr text --> text index ;  ColPali image --> _visual collection
+              on success: visual_pending -> visual_done   (checkpoint)
+              on failure: leave in visual_pending (retry next run)
+```
+
+## Scope
+
+One coherent spec; a multi-task implementation plan: (1) sidecar schema (`visual_pending`/`visual_done`) + pass-1 marking, (2) end-of-pass summary, (3) `carta embed --visual` drainer with per-page checkpoint, (4) `[visual]`/ColPali enablement + preflight, (5) config (`visual_timeout_s`) + docs. Builds on shipped features: hybrid retrieval (#14), colpali scoping + vision_routing (#17).


### PR DESCRIPTION
## Summary
Decouples "searchable fast" from "complete eventually" for image-heavy PDFs (datasheets), so Carta can embed everything thoroughly without the per-file watchdog killing slow files.

- **Pass-1 (`carta embed`)** extracts text fast and, for image-heavy pages (`TEXT_WITH_IMAGES`/`FLATTENED`), records them in the sidecar's `visual_pending` instead of running heavy vision inline (single-pass classify via `extract_pdf_text_and_classify`; **fail-closed** on classify error). Prints an end-of-pass nudge.
- **Pass-2 (`carta embed --visual`)** slowly, resumably drains the queue: per page → glm-ocr text (disjoint point-IDs `visual:{page}:{i}`, so pass-1 text is never clobbered) + ColPali page-image → `_visual` collection; checkpoints `visual_pending → visual_done`; a failed page stays pending for retry. Embedder/router constructed once per run. Preflight-gated on the optional `[visual]` extra.
- Config: `embed.two_pass_visual` (default true), `embed.visual_timeout_s` (default 3600). Helpers in `carta/embed/visual_queue.py`. Docs in README/AGENTS.

Spec: `docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md` · Plan: `docs/superpowers/plans/2026-06-07-two-pass-visual-embedding.md`

## Test Plan
- [x] Full suite green (**632 passed, 1 skipped**); new unit tests for queue helpers, pass-1 marking, drainer checkpoint/resume/preflight, and disjoint point-IDs.
- [ ] **Live end-to-end** (needs Qdrant + Ollama + `[visual]`/torch): `carta embed` on a datasheet dir → see the queue nudge → `carta embed --visual` → confirm pages move pending→done and `_visual` collection populates.

## Known follow-ups (not blocking)
- `visual_timeout_s` is defined but **not yet enforced** in the drainer (spec intent was "generous/disabled"; no per-page watchdog yet).
- `carta embed --visual` does **not** take the embed lock — concurrent `--visual` runs are possible (safe due to idempotent checkpointing, but a lock would be cleaner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)