### PR TITLE
feat(search): LLM reranker backend (search.rerank.backend: llm) — 0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Carta — documentation auditor, embedder, and semantic search for Claude Code projects",
-    "version": "0.7.1"
+    "version": "0.8.0"
   },
   "plugins": [
     {
       "name": "carta-cc",
       "source": "./",
       "description": "Maps, connects, and remembers your documentation. Structural scanning, LLM semantic audit, Qdrant embedding, and /doc-search recall.",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "author": {
         "name": "Ian-q"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "carta-cc",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Maps, connects, and remembers your documentation. Structural scanning, LLM semantic audit, Qdrant embedding, and semantic search.",
   "author": {
     "name": "Ian",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to **carta-cc** are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.0] — 2026-06-09
+
+### Added
+- **LLM reranker backend** for `search.rerank` (`backend: llm`). A single listwise Ollama call
+  reorders the candidate pool (`llm_model`, default `qwen3.5:0.8b`; `llm_timeout_s`). Opt-in — the
+  default `cross-encoder` (fastembed `bge-reranker-base`) path is unchanged. **Fail-open:** any
+  Ollama error/timeout/parse failure returns the fused order, so search is never worse than today.
+  Measured on a technical-docs corpus: recall@5 0.700 → **0.750**, MRR 0.546 → **0.589** with
+  `qwen3.5:0.8b` (a 9b model gave no recall gain — small model is the default).
+
 ## [0.7.1] — 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -205,6 +205,28 @@ embed:
   ollama_model: nomic-embed-text:latest
 ```
 
+### Search reranking
+
+Hybrid retrieval (dense + BM25, RRF-fused) is the default. An optional second-stage **reranker**
+reorders the candidate pool for better top-k precision:
+
+```yaml
+search:
+  rerank:
+    enabled: true
+    backend: llm            # cross-encoder | llm
+    model: BAAI/bge-reranker-base   # backend=cross-encoder (fastembed, local ONNX)
+    llm_model: qwen3.5:0.8b         # backend=llm: one listwise Ollama call per search
+    llm_timeout_s: 20
+    candidate_pool: 40      # docs fetched before reranking (use ~40 for the llm backend)
+```
+
+- **`cross-encoder`** — fastembed `bge-reranker-base`, no Ollama, fast.
+- **`llm`** — sends the query + candidate excerpts to a local Ollama model in a **single** call and
+  reorders by its judgment. **Fail-open:** any error/timeout falls back to the fused order. On a
+  real technical-docs corpus, `qwen3.5:0.8b` lifted recall@5 0.700 → 0.750 / MRR 0.546 → 0.589
+  (a larger 9b model gave no recall gain), so the small model is the default.
+
 ---
 
 ## Visual Embedding (ColPali/ColQwen2)

--- a/carta/__init__.py
+++ b/carta/__init__.py
@@ -3,4 +3,4 @@ from carta._compat import apply_macos_blas_workaround as _apply_macos_blas_worka
 
 _apply_macos_blas_workaround()
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/carta/config.py
+++ b/carta/config.py
@@ -28,7 +28,10 @@ DEFAULTS = {
         },
         "rerank": {
             "enabled": False,
-            "model": "BAAI/bge-reranker-base",
+            "backend": "cross-encoder",   # cross-encoder | llm
+            "model": "BAAI/bge-reranker-base",   # used when backend=cross-encoder
+            "llm_model": "qwen3.5:0.8b",  # used when backend=llm (local Ollama)
+            "llm_timeout_s": 20,
             "candidate_pool": 30,
         },
     },

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1605,15 +1605,16 @@ def run_search(query: str, cfg: dict, verbose: bool = False) -> list[dict]:
 
     # Optional second-stage cross-encoder reranking (opt-in via search.rerank.enabled)
     if rerank_enabled and all_results:
-        from carta.search.rerank import rerank_hits
+        from carta.search.rerank import rerank_dispatch
         pool = all_results[:candidate_pool]
         # rerank_hits reads chunk text from key "text"; run_search stores it as "excerpt"
         for h in pool:
             h["text"] = h.get("excerpt", "")
-        all_results = rerank_hits(
+        all_results = rerank_dispatch(
             query,
             pool,
-            model_name=rr_cfg.get("model", "BAAI/bge-reranker-base"),
+            rr_cfg=rr_cfg,
+            ollama_url=cfg.get("embed", {}).get("ollama_url", "http://localhost:11434"),
             top_n=top_n,
         )
         # Strip transient keys so returned dicts have a stable shape

--- a/carta/search/llm_rerank.py
+++ b/carta/search/llm_rerank.py
@@ -1,0 +1,82 @@
+"""Listwise LLM reranker via a single Ollama /api/chat call.
+
+Reorders the fused candidate pool by LLM-judged relevance to the query and
+truncates to top_n. Fail-open: any error/timeout/parse failure returns the
+input order unchanged (never worse than no rerank). Local Ollama only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import requests
+
+_SYSTEM = (
+    "You rank document passages by relevance to a search query. "
+    "Return ONLY a JSON array of passage numbers, most relevant first. "
+    "Include only clearly relevant passages."
+)
+
+
+def _build_prompt(query: str, hits: list[dict], max_excerpt_chars: int) -> str:
+    lines = [f"Query: {query}", "", "Passages:"]
+    for i, h in enumerate(hits):
+        excerpt = (h.get("excerpt", "") or "")[:max_excerpt_chars].replace("\n", " ")
+        lines.append(f"[{i}] {h.get('source', '')}: {excerpt}")
+    lines.append("")
+    lines.append("Return a JSON array of the passage numbers, most relevant first.")
+    return "\n".join(lines)
+
+
+def _parse_order(content: str, n: int) -> list[int]:
+    """Parse the model reply into a de-duplicated list of valid in-range indices."""
+    data = json.loads(content)
+    if isinstance(data, dict):
+        data = next((v for v in data.values() if isinstance(v, list)), [])
+    order: list[int] = []
+    seen = set()
+    for x in data:
+        try:
+            i = int(x)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= i < n and i not in seen:
+            seen.add(i)
+            order.append(i)
+    return order
+
+
+def llm_rerank_hits(query: str, hits: list[dict], *, model: str, ollama_url: str,
+                    top_n: int, timeout_s: int = 20, max_excerpt_chars: int = 500) -> list[dict]:
+    """Reorder *hits* by a single listwise Ollama call; return top_n. Fail-open."""
+    if not hits or not query.strip():
+        return hits[:top_n]
+    try:
+        resp = requests.post(
+            f"{ollama_url}/api/chat",
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": _SYSTEM},
+                    {"role": "user", "content": _build_prompt(query, hits, max_excerpt_chars)},
+                ],
+                "stream": False,
+                "format": "json",
+                "options": {"temperature": 0},
+            },
+            timeout=timeout_s,
+        )
+        resp.raise_for_status()
+        content = resp.json()["message"]["content"]
+        order = _parse_order(content, len(hits))
+    except Exception as exc:  # fail-open — never worse than the fused order
+        print(f"llm_rerank: fail-open ({type(exc).__name__}: {exc})", file=sys.stderr, flush=True)
+        return hits[:top_n]
+
+    if not order:
+        return hits[:top_n]
+    ranked = [hits[i] for i in order]
+    remainder = [h for j, h in enumerate(hits) if j not in set(order)]
+    merged = ranked + remainder
+    for rank, h in enumerate(merged):
+        h["rerank_score"] = float(len(merged) - rank)
+    return merged[:top_n]

--- a/carta/search/rerank.py
+++ b/carta/search/rerank.py
@@ -38,3 +38,22 @@ def rerank_hits(query: str, hits: list[dict], model_name: str, top_n: int) -> li
         h["rerank_score"] = s
     hits.sort(key=lambda h: h["rerank_score"], reverse=True)
     return hits[:top_n]
+
+
+def rerank_dispatch(query: str, hits: list[dict], *, rr_cfg: dict, ollama_url: str,
+                    top_n: int) -> list[dict]:
+    """Route reranking to the configured backend. Defaults to cross-encoder.
+
+    rr_cfg is cfg["search"]["rerank"]. backend="llm" uses the listwise Ollama
+    reranker; anything else (incl. unset) uses the fastembed cross-encoder.
+    """
+    if rr_cfg.get("backend", "cross-encoder") == "llm":
+        from carta.search.llm_rerank import llm_rerank_hits
+        return llm_rerank_hits(
+            query, hits,
+            model=rr_cfg.get("llm_model", "qwen3.5:0.8b"),
+            ollama_url=ollama_url,
+            top_n=top_n,
+            timeout_s=rr_cfg.get("llm_timeout_s", 20),
+        )
+    return rerank_hits(query, hits, model_name=rr_cfg.get("model", DEFAULT_RERANK_MODEL), top_n=top_n)

--- a/carta/search/tests/test_llm_rerank.py
+++ b/carta/search/tests/test_llm_rerank.py
@@ -30,3 +30,30 @@ def test_accepts_object_wrapped_array():
     with patch("carta.search.llm_rerank.requests.post", return_value=_resp('{"order": [1, 0]}')):
         out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
     assert [h["source"] for h in out] == ["b.md", "a.md"]
+
+
+import requests as _requests
+
+
+def test_fail_open_on_timeout():
+    with patch("carta.search.llm_rerank.requests.post", side_effect=_requests.Timeout()):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=3)
+    assert [h["source"] for h in out] == ["a.md", "b.md", "c.md"]
+
+
+def test_fail_open_on_non_json():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("not json at all")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["a.md", "b.md"]
+
+
+def test_out_of_range_and_dupes_filtered_then_filled():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("[3, 9, 3]")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=4)
+    assert [h["source"] for h in out] == ["d.md", "a.md", "b.md", "c.md"]
+
+
+def test_empty_hits_and_blank_query():
+    assert llm_rerank_hits("q", [], model="m", ollama_url="u", top_n=5) == []
+    out = llm_rerank_hits("   ", _hits(), model="m", ollama_url="u", top_n=2)
+    assert [h["source"] for h in out] == ["a.md", "b.md"]

--- a/carta/search/tests/test_llm_rerank.py
+++ b/carta/search/tests/test_llm_rerank.py
@@ -1,0 +1,32 @@
+import json
+from unittest.mock import patch, MagicMock
+from carta.search.llm_rerank import llm_rerank_hits
+
+
+def _hits():
+    return [
+        {"source": "a.md", "excerpt": "alpha", "type": "text"},
+        {"source": "b.md", "excerpt": "bravo", "type": "text"},
+        {"source": "c.md", "excerpt": "charlie", "type": "text"},
+        {"source": "d.md", "excerpt": "delta", "type": "text"},
+    ]
+
+
+def _resp(content: str):
+    r = MagicMock()
+    r.json.return_value = {"message": {"content": content}}
+    r.raise_for_status.return_value = None
+    return r
+
+
+def test_reorders_to_llm_index_order_and_truncates():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("[2, 0, 1, 3]")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["c.md", "a.md"]
+    assert out[0]["rerank_score"] > out[1]["rerank_score"]
+
+
+def test_accepts_object_wrapped_array():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp('{"order": [1, 0]}')):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["b.md", "a.md"]

--- a/carta/search/tests/test_rerank.py
+++ b/carta/search/tests/test_rerank.py
@@ -22,3 +22,33 @@ def test_rerank_truncates_to_top_n(monkeypatch):
     hits = [{"text": str(i), "file_path": f"{i}.md"} for i in range(5)]
     out = rerank_hits("q", hits, model_name="x", top_n=2)
     assert len(out) == 2
+
+
+from unittest.mock import patch
+from carta.search.rerank import rerank_dispatch
+
+
+def _dispatch_hits():
+    return [{"source": "a.md", "excerpt": "x", "type": "text"} for _ in range(3)]
+
+
+def test_dispatch_routes_to_cross_encoder_by_default():
+    rr = {"backend": "cross-encoder", "model": "BAAI/bge-reranker-base"}
+    with patch("carta.search.rerank.rerank_hits", return_value=["CE"]) as ce, \
+         patch("carta.search.llm_rerank.llm_rerank_hits", return_value=["LLM"]) as llm:
+        out = rerank_dispatch("q", _dispatch_hits(), rr_cfg=rr, ollama_url="u", top_n=2)
+    assert out == ["CE"]
+    ce.assert_called_once()
+    llm.assert_not_called()
+
+
+def test_dispatch_routes_to_llm_when_backend_llm():
+    rr = {"backend": "llm", "llm_model": "qwen3.5:0.8b", "llm_timeout_s": 9}
+    with patch("carta.search.rerank.rerank_hits", return_value=["CE"]) as ce, \
+         patch("carta.search.llm_rerank.llm_rerank_hits", return_value=["LLM"]) as llm:
+        out = rerank_dispatch("q", _dispatch_hits(), rr_cfg=rr, ollama_url="u", top_n=2)
+    assert out == ["LLM"]
+    llm.assert_called_once()
+    ce.assert_not_called()
+    assert llm.call_args.kwargs["model"] == "qwen3.5:0.8b"
+    assert llm.call_args.kwargs["timeout_s"] == 9

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -119,3 +119,11 @@ def test_two_pass_visual_defaults():
 def test_status_file_default_enabled():
     from carta.config import DEFAULTS
     assert DEFAULTS["embed"]["status_file"] is True
+
+
+def test_rerank_backend_defaults():
+    from carta.config import DEFAULTS
+    rr = DEFAULTS["search"]["rerank"]
+    assert rr["backend"] == "cross-encoder"
+    assert rr["llm_model"] == "qwen3.5:0.8b"
+    assert rr["llm_timeout_s"] == 20

--- a/docs/superpowers/plans/2026-06-09-llm-reranker.md
+++ b/docs/superpowers/plans/2026-06-09-llm-reranker.md
@@ -1,0 +1,515 @@
+# LLM Reranker Backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `search.rerank.backend: llm` that reorders the hybrid candidate pool with a single listwise Ollama call, leaving the existing cross-encoder path and default behavior unchanged.
+
+**Architecture:** A new pure-ish unit `carta/search/llm_rerank.py` (one Ollama `/api/chat` call, parse a JSON index order, reorder + truncate, fail-open). A small `rerank_dispatch()` in `carta/search/rerank.py` routes on `backend`. `run_search` calls the dispatcher instead of `rerank_hits` directly. Config gains `backend`/`llm_model`/`llm_timeout_s`.
+
+**Tech Stack:** Python 3.10+, `requests` (already a dep), Ollama `/api/chat`, pytest. Spec: `docs/superpowers/specs/2026-06-09-llm-reranker-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `carta/search/llm_rerank.py` — `llm_rerank_hits()` + helpers. One job: LLM listwise rerank, fail-open.
+- **Create** `carta/search/tests/test_llm_rerank.py` — unit tests, mocked `requests.post` (no live Ollama).
+- **Modify** `carta/search/rerank.py` — add `rerank_dispatch()` (routes cross-encoder | llm). Existing `rerank_hits` untouched.
+- **Modify** `carta/search/tests/test_rerank.py` — tests for `rerank_dispatch` routing.
+- **Modify** `carta/config.py` — `DEFAULTS["search"]["rerank"]` gains `backend`, `llm_model`, `llm_timeout_s`.
+- **Modify** `carta/tests/test_config.py` — assert new rerank defaults.
+- **Modify** `carta/embed/pipeline.py` — `run_search` rerank block calls `rerank_dispatch`.
+- **Modify** `README.md`, `CHANGELOG.md`, version files — docs + 0.8.0 release (final task).
+
+---
+
+## Task 1: `llm_rerank_hits` — happy-path reorder + truncate
+
+**Files:**
+- Create: `carta/search/llm_rerank.py`
+- Test: `carta/search/tests/test_llm_rerank.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# carta/search/tests/test_llm_rerank.py
+import json
+from unittest.mock import patch, MagicMock
+from carta.search.llm_rerank import llm_rerank_hits
+
+
+def _hits():
+    return [
+        {"source": "a.md", "excerpt": "alpha", "type": "text"},
+        {"source": "b.md", "excerpt": "bravo", "type": "text"},
+        {"source": "c.md", "excerpt": "charlie", "type": "text"},
+        {"source": "d.md", "excerpt": "delta", "type": "text"},
+    ]
+
+
+def _resp(content: str):
+    r = MagicMock()
+    r.json.return_value = {"message": {"content": content}}
+    r.raise_for_status.return_value = None
+    return r
+
+
+def test_reorders_to_llm_index_order_and_truncates():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("[2, 0, 1, 3]")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["c.md", "a.md"]
+    assert out[0]["rerank_score"] > out[1]["rerank_score"]
+
+
+def test_accepts_object_wrapped_array():
+    # Ollama format=json sometimes wraps: {"order": [...]}
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp('{"order": [1, 0]}')):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["b.md", "a.md"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/search/tests/test_llm_rerank.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'carta.search.llm_rerank'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# carta/search/llm_rerank.py
+"""Listwise LLM reranker via a single Ollama /api/chat call.
+
+Reorders the fused candidate pool by LLM-judged relevance to the query and
+truncates to top_n. Fail-open: any error/timeout/parse failure returns the
+input order unchanged (never worse than no rerank). Local Ollama only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import requests
+
+_SYSTEM = (
+    "You rank document passages by relevance to a search query. "
+    "Return ONLY a JSON array of passage numbers, most relevant first. "
+    "Include only clearly relevant passages."
+)
+
+
+def _build_prompt(query: str, hits: list[dict], max_excerpt_chars: int) -> str:
+    lines = [f"Query: {query}", "", "Passages:"]
+    for i, h in enumerate(hits):
+        excerpt = (h.get("excerpt", "") or "")[:max_excerpt_chars].replace("\n", " ")
+        lines.append(f"[{i}] {h.get('source', '')}: {excerpt}")
+    lines.append("")
+    lines.append("Return a JSON array of the passage numbers, most relevant first.")
+    return "\n".join(lines)
+
+
+def _parse_order(content: str, n: int) -> list[int]:
+    """Parse the model reply into a de-duplicated list of valid in-range indices."""
+    data = json.loads(content)
+    if isinstance(data, dict):
+        data = next((v for v in data.values() if isinstance(v, list)), [])
+    order: list[int] = []
+    seen = set()
+    for x in data:
+        try:
+            i = int(x)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= i < n and i not in seen:
+            seen.add(i)
+            order.append(i)
+    return order
+
+
+def llm_rerank_hits(query: str, hits: list[dict], *, model: str, ollama_url: str,
+                    top_n: int, timeout_s: int = 20, max_excerpt_chars: int = 500) -> list[dict]:
+    """Reorder *hits* by a single listwise Ollama call; return top_n. Fail-open."""
+    if not hits or not query.strip():
+        return hits[:top_n]
+    try:
+        resp = requests.post(
+            f"{ollama_url}/api/chat",
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": _SYSTEM},
+                    {"role": "user", "content": _build_prompt(query, hits, max_excerpt_chars)},
+                ],
+                "stream": False,
+                "format": "json",
+                "options": {"temperature": 0},
+            },
+            timeout=timeout_s,
+        )
+        resp.raise_for_status()
+        content = resp.json()["message"]["content"]
+        order = _parse_order(content, len(hits))
+    except Exception as exc:  # fail-open — never worse than the fused order
+        print(f"llm_rerank: fail-open ({type(exc).__name__}: {exc})", file=sys.stderr, flush=True)
+        return hits[:top_n]
+
+    if not order:
+        return hits[:top_n]
+    # Ranked first (LLM order), then any unranked in original fused order.
+    ranked = [hits[i] for i in order]
+    remainder = [h for j, h in enumerate(hits) if j not in set(order)]
+    merged = ranked + remainder
+    for rank, h in enumerate(merged):
+        h["rerank_score"] = float(len(merged) - rank)
+    return merged[:top_n]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/search/tests/test_llm_rerank.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/search/llm_rerank.py carta/search/tests/test_llm_rerank.py
+git commit -m "feat(search): listwise LLM reranker core (llm_rerank_hits)"
+```
+
+---
+
+## Task 2: Fail-open behavior
+
+**Files:**
+- Modify: `carta/search/tests/test_llm_rerank.py`
+- (implementation already handles these — this task proves it)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to carta/search/tests/test_llm_rerank.py
+import requests as _requests
+
+
+def test_fail_open_on_timeout():
+    with patch("carta.search.llm_rerank.requests.post", side_effect=_requests.Timeout()):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=3)
+    assert [h["source"] for h in out] == ["a.md", "b.md", "c.md"]  # original order, top_n
+
+
+def test_fail_open_on_non_json():
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("not json at all")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=2)
+    assert [h["source"] for h in out] == ["a.md", "b.md"]
+
+
+def test_out_of_range_and_dupes_filtered_then_filled():
+    # indices 9 (oob) and duplicate 0 dropped; remainder filled from fused order
+    with patch("carta.search.llm_rerank.requests.post", return_value=_resp("[3, 9, 3]")):
+        out = llm_rerank_hits("q", _hits(), model="m", ollama_url="http://x:11434", top_n=4)
+    assert [h["source"] for h in out] == ["d.md", "a.md", "b.md", "c.md"]
+
+
+def test_empty_hits_and_blank_query():
+    assert llm_rerank_hits("q", [], model="m", ollama_url="u", top_n=5) == []
+    out = llm_rerank_hits("   ", _hits(), model="m", ollama_url="u", top_n=2)
+    assert [h["source"] for h in out] == ["a.md", "b.md"]  # no LLM call on blank query
+```
+
+- [ ] **Step 2: Run tests to verify they pass** (implementation from Task 1 already covers these)
+
+Run: `python -m pytest carta/search/tests/test_llm_rerank.py -q`
+Expected: PASS (6 passed). If any fail, fix `llm_rerank.py` to match the asserted fail-open behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add carta/search/tests/test_llm_rerank.py
+git commit -m "test(search): cover llm_rerank fail-open paths"
+```
+
+---
+
+## Task 3: Config defaults
+
+**Files:**
+- Modify: `carta/config.py` (the `DEFAULTS["search"]["rerank"]` dict)
+- Test: `carta/tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to carta/tests/test_config.py
+def test_rerank_backend_defaults():
+    from carta.config import DEFAULTS
+    rr = DEFAULTS["search"]["rerank"]
+    assert rr["backend"] == "cross-encoder"        # default unchanged behavior
+    assert rr["llm_model"] == "qwen3.5:0.8b"
+    assert rr["llm_timeout_s"] == 20
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_config.py::test_rerank_backend_defaults -q`
+Expected: FAIL — `KeyError: 'backend'`
+
+- [ ] **Step 3: Edit `carta/config.py`**
+
+Find the `"rerank"` block inside `DEFAULTS["search"]`:
+
+```python
+        "rerank": {
+            "enabled": False,
+            "model": "BAAI/bge-reranker-base",
+            "candidate_pool": 30,
+        },
+```
+
+Replace with:
+
+```python
+        "rerank": {
+            "enabled": False,
+            "backend": "cross-encoder",   # cross-encoder | llm
+            "model": "BAAI/bge-reranker-base",   # used when backend=cross-encoder
+            "llm_model": "qwen3.5:0.8b",  # used when backend=llm (local Ollama)
+            "llm_timeout_s": 20,
+            "candidate_pool": 30,
+        },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_config.py::test_rerank_backend_defaults -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/config.py carta/tests/test_config.py
+git commit -m "feat(config): rerank backend/llm_model/llm_timeout_s defaults"
+```
+
+---
+
+## Task 4: `rerank_dispatch` — backend routing
+
+**Files:**
+- Modify: `carta/search/rerank.py` (add `rerank_dispatch`; leave `rerank_hits` as-is)
+- Test: `carta/search/tests/test_rerank.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to carta/search/tests/test_rerank.py
+from unittest.mock import patch
+from carta.search.rerank import rerank_dispatch
+
+
+def _hits():
+    return [{"source": "a.md", "excerpt": "x", "type": "text"} for _ in range(3)]
+
+
+def test_dispatch_routes_to_cross_encoder_by_default():
+    rr = {"backend": "cross-encoder", "model": "BAAI/bge-reranker-base"}
+    with patch("carta.search.rerank.rerank_hits", return_value=["CE"]) as ce, \
+         patch("carta.search.llm_rerank.llm_rerank_hits", return_value=["LLM"]) as llm:
+        out = rerank_dispatch("q", _hits(), rr_cfg=rr, ollama_url="u", top_n=2)
+    assert out == ["CE"]
+    ce.assert_called_once()
+    llm.assert_not_called()
+
+
+def test_dispatch_routes_to_llm_when_backend_llm():
+    rr = {"backend": "llm", "llm_model": "qwen3.5:0.8b", "llm_timeout_s": 9}
+    with patch("carta.search.rerank.rerank_hits", return_value=["CE"]) as ce, \
+         patch("carta.search.llm_rerank.llm_rerank_hits", return_value=["LLM"]) as llm:
+        out = rerank_dispatch("q", _hits(), rr_cfg=rr, ollama_url="u", top_n=2)
+    assert out == ["LLM"]
+    llm.assert_called_once()
+    ce.assert_not_called()
+    # forwards llm_model + timeout
+    assert llm.call_args.kwargs["model"] == "qwen3.5:0.8b"
+    assert llm.call_args.kwargs["timeout_s"] == 9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/search/tests/test_rerank.py -k dispatch -q`
+Expected: FAIL — `ImportError: cannot import name 'rerank_dispatch'`
+
+- [ ] **Step 3: Add `rerank_dispatch` to `carta/search/rerank.py`**
+
+Append:
+
+```python
+def rerank_dispatch(query: str, hits: list[dict], *, rr_cfg: dict, ollama_url: str,
+                    top_n: int) -> list[dict]:
+    """Route reranking to the configured backend. Defaults to cross-encoder.
+
+    rr_cfg is cfg["search"]["rerank"]. backend="llm" uses the listwise Ollama
+    reranker; anything else (incl. unset) uses the fastembed cross-encoder.
+    """
+    if rr_cfg.get("backend", "cross-encoder") == "llm":
+        from carta.search.llm_rerank import llm_rerank_hits
+        return llm_rerank_hits(
+            query, hits,
+            model=rr_cfg.get("llm_model", "qwen3.5:0.8b"),
+            ollama_url=ollama_url,
+            top_n=top_n,
+            timeout_s=rr_cfg.get("llm_timeout_s", 20),
+        )
+    return rerank_hits(query, hits, model_name=rr_cfg.get("model", DEFAULT_RERANK_MODEL), top_n=top_n)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/search/tests/test_rerank.py -k dispatch -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/search/rerank.py carta/search/tests/test_rerank.py
+git commit -m "feat(search): rerank_dispatch routes cross-encoder|llm"
+```
+
+---
+
+## Task 5: Wire `run_search` to the dispatcher
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (the rerank block inside `run_search`)
+
+- [ ] **Step 1: Locate the current rerank block**
+
+Run: `grep -n "rerank_hits\|from carta.search.rerank" carta/embed/pipeline.py`
+You will find an import `from carta.search.rerank import rerank_hits` and a block like:
+
+```python
+    if rerank_enabled and all_results:
+        from carta.search.rerank import rerank_hits
+        pool = all_results[:candidate_pool]
+        for h in pool:
+            h["text"] = h.get("excerpt", "")
+        all_results = rerank_hits(
+            query,
+            pool,
+            model_name=rr_cfg.get("model", "BAAI/bge-reranker-base"),
+            top_n=top_n,
+        )
+        for _h in all_results:
+            _h.pop("text", None)
+            _h.pop("rerank_score", None)
+```
+
+- [ ] **Step 2: Replace the `rerank_hits(...)` call with the dispatcher**
+
+Change the import line to `from carta.search.rerank import rerank_dispatch` and the call to:
+
+```python
+        all_results = rerank_dispatch(
+            query,
+            pool,
+            rr_cfg=rr_cfg,
+            ollama_url=cfg.get("embed", {}).get("ollama_url", "http://localhost:11434"),
+            top_n=top_n,
+        )
+```
+
+Leave the `pool`/`text`-stamping and the post-loop `pop` cleanup exactly as they are. (The cross-encoder path reads `h["text"]`; the LLM path reads `h["excerpt"]` — both keys are present, so no change needed there.)
+
+- [ ] **Step 3: Run the full search/pipeline + rerank suites to verify no regression**
+
+Run: `python -m pytest carta/embed/tests/ carta/search/tests/ carta/tests/test_pipeline.py -q`
+Expected: PASS (the 2 pre-existing pass; nothing new red). The existing rerank-enabled run_search tests now flow through `rerank_dispatch` → cross-encoder (default backend) → identical behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add carta/embed/pipeline.py
+git commit -m "feat(search): run_search reranks via rerank_dispatch (backend-aware)"
+```
+
+---
+
+## Task 6: Live eval + model bench (manual — not CI)
+
+**Files:** none (measurement). Requires Qdrant + Ollama up, `qwen3.5:0.8b` + `qwen3.5:9b` pulled, cwd = an embedded project (ET-embed).
+
+- [ ] **Step 1: Baseline (record current)**
+
+Run (cwd ET-embed): `carta eval .carta/eval/et-embed.yaml -k 5`
+Record recall@5 / MRR (expected ~0.700 / 0.546 with rerank off).
+
+- [ ] **Step 2: Eval with `backend: llm`, small model**
+
+Temporarily set in `.carta/config.yaml`:
+```yaml
+search:
+  rerank: {enabled: true, backend: llm, llm_model: qwen3.5:0.8b, candidate_pool: 40}
+```
+Run: `OMP_NUM_THREADS=1 carta eval .carta/eval/et-embed.yaml -k 5`
+Record recall@5 / MRR. Success bar: > 0.700 (pulls rank-8–43 docs into top-5).
+
+- [ ] **Step 3: Eval with `llm_model: qwen3.5:9b`**
+
+Switch `llm_model: qwen3.5:9b`, re-run. Record recall@5 / MRR + rough latency.
+
+- [ ] **Step 4: Decide + restore**
+
+Keep `qwen3.5:0.8b` unless 9b is *significantly* better. Restore `.carta/config.yaml` (rerank off / project default). Write the numbers into the PR description.
+
+- [ ] **Step 5: (no commit — measurement only)**
+
+---
+
+## Task 7: Docs + 0.8.0 release
+
+**Files:**
+- Modify: `README.md` (Configuration / rerank section)
+- Modify: `CHANGELOG.md`, `carta/__init__.py`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: README — document the backend**
+
+In the rerank/Configuration section, add:
+
+```markdown
+- `search.rerank.backend`: `cross-encoder` (default, fastembed `bge-reranker-base`) or `llm`
+  (listwise rerank via a single local Ollama call, `search.rerank.llm_model`, default
+  `qwen3.5:0.8b`). The LLM backend is fail-open — any error/timeout falls back to the fused order.
+```
+
+- [ ] **Step 2: CHANGELOG — add 0.8.0 entry** (above 0.7.1)
+
+```markdown
+## [0.8.0] — 2026-06-09
+
+### Added
+- **LLM reranker backend** for `search.rerank` (`backend: llm`) — a single listwise Ollama call
+  reorders the candidate pool (`llm_model`, default `qwen3.5:0.8b`; `llm_timeout_s`). Opt-in;
+  the default cross-encoder path is unchanged. Fail-open: any error/timeout returns the fused order.
+```
+
+- [ ] **Step 3: Bump version to 0.8.0** in `carta/__init__.py`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (2 occurrences).
+
+- [ ] **Step 4: Full suite + commit**
+
+Run: `python -m pytest -q`
+Expected: PASS (all green, 2 skipped).
+
+```bash
+git add -A
+git commit -m "docs+release: 0.8.0 — LLM reranker backend"
+```
+
+- [ ] **Step 5: PR**
+
+Push `feat/llm-reranker`, open a PR to main with the eval numbers from Task 6. After merge, tag `v0.8.0` to publish (release.yml).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** backend dispatch (T4/T5), listwise single call (T1), fail-open (T1/T2), config keys (T3), eval/bench incl. model decision (T6), README + CHANGELOG (T7), candidate_pool open-question resolved to 40 in T6. ✔
+- **Placeholders:** none — every code/command step is concrete. ✔
+- **Type consistency:** `llm_rerank_hits(query, hits, *, model, ollama_url, top_n, timeout_s, max_excerpt_chars)` and `rerank_dispatch(query, hits, *, rr_cfg, ollama_url, top_n)` are used identically in T4/T5. `rerank_score` stamped (matches the cross-encoder shape `run_search` already strips). ✔
+- **Out of scope (correct):** graph-aware retrieval, `related:` normalization, link-discovery flywheel — phase 2/3.

--- a/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
+++ b/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
@@ -76,7 +76,7 @@ search:
     enabled: true            # existing
     backend: cross-encoder   # NEW: cross-encoder | llm  (default cross-encoder)
     model: BAAI/bge-reranker-base   # used when backend=cross-encoder
-    llm_model: qwen3.5:9b           # NEW: used when backend=llm (local Ollama)
+    llm_model: qwen3.5:0.8b         # NEW: used when backend=llm (local Ollama) — small-first
     llm_timeout_s: 20               # NEW
     candidate_pool: 50              # bump default? see Open Questions
 ```
@@ -107,8 +107,9 @@ Live eval (manual, not CI): `carta eval .carta/eval/et-embed.yaml -k 5` with `ba
 ## Open questions (resolve in plan)
 1. **Default `candidate_pool`** — keep 30 or bump to 50? Bigger pool = more context for the LLM but
    a longer prompt. Lean 40.
-2. **`llm_model` default** — `qwen3.5:9b` (quality) vs `qwen3.5:0.8b` (fast, already the recall
-   judge). Bench both on the eval; pick on the recall/latency tradeoff.
+2. **`llm_model` default** — **decided: start with `qwen3.5:0.8b`** (fast, already the recall
+   judge). Bench it against `qwen3.5:9b` on the eval; keep the small model unless 9b is
+   *significantly* better on recall. Open to trying another local model if one looks well-suited.
 3. **Excerpt budget** — `max_excerpt_chars` 500 × ~40 candidates ≈ 20k chars; fits small-model
    context but verify against the chosen model.
 

--- a/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
+++ b/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
@@ -1,0 +1,119 @@
+# Design — LLM reranker backend for `search.rerank`
+
+**Date:** 2026-06-09 · **Status:** approved (brainstorm) · **Target:** carta-cc (next minor, 0.8.0)
+
+## Problem
+
+On the ET-embed corpus, hybrid retrieval lands every relevant doc in the candidate
+pool — `recall@50 = 1.000` — but several land too low for top-5:
+
+| Query | rank |
+|---|---:|
+| Safety MCU CAN message IDs and heartbeat frames | 33 |
+| telemetry timing architecture and rates | 43 |
+| VCU connector pinout and connector map | 18 |
+| virtual load cell estimation | 8 |
+| VCU power architecture | 6 |
+
+So `recall@5` (0.700) is bottlenecked by **ranking**, not retrieval. The only reranker in
+fastembed's catalog, `BAAI/bge-reranker-base`, was tested at `candidate_pool` 30 **and** 50 —
+both net 0.700 (it just reshuffles which 6 miss). It is too weak to float these subtly-relevant
+docs. A stronger reranker is the highest-ROI, graph-independent lever.
+
+(Graph-aware retrieval — 1-hop `related:` expansion — is the complementary lever and the
+Carta-native one, but it depends on normalizing + densifying the `related:` graph via the audit/
+linking work. It is **out of scope here** — a separate phase-2 spec.)
+
+## Goals / Non-goals
+
+**Goals**
+- Add an **LLM reranker backend** to the existing `search.rerank` stage, selectable by config.
+- Single listwise Ollama call per search (not N pointwise calls).
+- Strictly additive + fail-open: default behavior and the existing cross-encoder path unchanged;
+  any LLM error/timeout falls back to the fused order (never worse than today).
+- Measurable: re-run `et-embed.yaml`; success = pulling rank-8–43 docs into top-5 above 0.700.
+
+**Non-goals**
+- Graph-aware retrieval / `related:` traversal (phase 2).
+- The reranker→link-discovery feedback loop (phase 3).
+- Any new external/paid API. Local Ollama only.
+- Changing the hybrid fetch or fusion.
+
+## Design
+
+### Integration point
+`run_search` (`carta/embed/pipeline.py`) already fetches `candidate_pool` candidates when
+`search.rerank.enabled` and calls `rerank_hits(query, pool, model_name, top_n)` from
+`carta/search/rerank.py`. We dispatch on a new `backend` key:
+
+- `backend: cross-encoder` (**default**) → existing `rerank_hits` (fastembed). Unchanged.
+- `backend: llm` → new `llm_rerank_hits(...)`.
+
+### New unit — `carta/search/llm_rerank.py`
+```
+llm_rerank_hits(query, hits, *, model, ollama_url, top_n,
+                timeout_s=20, max_excerpt_chars=500) -> list[dict]
+```
+One purpose: reorder `hits` by LLM-judged relevance to `query`, return top_n. Pure-ish: its only
+dependency is one Ollama `/api/chat` HTTP call (same plumbing as `carta/hook/hook.py`).
+
+**Mechanism (listwise, one call):**
+1. Build a numbered list of candidates: `[i] {source}\n{excerpt[:max_excerpt_chars]}` for each hit.
+2. Prompt: *"Rank the passages most relevant to the query. Return ONLY a JSON array of the
+   passage numbers, most relevant first, length ≤ top_n."* (`format: json`, low temperature).
+3. Parse the returned index array; reorder `hits` accordingly; append any unranked hits in their
+   original fused order; truncate to `top_n`.
+4. Stamp `rerank_score` as a descending synthetic rank (so output shape matches the cross-encoder
+   path, which `run_search` already strips).
+
+**Fail-open** (return fused `hits[:top_n]` unchanged) on: Ollama unreachable/timeout, non-JSON or
+malformed reply, empty/blank query, or zero hits. Never raises into `run_search`.
+
+### Config (`search.rerank`)
+```yaml
+search:
+  rerank:
+    enabled: true            # existing
+    backend: cross-encoder   # NEW: cross-encoder | llm  (default cross-encoder)
+    model: BAAI/bge-reranker-base   # used when backend=cross-encoder
+    llm_model: qwen3.5:9b           # NEW: used when backend=llm (local Ollama)
+    llm_timeout_s: 20               # NEW
+    candidate_pool: 50              # bump default? see Open Questions
+```
+`ollama_url` is read from `embed.ollama_url`. Defaults keep the cross-encoder path; `backend: llm`
+is opt-in. DEFAULTS in `carta/config.py` gain `backend`, `llm_model`, `llm_timeout_s`.
+
+### Data flow
+`run_search` → hybrid fetch (`candidate_pool` hits, fused) → if `rerank.enabled`: dispatch on
+`backend` → (`llm` → one Ollama call → reordered top_n | `cross-encoder` → fastembed) → strip
+transient keys → return top_n. Visual/RRF fusion path unchanged.
+
+### Error handling
+- Ollama down / timeout / 5xx → log one stderr line, return fused top_n.
+- Reply not parseable as a JSON index array → fail-open.
+- Indices out of range / duplicated → filter to valid/unique, fill remainder from fused order.
+- `backend: llm` but `embed.ollama_url` unset → fail-open + warn once.
+
+### Testing (TDD)
+Pure-function tests with a mocked Ollama call (`requests.post`), no live model:
+- Reorders to the LLM's returned index order; truncates to `top_n`.
+- Unranked candidates appended in original order (no dropped hits).
+- Fail-open: timeout, non-JSON, out-of-range indices, empty hits → fused order, never raises.
+- `run_search` dispatch: `backend: llm` calls `llm_rerank_hits`; `cross-encoder`/unset calls the
+  existing path (monkeypatch both; assert the right one fires).
+Live eval (manual, not CI): `carta eval .carta/eval/et-embed.yaml -k 5` with `backend: llm` vs the
+0.700 cross-encoder/none baseline.
+
+## Open questions (resolve in plan)
+1. **Default `candidate_pool`** — keep 30 or bump to 50? Bigger pool = more context for the LLM but
+   a longer prompt. Lean 40.
+2. **`llm_model` default** — `qwen3.5:9b` (quality) vs `qwen3.5:0.8b` (fast, already the recall
+   judge). Bench both on the eval; pick on the recall/latency tradeoff.
+3. **Excerpt budget** — `max_excerpt_chars` 500 × ~40 candidates ≈ 20k chars; fits small-model
+   context but verify against the chosen model.
+
+## Phasing
+- **Phase 1 (this spec):** LLM reranker backend.
+- **Phase 2:** normalize the `related:` graph (id-vs-path) + graph-aware 1-hop expansion in
+  `run_search`, fed by the audit/linking work.
+- **Phase 3:** mine reranker signal to *suggest* new `related:` links back into the audit (the flywheel).


### PR DESCRIPTION
Adds an opt-in **LLM reranker** to `search.rerank`, per spec `docs/superpowers/specs/2026-06-09-llm-reranker-design.md` + plan `docs/superpowers/plans/2026-06-09-llm-reranker.md`.

## Why
Diagnostic on ET-embed: **recall@50 = 1.0** — every relevant doc is retrieved, just ranked too low for top-5 (Safety-MCU @33, telemetry-timing @43). It's a ranking problem; `bge-reranker-base` was too weak (net 0.700 at pool 30 *and* 50).

## What
- `carta/search/llm_rerank.py` — `llm_rerank_hits`: one **listwise** Ollama `/api/chat` call reorders the candidate pool; **fail-open** (any error/timeout → fused order).
- `rerank_dispatch` routes `search.rerank.backend`: `cross-encoder` (default, unchanged) | `llm`.
- Config defaults: `backend`, `llm_model: qwen3.5:0.8b`, `llm_timeout_s`.
- `run_search` reranks via the dispatcher. README + CHANGELOG + 0.8.0 bump.

## Measured (ET-embed, 20-query md eval, text-only)
| Reranker | recall@5 | MRR |
|---|---:|---:|
| baseline (hybrid) | 0.700 | 0.546 |
| **llm — qwen3.5:0.8b** | **0.750** | **0.589** |
| llm — qwen3.5:9b | 0.750 | 0.564 |

Small model wins (higher MRR, faster) → it's the default. The 5 remaining misses are rank-33/43 cases for **phase 2 (graph-aware retrieval)** — e.g. Safety-MCU is `related:`-linked to its #1-ranked neighbor.

## Tests
New `test_llm_rerank.py` (6: reorder, object-wrapped array, fail-open ×4), `rerank_dispatch` routing (2), config defaults (1). Full suite **736 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)