### PR TITLE
fix(visual): add accelerate to [visual] extra for transformers>=5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ visual = [
     # introduced in transformers 4.49, which needs no PEFT adapters.
     "torch>=2.0.0",
     "transformers>=4.49.0",
+    # transformers>=5.x routes from_pretrained(device_map=...) through accelerate,
+    # which it no longer pulls in transitively — required for the device_map we pass
+    # in colpali.py _load_model. Without it: ValueError "requires accelerate".
+    "accelerate>=0.26.0",
     "pillow>=10.0.0",
     "numpy>=1.24.0",
 ]


### PR DESCRIPTION
## Problem
Installing `carta[visual]` and running `carta embed --visual` fails at ColPali model load under **transformers ≥ 5**:

```
ValueError: Using a `device_map` ... requires `accelerate`. Install it with: pip install accelerate
```

transformers≥5 routes `from_pretrained(device_map=...)` through `accelerate` but no longer pulls it transitively. `colpali.py` `_load_model` passes `device_map=self.device`, so the two-pass visual drain can't start.

## Fix
Add `accelerate>=0.26.0` to the `[visual]` optional-dependency group so the ColPali pass works out of the box.

Found while running the two-pass visual pipeline end-to-end on ET-embed (transformers 5.10.2, torch 2.12, Python 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)