### PR TITLE
release: 0.7.1 — macOS ColPali segfault fix + status-line for the visual pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Carta — documentation auditor, embedder, and semantic search for Claude Code projects",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "carta-cc",
       "source": "./",
       "description": "Maps, connects, and remembers your documentation. Structural scanning, LLM semantic audit, Qdrant embedding, and /doc-search recall.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Ian-q"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "carta-cc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Maps, connects, and remembers your documentation. Structural scanning, LLM semantic audit, Qdrant embedding, and semantic search.",
   "author": {
     "name": "Ian",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **carta-cc** are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.1] — 2026-06-08
+
+### Fixed
+- **ColPali no longer segfaults on macOS.** torch-CPU dispatched ColPali matmuls to Apple's *multithreaded* Accelerate `cblas_sgemm`, which intermittently SIGSEGV'd (exit 139, "Python crashed") during `carta embed --visual`. Carta now pins BLAS to a single thread on Darwin (`carta._compat`, applied at import before torch loads) plus `torch.set_num_threads(1)` in the visual drain. Slower per page, but stable.
+- **Status-line tracks the visual pass.** `run_visual_embed` (`carta embed --visual`) now drives `StatusWriter`, so the status-line widget shows live progress during the drain instead of freezing on pass-1's final state.
+
+## [0.7.0] — 2026-06-08
+
+### Added
+- **`carta export` / `carta import`** — share a project's embeddings between machines via a portable archive (safe tar extraction, snapshot cleanup).
+
 ## [0.6.0] — 2026-06-08
 
 ### Added

--- a/carta/__init__.py
+++ b/carta/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.7.0"
+# Apply platform workarounds BEFORE anything imports torch (see _compat).
+from carta._compat import apply_macos_blas_workaround as _apply_macos_blas_workaround
+
+_apply_macos_blas_workaround()
+
+__version__ = "0.7.1"

--- a/carta/_compat.py
+++ b/carta/_compat.py
@@ -1,0 +1,34 @@
+"""Platform compatibility shims applied at import time.
+
+Kept dependency-free (stdlib only) so it can run from ``carta/__init__.py``
+*before* anything imports torch.
+"""
+import os
+import platform
+
+# BLAS thread-count env vars, read by their libraries at first init. Must be set
+# before torch (and thus Accelerate/OpenBLAS/MKL) is imported to take effect.
+_BLAS_THREAD_VARS = (
+    "VECLIB_MAXIMUM_THREADS",  # Apple Accelerate (macOS torch-CPU default)
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+)
+
+
+def apply_macos_blas_workaround(system: str | None = None) -> bool:
+    """Pin BLAS to a single thread on macOS to avoid a torch-CPU segfault.
+
+    torch-CPU on Apple Silicon dispatches matmuls (e.g. ColPali's ``addmm``) to
+    Apple's Accelerate ``cblas_sgemm``, whose *multithreaded* ``dispatch_apply``
+    path intermittently SIGSEGVs under load (worse under memory pressure). Pinning
+    the BLAS libraries to one thread sidesteps it. Slower, but stable.
+
+    Uses ``setdefault`` so an explicit user setting always wins. Returns True when
+    applied (i.e. running on macOS).
+    """
+    if (system or platform.system()) != "Darwin":
+        return False
+    for var in _BLAS_THREAD_VARS:
+        os.environ.setdefault(var, "1")
+    return True

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -900,10 +900,22 @@ def run_visual_embed(
     client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
     queued = _discover_visual_pending(repo_root)
     summary["files"] = len(queued)
+    total_pages = sum(len(sc.get(VISUAL_PENDING_KEY, []) or []) for _, sc in queued)
+
+    # Status-line widget: track the --visual drain too (not just `carta embed`).
+    status = StatusWriter(repo_root, enabled=cfg.get("embed", {}).get("status_file", True))
+    status.start(total_pages)
 
     # Construct router and embedder ONCE for the entire drain — not per page.
     from carta.vision.router import SmartRouter
     from carta.embed.colpali import ColPaliEmbedder
+    # Pin torch to one thread: ColPali matmuls otherwise crash Apple's multithreaded
+    # Accelerate BLAS on macOS (belt-and-suspenders with the env-var pin in carta._compat).
+    try:
+        import torch
+        torch.set_num_threads(1)
+    except Exception:
+        pass
     embed_cfg = cfg.get("embed", {}) or {}
     model_name = embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf")
     device = embed_cfg.get("colpali_device", "cpu")
@@ -920,24 +932,34 @@ def run_visual_embed(
         cache_dir=str(cache_dir_path),
     )
 
-    for sc_path, sc in queued:
-        for page in list(sc.get(VISUAL_PENDING_KEY, []) or []):
-            try:
-                _visual_embed_one_page(sc, page, cfg, client, repo_root, router, embedder, verbose)
-                move_to_done(sc, page)
-                _update_sidecar(sc_path, {
-                    VISUAL_PENDING_KEY: sc[VISUAL_PENDING_KEY],
-                    VISUAL_DONE_KEY: sc[VISUAL_DONE_KEY],
-                })
-                summary["pages_embedded"] += 1
-            except Exception as e:
-                summary["pages_failed"] += 1
-                print(
-                    f"  visual: page {page} of {sc.get('current_path')} failed: {e} "
-                    f"(left pending)",
-                    flush=True,
-                )
+    idx = 0
+    try:
+        for sc_path, sc in queued:
+            for page in list(sc.get(VISUAL_PENDING_KEY, []) or []):
+                idx += 1
+                status.file_start(idx, f"page {page} of {sc.get('current_path', '')}")
+                try:
+                    _visual_embed_one_page(sc, page, cfg, client, repo_root, router, embedder, verbose)
+                    move_to_done(sc, page)
+                    _update_sidecar(sc_path, {
+                        VISUAL_PENDING_KEY: sc[VISUAL_PENDING_KEY],
+                        VISUAL_DONE_KEY: sc[VISUAL_DONE_KEY],
+                    })
+                    summary["pages_embedded"] += 1
+                    status.file_done(embedded=1)
+                except Exception as e:
+                    summary["pages_failed"] += 1
+                    status.file_done(errors=1)
+                    print(
+                        f"  visual: page {page} of {sc.get('current_path')} failed: {e} "
+                        f"(left pending)",
+                        flush=True,
+                    )
+    except BaseException:
+        status.finish("failed")
+        raise
 
+    status.finish("done")
     return summary
 
 

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -34,6 +34,30 @@ def test_drainer_checkpoints_each_page(monkeypatch, tmp_path):
     assert sc[VISUAL_PENDING_KEY] == [] and sc[VISUAL_DONE_KEY] == [1, 2]
 
 
+def test_drainer_writes_status_file(monkeypatch, tmp_path):
+    """run_visual_embed must drive StatusWriter so the status-line widget tracks
+    the --visual pass (previously only `carta embed` wrote embed-status.json)."""
+    import json
+    sc = {"current_path": "docs/x.pdf", "slug": "x", VISUAL_PENDING_KEY: [1, 2], VISUAL_DONE_KEY: []}
+    monkeypatch.setattr(pipeline, "_discover_visual_pending", lambda r: [("sc_path", sc)], raising=False)
+    monkeypatch.setattr(pipeline, "_update_sidecar", lambda *a, **k: None)
+    monkeypatch.setattr(pipeline, "_visual_embed_one_page",
+                        lambda *a, **k: True, raising=False)
+    monkeypatch.setattr(pipeline, "is_colpali_available", lambda: True, raising=False)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda **k: MagicMock())
+    _mock_router_embedder(monkeypatch)
+    (tmp_path / ".carta").mkdir()  # StatusWriter writes into an existing .carta/
+
+    pipeline.run_visual_embed(tmp_path, {"qdrant_url": "x", "embed": {}})
+
+    status_path = tmp_path / ".carta" / "embed-status.json"
+    assert status_path.exists(), "run_visual_embed must write embed-status.json"
+    st = json.loads(status_path.read_text())
+    assert st["total"] == 2          # 2 pending pages
+    assert st["embedded"] == 2
+    assert st["phase"] == "done"
+
+
 def test_drainer_leaves_failed_page_pending(monkeypatch, tmp_path):
     sc = {"current_path": "docs/x.pdf", "slug": "x", VISUAL_PENDING_KEY: [1], VISUAL_DONE_KEY: []}
     monkeypatch.setattr(pipeline, "_discover_visual_pending", lambda r: [("sc", sc)], raising=False)

--- a/carta/tests/test_macos_blas.py
+++ b/carta/tests/test_macos_blas.py
@@ -1,0 +1,36 @@
+"""Tests for the macOS single-threaded-BLAS workaround (0.7.1).
+
+torch-CPU on Apple Silicon segfaults in Accelerate's multithreaded cblas_sgemm
+during ColPali matmuls. Pinning BLAS to one thread BEFORE torch imports avoids it.
+"""
+import os
+import pytest
+from carta._compat import apply_macos_blas_workaround, _BLAS_THREAD_VARS
+
+
+@pytest.fixture(autouse=True)
+def _clean_blas_env(monkeypatch):
+    for v in _BLAS_THREAD_VARS:
+        monkeypatch.delenv(v, raising=False)
+    yield
+
+
+def test_applies_on_darwin(monkeypatch):
+    applied = apply_macos_blas_workaround(system="Darwin")
+    assert applied is True
+    for v in _BLAS_THREAD_VARS:
+        assert os.environ[v] == "1"
+
+
+def test_noop_off_darwin(monkeypatch):
+    applied = apply_macos_blas_workaround(system="Linux")
+    assert applied is False
+    for v in _BLAS_THREAD_VARS:
+        assert v not in os.environ
+
+
+def test_respects_user_override(monkeypatch):
+    monkeypatch.setenv("OMP_NUM_THREADS", "8")
+    apply_macos_blas_workaround(system="Darwin")
+    assert os.environ["OMP_NUM_THREADS"] == "8"  # setdefault — not clobbered
+    assert os.environ["VECLIB_MAXIMUM_THREADS"] == "1"  # others still pinned


### PR DESCRIPTION
Patch on 0.7.0. Tag `v0.7.1` after merge to publish (release.yml).

## Fixed
- **ColPali segfault on macOS (exit 139 / "Python crashed").** torch-CPU dispatched ColPali matmuls to Apple's *multithreaded* Accelerate `cblas_sgemm`, which intermittently SIGSEGV'd during `carta embed --visual` (crash stack: `libBLAS cblas_sgemm` ← `libdispatch dispatch_apply` ← torch `addmm`). Fix: `carta._compat.apply_macos_blas_workaround()` pins BLAS thread env vars on Darwin **at import, before torch loads** (`setdefault` — respects user overrides), plus `torch.set_num_threads(1)` in the visual drain. Single-threaded BLAS is slower but stable.
- **Status-line froze during `--visual`.** `run_visual_embed` now drives `StatusWriter` (start/​file_start/​file_done/​finish), so the widget shows live drain progress instead of pass-1's stale "done".

## Docs
- Backfilled the missing **0.7.0** CHANGELOG entry (`carta export/import`).

## Tests
- New `test_macos_blas.py` (Darwin-gated, setdefault, off-Darwin no-op).
- New `test_drainer_writes_status_file`. Full suite: 727 passed, 2 skipped.

## Honesty note
The segfault is intermittent (~1 per 100–200 pages), so the fix can't be unit-proven against a crash; single-threaded BLAS is the documented Apple-Silicon workaround for exactly this Accelerate `sgemm` crash and is low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)