### PR TITLE
fix(test): drainer tests must not require the torch [visual] extra (CI red on main)

### DIFF
--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -6,9 +6,16 @@ from carta.embed.visual_queue import VISUAL_PENDING_KEY, VISUAL_DONE_KEY
 
 
 def _mock_router_embedder(monkeypatch):
-    """Patch SmartRouter and ColPaliEmbedder so run_visual_embed doesn't need real models."""
-    monkeypatch.setattr("carta.embed.pipeline.SmartRouter", lambda cfg: MagicMock(), raising=False)
-    monkeypatch.setattr("carta.embed.pipeline.ColPaliEmbedder", lambda **k: MagicMock(), raising=False)
+    """Patch SmartRouter and ColPaliEmbedder so run_visual_embed doesn't need real models.
+
+    run_visual_embed / _visual_embed_one_page import these *locally* from their source
+    modules (carta.embed.colpali, carta.vision.router), so the patch must target the
+    source modules — patching carta.embed.pipeline.* has no effect and lets the real
+    ColPaliEmbedder constructor run, which ImportErrors when the [visual] extra (torch)
+    isn't installed (e.g. in CI).
+    """
+    monkeypatch.setattr("carta.vision.router.SmartRouter", lambda cfg: MagicMock(), raising=False)
+    monkeypatch.setattr("carta.embed.colpali.ColPaliEmbedder", lambda **k: MagicMock())
 
 
 def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem
`test_visual_drainer.py::test_drainer_checkpoints_each_page` and `::test_drainer_leaves_failed_page_pending` have been **failing on main since #20**, and therefore on every open PR (#21–#24):

```
ImportError: transformers>=4.49 with ColPali/ColQwen2 support is required. Install with: pip install 'carta-cc[visual]'
```

CI installs base `carta-cc` (no `[visual]`/torch). The tests *try* to mock `ColPaliEmbedder`, but they patch `carta.embed.pipeline.ColPaliEmbedder` while `run_visual_embed` imports it **locally** from `carta.embed.colpali` — so the patch misses and the real constructor runs → ImportError.

## Fix
Patch the **source** modules (`carta.embed.colpali.ColPaliEmbedder`, `carta.vision.router.SmartRouter`). Test-only change; the drainer tests now run mock-only without torch, matching the #15 precedent (skip/​mock optional-dep tests in CI).

Verified locally in a torch-free venv: all 4 `test_visual_drainer` tests pass.

**Merge this first** — it unblocks CI on #21/#22/#23 (and #24 after retarget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)