### PR TITLE
fix(search): auto-enable visual search when _visual collection exists (BUG-2)

### DIFF
--- a/carta/config.py
+++ b/carta/config.py
@@ -62,7 +62,10 @@ DEFAULTS = {
         # Checkpoints must use the HF-native variants (no PEFT adapters):
         #   ColQwen2:  vidore/colqwen2-v1.0-hf  (default, ~5GB, lower VRAM)
         #   ColPali:   vidore/colpali-v1.3-hf   (~7GB)
-        "colpali_enabled": False,  # opt-in flag
+        # Tri-state: None = auto (search the _visual collection when it exists and
+        # is non-empty, so two-pass output is visible by default); True = force on;
+        # False = hard opt-out. Auto never loads ColPali unless there's something to search.
+        "colpali_enabled": None,
         "colpali_model": "vidore/colqwen2-v1.0-hf",  # or vidore/colpali-v1.3-hf
         "colpali_device": "cpu",  # "cpu", "cuda", "mps"
         "colpali_batch_size": 1,  # pages per batch (1 for CPU)

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1357,6 +1357,21 @@ def _hybrid_query_collection(client, coll_name, query, dense_vec, top_n,
     )
 
 
+def _visual_collection_ready(client, coll_name: str) -> bool:
+    """True when the visual collection exists and holds at least one point.
+
+    Used to auto-gate visual search: in the default (auto) mode we only pay the
+    ColPali model load + query embed when there's actually something to search.
+    Any error (missing collection, transport failure) is treated as not-ready.
+    """
+    try:
+        info = client.get_collection(coll_name)
+    except Exception:
+        return False
+    count = getattr(info, "points_count", None)
+    return bool(count and count > 0)
+
+
 def _rrf_merge_collections(per_collection: list[list[dict]], top_n: int, k: int = 60) -> list[dict]:
     """Fuse ranked hit lists from multiple collections with Reciprocal Rank Fusion.
 
@@ -1419,7 +1434,9 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
     except ValueError:
         # Fall back to default collections
         collections = [collection_name(cfg, "doc")]
-        if cfg.get("embed", {}).get("colpali_enabled", False):
+        # List visual unless explicitly opted out; run_search gates the actual query
+        # on collection readiness, so an absent/empty collection costs nothing.
+        if cfg.get("embed", {}).get("colpali_enabled", None) is not False:
             collections.append(f"{cfg['project_name']}_visual")
     
     try:
@@ -1438,14 +1455,19 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
             if coll_name.endswith("_visual"):
                 # Visual collection search using ColPali
                 from carta.embed.colpali import is_colpali_available, ColPaliEmbedder, ColPaliError
-                
+
+                embed_cfg = cfg.get("embed", {})
+                # Tri-state colpali_enabled: False = hard opt-out; True/None(auto) = on,
+                # but only when ColPali is importable AND the collection has content.
+                # The readiness check runs before the (expensive) model load so projects
+                # with no visual content pay nothing.
+                if embed_cfg.get("colpali_enabled", None) is False:
+                    continue
                 if not is_colpali_available():
                     continue
-                    
-                embed_cfg = cfg.get("embed", {})
-                if not embed_cfg.get("colpali_enabled", False):
+                if not _visual_collection_ready(client, coll_name):
                     continue
-                    
+
                 model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
                 device = embed_cfg.get("colpali_device", "cpu")
                 

--- a/carta/embed/tests/test_visual_search_gating.py
+++ b/carta/embed/tests/test_visual_search_gating.py
@@ -1,0 +1,31 @@
+"""Tests for auto-gating the visual collection in search (BUG-2 fix).
+
+colpali_enabled is tri-state: False = hard opt-out, True = force on,
+None/unset (default) = auto — search the _visual collection when it exists
+and is non-empty, so two-pass output is visible by default without forcing
+every project to load ColPali on every search.
+"""
+from unittest.mock import MagicMock
+from carta.embed.pipeline import _visual_collection_ready
+
+
+def _client_with_count(count):
+    client = MagicMock()
+    info = MagicMock()
+    info.points_count = count
+    client.get_collection.return_value = info
+    return client
+
+
+def test_ready_true_when_collection_has_points():
+    assert _visual_collection_ready(_client_with_count(10), "proj_visual") is True
+
+
+def test_ready_false_when_collection_empty():
+    assert _visual_collection_ready(_client_with_count(0), "proj_visual") is False
+
+
+def test_ready_false_when_collection_missing():
+    client = MagicMock()
+    client.get_collection.side_effect = Exception("404 not found")
+    assert _visual_collection_ready(client, "proj_visual") is False

--- a/carta/search/scoped.py
+++ b/carta/search/scoped.py
@@ -33,23 +33,25 @@ def get_search_collections(cfg: dict, scope: str = "repo") -> list[str]:
         raise ValueError(f"Invalid scope: {scope}. Must be 'repo', 'shared', or 'global'.")
     
     project_name = cfg.get("project_name", "carta-project")
-    
-    # Check if ColPali visual embedding is enabled
-    colpali_enabled = cfg.get("embed", {}).get("colpali_enabled", False)
-    
+
+    # Visual collection is listed unless ColPali is *explicitly* disabled
+    # (colpali_enabled: false). Default (None=auto) and True both list it; run_search
+    # then only queries it when the collection actually exists and is non-empty.
+    visual_opted_out = cfg.get("embed", {}).get("colpali_enabled", None) is False
+
     # Filter collection types based on config
     if scope == "global":
         # Global scope: only carta_global_* collections
         types = COLLECTION_TYPES.copy()
-        if not colpali_enabled:
-            types.remove("visual")  # Skip visual if ColPali not enabled
+        if visual_opted_out:
+            types.remove("visual")
         return [f"carta_global_{t}" for t in types]
-    
+
     if scope == "repo":
         # Repo scope: only current project collections
         types = COLLECTION_TYPES.copy()
-        if not colpali_enabled:
-            types.remove("visual")  # Skip visual if ColPali not enabled
+        if visual_opted_out:
+            types.remove("visual")
         return [f"{project_name}_{t}" for t in types]
     
     # scope == "shared"

--- a/carta/tests/test_scoped.py
+++ b/carta/tests/test_scoped.py
@@ -19,19 +19,41 @@ class TestGetSearchCollectionsRepoScope:
     """scope='repo' should return only current project collections."""
 
     def test_repo_scope_returns_project_collections(self, minimal_cfg):
-        """Should return {project_name}_doc, {project_name}_notes, {project_name}_session."""
+        """Should return doc, notes, session, and visual (visual auto-included by default)."""
         # Arrange
         minimal_cfg["project_name"] = "myproject"
-        
+
         # Act
         result = get_search_collections(minimal_cfg, scope="repo")
-        
+
         # Assert
         assert sorted(result) == sorted([
             "myproject_doc",
-            "myproject_notes", 
-            "myproject_session"
+            "myproject_notes",
+            "myproject_session",
+            "myproject_visual",
         ])
+
+    def test_repo_scope_includes_visual_by_default(self, minimal_cfg):
+        """colpali_enabled unset (auto) -> visual collection is listed."""
+        minimal_cfg["project_name"] = "myproject"
+        minimal_cfg.get("embed", {}).pop("colpali_enabled", None)
+        result = get_search_collections(minimal_cfg, scope="repo")
+        assert "myproject_visual" in result
+
+    def test_repo_scope_excludes_visual_when_explicitly_disabled(self, minimal_cfg):
+        """colpali_enabled: false is a hard opt-out -> visual not listed."""
+        minimal_cfg["project_name"] = "myproject"
+        minimal_cfg.setdefault("embed", {})["colpali_enabled"] = False
+        result = get_search_collections(minimal_cfg, scope="repo")
+        assert "myproject_visual" not in result
+
+    def test_repo_scope_includes_visual_when_enabled(self, minimal_cfg):
+        """colpali_enabled: true -> visual listed."""
+        minimal_cfg["project_name"] = "myproject"
+        minimal_cfg.setdefault("embed", {})["colpali_enabled"] = True
+        result = get_search_collections(minimal_cfg, scope="repo")
+        assert "myproject_visual" in result
 
     def test_repo_scope_ignores_global_setting(self, minimal_cfg):
         """cross_project_recall.enabled should not affect repo scope."""
@@ -48,13 +70,14 @@ class TestGetSearchCollectionsGlobalScope:
     """scope='global' should return only carta_global_* collections."""
 
     def test_global_scope_returns_global_collections(self, minimal_cfg):
-        """Should return carta_global_doc, carta_global_notes, carta_global_session."""
+        """Should return carta_global_ doc, notes, session, visual (visual auto-included)."""
         result = get_search_collections(minimal_cfg, scope="global")
-        
+
         assert sorted(result) == sorted([
             "carta_global_doc",
             "carta_global_notes",
-            "carta_global_session"
+            "carta_global_session",
+            "carta_global_visual",
         ])
 
     def test_global_scope_does_not_discover(self, minimal_cfg):


### PR DESCRIPTION
**Stacked on #21** (base = `fix/visual-text-score-merge`; retarget to main once #21 merges).

## Problem
`colpali_enabled` was a *third* opt-in gate (besides `two_pass_visual` and the `--visual` flag) defaulting **off**. Running the full two-pass pipeline populated the `_visual` collection, but it stayed **invisible to search** until a user separately flipped `colpali_enabled: true` — and (pre-#21) flipping it tanked text recall. A silent footgun.

## Fix — tri-state `colpali_enabled`, default `None` (auto)
- `False` → hard opt-out (never search visual)
- `True` → force on
- `None`/unset (**new default**) → auto: search `_visual` when it **exists and is non-empty**

`run_search` checks `_visual_collection_ready()` **before** loading ColPali, so projects with no visual content pay nothing (no model load, no query embed). `get_search_collections` lists the visual collection unless explicitly opted out. The legacy inline-embed gate is unchanged (`None` is falsy).

## Verified (ET-embed, auto mode, no explicit enable)
- Visual results auto-surface, RRF-interleaved with text — e.g. a TPS54331 query returns datasheet §Detailed-Description + the page-10 image + the layout-example text together.
- Eval **0.650 / 0.577** (vs 0.700/0.546 text-only); no regression vs the #21 number.
- Full suite green (the 2 `test_visual_drainer` failures are pre-existing, need the torch `[visual]` extra).

## Tests
New `test_visual_search_gating.py` (readiness helper tri-state); updated `test_scoped.py` to assert visual is listed by default and excluded only on explicit `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)