### PR TITLE
Note capture: carta_remember MCP tool + carta remember CLI (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to **carta-cc** are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.10.0] — 2026-06-11
+
+### Added
+- **Note capture — the write side of session memory.** `carta_remember` (MCP tool) and
+  `carta remember` (CLI) save curated project knowledge as plain markdown files with
+  `doc_type` frontmatter — `quirk` → `docs/quirks/`, `bug-note`/`helpful-note` →
+  `docs/notes/` (paths configurable via `memory.quirks_dir`/`memory.notes_dir`) — and embed
+  them into `{project}_notes` through the standard pipeline. Notes are git-shareable repo
+  docs: they show up in `carta scan`/audit, export with `carta export`, and survive
+  re-embeds. Search results and proactive-recall injections label them (`[quirk] …`).
+- **Frontmatter `doc_type` override.** A `doc_type:` key in markdown frontmatter now wins
+  over parent-directory inference, and `quirks/` / `notes/` directories map to note types —
+  hand-written notes route correctly on (re-)embed.
+
+### Fixed
+- **`collection_for_doc_type` was dead code — note types never reached `_notes`.**
+  `upsert_chunks` hardcoded the `_doc` collection; it now routes by the batch's doc_type.
+  `carta init` creates `{project}_notes` (instead of the never-used `_quirk`); existing
+  projects need no migration — the collection is auto-created on first capture.
+
 ## [0.9.1] — 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ last_reviewed: 2026-03-20
 | `/doc-audit` | Structural + semantic audit, generates `AUDIT_REPORT.md` |
 | `/doc-embed` | Ingest PDFs, manuals, and audio transcripts into Qdrant |
 | `/doc-search` | Natural language search over the embedded knowledge base |
+| `carta remember` / `carta_remember` | Save a curated project note (quirk / bug-note / helpful-note) as a repo markdown file and embed it |
 
 ---
 
@@ -266,6 +267,27 @@ It was measured **neutral** on a corpus where a strong reranker already floats i
 most likely to help corpora with a rich, well-linked `related:` graph and relevant docs that rank
 deep. The companion `related:` resolver (id/path normalization) and the `carta scan`
 `noncanonical_related` check ship regardless and feed link-graph cleanup.
+
+### Capturing notes (quirks, bug notes, helpful notes)
+
+The write side of session memory. When you (or Claude) learn something durable about the
+project, save it:
+
+```bash
+carta remember "EZKontrol bench tests silently fail unless motor CAN is powered" \
+  --type quirk --title "EZKontrol bench power" --tags can,bench
+```
+
+or from Claude via the `carta_remember` MCP tool. Notes are plain markdown files with
+`doc_type` frontmatter — `quirk` → `docs/quirks/`, `bug-note`/`helpful-note` → `docs/notes/`
+(configurable via `memory.quirks_dir` / `memory.notes_dir`) — embedded into
+`{project}_notes` and retrieved by the same hybrid search, reranker, and proactive-recall
+hook as your docs. Search output labels them: `[quirk] docs/quirks/2026-06-11-….md`.
+
+Notes are knowledge artifacts, not tool state: git-shareable, audited by `carta scan`
+(staleness, links), exported by `carta export`, and still useful if you remove Carta.
+Hand-written files work too — drop a markdown file in `docs/quirks/` (or set
+`doc_type: quirk` in frontmatter anywhere) and `carta embed` routes it correctly.
 
 ---
 

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -580,6 +580,24 @@ def cmd_eval(args):
         sys.exit(1)
 
 
+def cmd_remember(args):
+    """Save a curated project note (quirk/bug-note/helpful-note) and embed it."""
+    from carta.config import load_config
+    from carta.memory.capture import capture_note
+    cfg_path = find_config()
+    cfg = load_config(cfg_path)
+    repo_root = cfg_path.parent.parent
+    tags = [t.strip() for t in (args.tags or "").split(",") if t.strip()] or None
+    try:
+        result = capture_note(cfg, repo_root, args.text, note_type=args.type,
+                              title=args.title, tags=tags)
+    except (ValueError, RuntimeError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"✓ Note saved: {result['path']} → {result['collection']} "
+          f"({result['chunks']} chunks)")
+
+
 def cmd_export(args):
     """Bundle this project's embeddings into a portable .tar.gz for sharing."""
     from carta.config import load_config
@@ -696,6 +714,18 @@ def main():
     eval_p.add_argument("eval_path", help="Path to eval-set YAML (see carta/eval/datasets/example.yaml)")
     eval_p.add_argument("-k", type=int, default=5, help="top-k cutoff (default 5)")
 
+    remember_p = sub.add_parser(
+        "remember",
+        help="Save a project note (quirk/bug-note/helpful-note) and embed it",
+    )
+    remember_p.add_argument("text", help="The note text")
+    remember_p.add_argument(
+        "--type", choices=["quirk", "bug-note", "helpful-note"],
+        default="helpful-note", help="Note type (default: helpful-note)",
+    )
+    remember_p.add_argument("--title", default="", help="Optional title (drives the filename slug)")
+    remember_p.add_argument("--tags", default="", help="Comma-separated tags")
+
     update_p = sub.add_parser("update", help="Update carta to the latest version")
     update_p.add_argument("--check", action="store_true", help="Show available version without upgrading")
     update_p.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
@@ -751,6 +781,7 @@ def main():
         "audit": cmd_audit,
         "doctor": cmd_doctor,
         "eval": cmd_eval,
+        "remember": cmd_remember,
         "update": cmd_update,
         "statusline": cmd_statusline,
         "export": cmd_export,

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -303,8 +303,10 @@ def cmd_search(args):
         )
         _notify_if_update(cfg_path, cfg)
         return
+    from carta.config import NOTE_DOC_TYPES
     for r in results:
-        print(f"[{r['score']:.2f}] {r['source']} — {r['excerpt']}")
+        tag = f"[{r['doc_type']}] " if r.get("doc_type") in NOTE_DOC_TYPES else ""
+        print(f"[{r['score']:.2f}] {tag}{r['source']} — {r['excerpt']}")
 
     hops = getattr(args, "hops", 0)
     if hops > 0:

--- a/carta/config.py
+++ b/carta/config.py
@@ -5,6 +5,7 @@ import yaml
 REQUIRED_FIELDS = ["project_name", "qdrant_url"]
 
 # Curated note types — routed to {project}_notes and labeled in search output.
+# Keep in sync with PROTECTED_DOC_TYPES in carta/embed/lifecycle.py (orphan-cleanup guard).
 NOTE_DOC_TYPES = ("quirk", "bug-note", "helpful-note")
 
 DEFAULTS = {

--- a/carta/config.py
+++ b/carta/config.py
@@ -4,6 +4,9 @@ import yaml
 
 REQUIRED_FIELDS = ["project_name", "qdrant_url"]
 
+# Curated note types — routed to {project}_notes and labeled in search output.
+NOTE_DOC_TYPES = ("quirk", "bug-note", "helpful-note")
+
 DEFAULTS = {
     "docs_root": "docs/",
     "stale_threshold_days": 30,
@@ -19,6 +22,10 @@ DEFAULTS = {
         "configuration values",
         "environment variable names",
     ],
+    "memory": {
+        "quirks_dir": "docs/quirks",     # note_type: quirk
+        "notes_dir": "docs/notes",       # note_type: bug-note, helpful-note
+    },
     "search": {
         "top_n": 5,
         "hybrid": {
@@ -161,7 +168,7 @@ def collection_for_doc_type(cfg: dict, doc_type: str) -> str:
     Returns:
         Collection name (e.g., "myproject_doc", "myproject_notes", "myproject_session").
     """
-    if doc_type in ("quirk", "bug-note", "helpful-note"):
+    if doc_type in NOTE_DOC_TYPES:
         return collection_name(cfg, "notes")
     elif doc_type == "session":
         return collection_name(cfg, "session")

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -18,7 +18,7 @@ from qdrant_client.models import (
     VectorParams,
 )
 
-from carta.config import collection_name
+from carta.config import collection_name, collection_for_doc_type
 
 # nomic-embed-text produces 768-dimensional vectors
 VECTOR_DIM = 768
@@ -181,7 +181,11 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     Returns:
         Number of points upserted.
     """
-    coll_name = collection_name(cfg, "doc")
+    # Route by the batch's doc_type (batches come from a single file, so they are
+    # doc_type-homogeneous). Note types (quirk/bug-note/helpful-note) land in
+    # {project}_notes; everything else (incl. image/visual chunk types) stays in _doc.
+    batch_doc_type = chunks[0].get("doc_type", "unknown") if chunks else "unknown"
+    coll_name = collection_for_doc_type(cfg, batch_doc_type)
     embed_cfg = cfg["embed"]
     ollama_url = embed_cfg["ollama_url"]
     model = embed_cfg["ollama_model"]

--- a/carta/embed/induct.py
+++ b/carta/embed/induct.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import yaml
 
-from carta.config import collection_name
+from carta.config import collection_name, collection_for_doc_type
 
 
 # Map parent directory names to doc_type values
@@ -17,6 +17,8 @@ _PATH_TYPE_MAP = {
     "reference": "reference",
     "specs": "spec",
     "guides": "guide",
+    "quirks": "quirk",
+    "notes": "helpful-note",
 }
 
 
@@ -42,6 +44,25 @@ def infer_doc_type(file_path: Path) -> str:
     return "unknown"
 
 
+def resolve_doc_type(file_path: Path, rel_path: Path) -> str:
+    """Resolve a file's doc_type: explicit frontmatter wins, else parent-dir inference.
+
+    Args:
+        file_path: absolute path (read for frontmatter when markdown).
+        rel_path: repo-relative path (parent names drive inference).
+    """
+    if file_path.suffix == ".md":
+        from carta.scanner.scanner import parse_frontmatter
+        try:
+            fm = parse_frontmatter(file_path) or {}
+        except Exception:
+            fm = {}
+        fm_type = fm.get("doc_type")
+        if isinstance(fm_type, str) and fm_type.strip():
+            return fm_type.strip()
+    return infer_doc_type(rel_path)
+
+
 def generate_sidecar_stub(
     file_path: Path,
     repo_root: Path,
@@ -57,7 +78,7 @@ def generate_sidecar_stub(
         notes: optional free-text notes.
     """
     rel_path = file_path.relative_to(repo_root)
-    doc_type = infer_doc_type(rel_path)
+    doc_type = resolve_doc_type(file_path, rel_path)
     slug = slug_from_filename(file_path.name)
     file_type = "markdown" if file_path.suffix == ".md" else "pdf"
 
@@ -72,7 +93,7 @@ def generate_sidecar_stub(
         "image_count": None,
         "image_chunks": None,
         "file_mtime": None,
-        "collection": collection_name(cfg, "doc"),
+        "collection": collection_for_doc_type(cfg, doc_type),
         "spec_summary": None,
         "notes": notes or "",
         # Lifecycle fields (Plan 999.1-02)

--- a/carta/embed/induct.py
+++ b/carta/embed/induct.py
@@ -54,6 +54,9 @@ def resolve_doc_type(file_path: Path, rel_path: Path) -> str:
     if file_path.suffix == ".md":
         from carta.scanner.scanner import parse_frontmatter
         try:
+            # parse_frontmatter handles malformed YAML itself (returns None);
+            # the except is fail-open for unreadable/binary/non-UTF-8 files,
+            # which fall through to path inference like any other file.
             fm = parse_frontmatter(file_path) or {}
         except Exception:
             fm = {}

--- a/carta/embed/lifecycle.py
+++ b/carta/embed/lifecycle.py
@@ -148,6 +148,7 @@ def cleanup_expired_orphans(
 
 
 # Protected doc types that should never be deleted by orphan cleanup
+# Keep in sync with NOTE_DOC_TYPES in carta/config.py (routing/labeling).
 PROTECTED_DOC_TYPES = frozenset({"quirk", "bug-note", "helpful-note"})
 
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1571,6 +1571,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
                             "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
                             "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
                             "type": "visual",
+                            "doc_type": payload.get("doc_type", ""),
                         })
                         
                 except Exception:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1619,6 +1619,7 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
                         "source": payload.get("file_path", payload.get("slug", "")),
                         "excerpt": payload.get("text", ""),
                         "type": "text",
+                        "doc_type": payload.get("doc_type", ""),
                     })
 
             per_collection.append(coll_results)

--- a/carta/hook/hook.py
+++ b/carta/hook/hook.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import requests
 
-from carta.config import find_config, load_config
+from carta.config import find_config, load_config, NOTE_DOC_TYPES
 from carta.embed.pipeline import run_search
 
 
@@ -227,8 +227,9 @@ def _inject(hits: list[dict]) -> None:
     """
     context_lines = ["## Relevant documentation\n"]
     for h in hits:
+        tag = f"[{h['doc_type']}] " if h.get("doc_type") in NOTE_DOC_TYPES else ""
         context_lines.append(
-            f"**Source: {h['source']} (score: {h['score']:.2f})**\n"
+            f"**Source: {tag}{h['source']} (score: {h['score']:.2f})**\n"
             f"> {h['excerpt'][:200]}\n"
         )
     context_text = "\n".join(context_lines)

--- a/carta/hook/tests/test_hook.py
+++ b/carta/hook/tests/test_hook.py
@@ -523,3 +523,25 @@ def test_judge_no_returns_false():
     with patch("carta.hook.hook._call_ollama_judge", return_value=False):
         result = _judge_with_timeout("prompt", hits, cfg, timeout_s=3)
     assert result is False
+
+
+def test_inject_labels_note_hits():
+    """Recalled notes are labeled with their type so Claude can tell curated memory
+    from plain docs; plain docs stay unlabeled."""
+    hits = [
+        {"score": 0.92, "source": "docs/quirks/2026-06-11-psu.md",
+         "excerpt": "bench PSU must be on", "doc_type": "quirk"},
+        {"score": 0.91, "source": "docs/CAN/TOPOLOGY.md",
+         "excerpt": "two CAN buses", "doc_type": ""},
+    ]
+    cfg = _make_cfg()
+    with (
+        patch("sys.stdin", _stdin("query")),
+        patch("carta.hook.hook.find_config", return_value=Path("/fake/.carta/config.yaml")),
+        patch("carta.hook.hook.load_config", return_value=cfg),
+        patch("carta.hook.hook.run_search", return_value=hits),
+    ):
+        out = _capture_main()
+    data = json.loads(out.strip())
+    assert "[quirk] docs/quirks/2026-06-11-psu.md" in data["context"]
+    assert "Source: docs/CAN/TOPOLOGY.md" in data["context"]

--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -484,13 +484,11 @@ Returns top results from all collections with scores and excerpts.
 
 ---
 
-### `/session-memory <text>`
-Capture session context for future recall.
+### Saving project notes
 
-**Example:**
-```
-/session-memory save key decisions about API design
-```
+Use the `carta_remember` MCP tool (or `carta remember "text" --type quirk`) to save durable
+project knowledge — surprising quirks, bug-investigation findings, helpful notes. Notes are
+written to docs/quirks/ or docs/notes/ (git-shareable) and are immediately searchable.
 
 ---
 

--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -10,7 +10,7 @@ import yaml
 
 CARTA_RUNTIME_SRC = Path(__file__).parent.parent
 
-VECTOR_DIMENSIONS = {"doc": 768, "session": 768, "quirk": 768}
+VECTOR_DIMENSIONS = {"doc": 768, "session": 768, "notes": 768}
 
 
 def _is_interactive() -> bool:
@@ -252,7 +252,7 @@ def run_bootstrap(project_root: Path, *, skip_skills: bool = False) -> None:
                 print(f"\n✓ Carta skills at {display}: {', '.join(msg_parts)}")
                 print("  (Reload Claude Code to activate)")
 
-    colls = f"{project_name}_doc, {project_name}_session, {project_name}_quirk"
+    colls = f"{project_name}_doc, {project_name}_session, {project_name}_notes"
     if collections_ok:
         print(f"\n✅ Carta ready. Collections: {colls}")
         print("  Slash commands available: /doc-audit, /doc-embed, /doc-search")
@@ -356,7 +356,7 @@ def _remove_plugin_cache() -> bool:
 def _create_qdrant_collections(project_name: str, qdrant_url: str, vector_size: int = 768) -> bool:
     """Create Qdrant collections. Returns True if all succeeded."""
     failures = 0
-    for type_ in ["doc", "session", "quirk"]:
+    for type_ in ["doc", "session", "notes"]:
         collection = f"{project_name}_{type_}"
         try:
             r = requests.put(
@@ -423,7 +423,7 @@ def _create_mcp_configs(project_root: Path) -> None:
 
 def _append_claude_md(project_root: Path, project_name: str) -> None:
     claude_md = project_root / "CLAUDE.md"
-    note = f"\n<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_quirk -->\n"
+    note = f"\n<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_notes -->\n"
     if claude_md.exists():
         if "Carta is active" in claude_md.read_text():
             return
@@ -507,7 +507,7 @@ Capture session context for future recall.
 2. Seed knowledge store: `/doc-embed`
 3. Search docs: `/doc-search <query>`
 
-<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_quirk -->
+<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_notes -->
 '''
     agents_md.write_text(content)
     print(f"  Created AGENTS.md with Carta slash commands")

--- a/carta/install/tests/test_bootstrap.py
+++ b/carta/install/tests/test_bootstrap.py
@@ -116,7 +116,7 @@ def test_create_qdrant_collections_uses_namespaced_names():
     called_urls = [call.args[0] for call in mock_req.put.call_args_list]
     assert any("my-project_doc" in url for url in called_urls)
     assert any("my-project_session" in url for url in called_urls)
-    assert any("my-project_quirk" in url for url in called_urls)
+    assert any("my-project_notes" in url for url in called_urls)
 
 def test_bootstrap_continues_if_qdrant_unavailable(tmp_path):
     """bootstrap should warn and continue (not exit) when Qdrant is unreachable but not critically failing."""

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -408,6 +408,47 @@ def carta_scan() -> dict:
         return {"error": "service_unavailable", "detail": str(e)}
 
 
+def _remember(text: str, *, note_type: str = "helpful-note", title: str = "",
+              tags: list[str] | None = None) -> dict:
+    """Plain-function core for carta_remember (kept undecorated for testability)."""
+    try:
+        cfg = _load_cfg()
+        repo_root = _repo_root_from_cfg()
+    except (ConfigError, FileNotFoundError) as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+    try:
+        from carta.memory.capture import capture_note
+        result = capture_note(cfg, repo_root, text, note_type=note_type,
+                              title=title, tags=tags)
+        return {"status": "ok", **result}
+    except ValueError as e:
+        return {"error": "invalid_request", "detail": str(e)}
+    except Exception as e:
+        _logger.warning("carta_remember error: %s", e)
+        return {"error": "service_unavailable", "detail": str(e)}
+
+
+@mcp_server.tool()
+def carta_remember(
+    text: str,
+    note_type: str = "helpful-note",
+    title: str = "",
+    tags: list[str] | None = None,
+) -> dict:
+    """Save a curated project note as a repo markdown file and embed it for search.
+
+    Use when you learn something durable about THIS project worth remembering across
+    sessions: note_type="quirk" for surprising system/hardware behavior,
+    "bug-note" for bug-investigation findings, "helpful-note" for other durable
+    knowledge. The note lands in docs/quirks/ or docs/notes/ (git-shareable) and is
+    immediately retrievable via carta_search and proactive recall.
+
+    Returns:
+        {"status": "ok", "path", "collection", "chunks"} or {"error", "detail"}.
+    """
+    return _remember(text, note_type=note_type, title=title, tags=tags)
+
+
 def main() -> None:
     """Entry point for carta-mcp command."""
     mcp_server.run()

--- a/carta/memory/capture.py
+++ b/carta/memory/capture.py
@@ -1,0 +1,101 @@
+"""Note capture — write a curated note as a repo markdown file and embed it.
+
+Notes are knowledge artifacts: content-named files in the user's docs tree
+(docs/quirks/, docs/notes/ by default), plain markdown with generic frontmatter,
+useful with or without Carta. See the repo footprint policy in
+docs/superpowers/specs/2026-06-10-note-capture-design.md.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from carta.config import NOTE_DOC_TYPES, collection_for_doc_type
+
+
+def _slugify(text: str, max_words: int = 6) -> str:
+    words = re.sub(r"[^a-zA-Z0-9\s-]", "", text).split()[:max_words]
+    slug = "-".join(w.lower() for w in words)
+    return slug or "note"
+
+
+def _note_dir(cfg: dict, note_type: str) -> str:
+    mem = cfg.get("memory", {})
+    if note_type == "quirk":
+        return mem.get("quirks_dir", "docs/quirks")
+    return mem.get("notes_dir", "docs/notes")
+
+
+def capture_note(cfg: dict, repo_root: Path, text: str, *,
+                 note_type: str, title: str = "",
+                 tags: list[str] | None = None) -> dict:
+    """Write a note file with frontmatter and embed it via the standard pipeline.
+
+    Args:
+        cfg: carta config dict.
+        repo_root: absolute repo root path.
+        text: the note body (stored verbatim).
+        note_type: one of NOTE_DOC_TYPES.
+        title: optional title; drives the filename slug and frontmatter title.
+        tags: optional list of tags for the frontmatter.
+
+    Returns:
+        {"path": <repo-relative str>, "collection": <name>, "chunks": <int>}
+
+    Raises:
+        ValueError: invalid note_type or empty text.
+        RuntimeError: file written but embedding failed (file is kept).
+    """
+    if note_type not in NOTE_DOC_TYPES:
+        raise ValueError(
+            f"invalid note_type {note_type!r} — must be one of {', '.join(NOTE_DOC_TYPES)}"
+        )
+    if not text or not text.strip():
+        raise ValueError("note text is empty")
+
+    target_dir = Path(repo_root) / _note_dir(cfg, note_type)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    slug = _slugify(title or text)
+    today = date.today().isoformat()
+    path = target_dir / f"{today}-{slug}.md"
+    n = 2
+    while path.exists():
+        path = target_dir / f"{today}-{slug}-{n}.md"
+        n += 1
+
+    frontmatter = {
+        "doc_type": note_type,
+        "title": title or " ".join(text.split()[:8]),
+        "created": today,
+    }
+    if tags:
+        frontmatter["tags"] = list(tags)
+
+    content = (
+        "---\n"
+        + yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
+        + "---\n\n"
+        + text.strip()
+        + "\n"
+    )
+    path.write_text(content)
+    rel = str(path.relative_to(repo_root))
+
+    from carta.embed.pipeline import run_embed_file
+    try:
+        result = run_embed_file(path, cfg) or {}
+    except Exception as e:
+        raise RuntimeError(
+            f"note written to {rel} but embedding failed: {e} — "
+            f"run `carta embed` to index it"
+        ) from e
+
+    return {
+        "path": rel,
+        "collection": collection_for_doc_type(cfg, note_type),
+        "chunks": result.get("chunks", 0),
+    }

--- a/carta/tests/test_bootstrap.py
+++ b/carta/tests/test_bootstrap.py
@@ -167,3 +167,25 @@ def test_bootstrap_continues_when_qdrant_unreachable(tmp_path):
             run_bootstrap(project_root)
         except SystemExit as e:
             raise AssertionError(f"bootstrap exited with code {e.code} when Qdrant was unreachable") from e
+
+
+def test_bootstrap_creates_notes_not_quirk(monkeypatch):
+    """Init must create {project}_notes (what routing/search use), not legacy _quirk."""
+    from unittest.mock import MagicMock
+    from carta.install import bootstrap as bs
+
+    calls = []
+
+    def fake_put(url, json=None, timeout=None):
+        calls.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        return r
+
+    monkeypatch.setattr(bs.requests, "put", fake_put)
+    ok = bs._create_qdrant_collections("p", "http://localhost:6333")
+    assert ok
+    assert any(u.endswith("/collections/p_notes") for u in calls)
+    assert any(u.endswith("/collections/p_doc") for u in calls)
+    assert any(u.endswith("/collections/p_session") for u in calls)
+    assert not any(u.endswith("/collections/p_quirk") for u in calls)

--- a/carta/tests/test_capture.py
+++ b/carta/tests/test_capture.py
@@ -1,0 +1,85 @@
+"""Tests for carta/memory/capture.py — note capture core."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from carta.memory.capture import capture_note
+
+
+def _cfg():
+    return {
+        "project_name": "p",
+        "qdrant_url": "http://localhost:6333",
+        "memory": {"quirks_dir": "docs/quirks", "notes_dir": "docs/notes"},
+        "embed": {"ollama_url": "http://localhost:11434", "ollama_model": "m"},
+    }
+
+
+def _capture(tmp_path, text="The bench PSU must be on for CAN tests", **kw):
+    kw.setdefault("note_type", "quirk")
+    with patch("carta.embed.pipeline.run_embed_file",
+               return_value={"status": "ok", "chunks": 2}) as emb:
+        out = capture_note(_cfg(), tmp_path, text, **kw)
+    return out, emb
+
+
+class TestCaptureNote:
+    def test_quirk_file_written_with_frontmatter(self, tmp_path):
+        out, emb = _capture(tmp_path, title="Bench PSU quirk", tags=["bench", "can"])
+        p = tmp_path / out["path"]
+        assert p.parent == tmp_path / "docs" / "quirks"
+        content = p.read_text()
+        assert content.startswith("---\n")
+        fm = yaml.safe_load(content.split("---")[1])
+        assert fm["doc_type"] == "quirk"
+        assert fm["title"] == "Bench PSU quirk"
+        assert fm["tags"] == ["bench", "can"]
+        assert "created" in fm
+        assert "The bench PSU must be on" in content
+        assert out["collection"] == "p_notes"
+        assert out["chunks"] == 2
+        emb.assert_called_once()
+
+    def test_bug_note_and_helpful_note_go_to_notes_dir(self, tmp_path):
+        for nt in ("bug-note", "helpful-note"):
+            out, _ = _capture(tmp_path, note_type=nt)
+            assert (tmp_path / out["path"]).parent == tmp_path / "docs" / "notes"
+
+    def test_title_drives_slug_else_first_words(self, tmp_path):
+        out, _ = _capture(tmp_path, title="EZKontrol CAN Handshake!")
+        assert "ezkontrol-can-handshake" in out["path"]
+        out2, _ = _capture(tmp_path, text="Always check the shunt resistor first", title="")
+        assert "always-check-the-shunt" in out2["path"]
+
+    def test_filename_collision_appends_suffix(self, tmp_path):
+        out1, _ = _capture(tmp_path, title="Same Title")
+        out2, _ = _capture(tmp_path, title="Same Title")
+        assert out1["path"] != out2["path"]
+        assert out2["path"].endswith("-2.md")
+
+    def test_invalid_note_type_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="note_type"):
+            capture_note(_cfg(), tmp_path, "x", note_type="session")
+
+    def test_empty_text_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="empty"):
+            capture_note(_cfg(), tmp_path, "   ", note_type="quirk")
+
+    def test_embed_failure_keeps_file_and_raises(self, tmp_path):
+        with patch("carta.embed.pipeline.run_embed_file",
+                   side_effect=RuntimeError("qdrant down")):
+            with pytest.raises(RuntimeError, match="carta embed"):
+                capture_note(_cfg(), tmp_path, "important fact", note_type="quirk")
+        written = list((tmp_path / "docs" / "quirks").glob("*.md"))
+        assert len(written) == 1, "the note file must survive an embed failure"
+
+    def test_custom_dirs_from_config(self, tmp_path):
+        cfg = _cfg()
+        cfg["memory"]["quirks_dir"] = "docs/carta/quirks"
+        with patch("carta.embed.pipeline.run_embed_file",
+                   return_value={"status": "ok", "chunks": 1}):
+            out = capture_note(cfg, tmp_path, "fact", note_type="quirk")
+        assert out["path"].startswith("docs/carta/quirks/")

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -269,3 +269,50 @@ class TestCmdEvalRerankAssertion:
         captured = capsys.readouterr()
         assert code is None
         assert "rerank: not requested" in captured.out
+
+
+class TestCmdRemember:
+    def _args(self, **kw):
+        import argparse
+        kw.setdefault("text", "the bench PSU must be on")
+        kw.setdefault("type", "quirk")
+        kw.setdefault("title", "")
+        kw.setdefault("tags", "")
+        return argparse.Namespace(**kw)
+
+    def _run(self, args, capture_result=None, capture_error=None):
+        from unittest.mock import patch
+        from carta.cli import cmd_remember
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333"}
+        kwargs = {}
+        if capture_error:
+            kwargs["side_effect"] = capture_error
+        else:
+            kwargs["return_value"] = capture_result or {
+                "path": "docs/quirks/2026-06-11-x.md", "collection": "p_notes", "chunks": 2}
+        with patch("carta.cli.find_config", return_value=Path("/fake/.carta/config.yaml")), \
+             patch("carta.config.load_config", return_value=cfg), \
+             patch("carta.memory.capture.capture_note", **kwargs) as cap:
+            try:
+                cmd_remember(args)
+            except SystemExit as e:
+                return e.code, cap
+        return None, cap
+
+    def test_happy_path_prints_path_and_collection(self, capsys):
+        code, cap = self._run(self._args(tags="bench, can"))
+        out = capsys.readouterr().out
+        assert code is None
+        assert "docs/quirks/2026-06-11-x.md" in out
+        assert "p_notes" in out
+        # comma-string tags become a list
+        assert cap.call_args.kwargs["tags"] == ["bench", "can"]
+
+    def test_no_tags_passes_none(self):
+        code, cap = self._run(self._args(tags=""))
+        assert cap.call_args.kwargs["tags"] is None
+
+    def test_capture_error_exits_1(self, capsys):
+        code, _ = self._run(self._args(), capture_error=ValueError("bad"))
+        assert code == 1
+        assert "bad" in capsys.readouterr().err

--- a/carta/tests/test_embed.py
+++ b/carta/tests/test_embed.py
@@ -244,3 +244,41 @@ class TestCollectionForDocType:
 
         assert collection_for_doc_type(cfg, "unknown_type") == "myproject_doc"
         assert collection_for_doc_type(cfg, "random-string") == "myproject_doc"
+
+
+class TestUpsertChunksRouting:
+    """upsert_chunks must route by the chunks' doc_type via collection_for_doc_type —
+    it previously hardcoded {project}_doc, making note types unreachable."""
+
+    def _run(self, doc_type):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.embed import upsert_chunks
+        chunks = [{"slug": "s", "text": "hello world", "chunk_index": 0,
+                   "doc_type": doc_type}]
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "http://localhost:11434",
+                          "ollama_model": "m", "embedding_workers": 1}}
+        client = MagicMock()
+        with patch("carta.embed.embed.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.embed.collection_is_hybrid", return_value=False), \
+             patch("carta.embed.embed.ensure_collection") as ens:
+            upsert_chunks(chunks, cfg, client=client)
+        ensured = ens.call_args[0][1]
+        # the same name must be used for the actual upsert call
+        assert ensured in str(client.upsert.call_args)
+        return ensured
+
+    def test_quirk_routes_to_notes(self):
+        assert self._run("quirk") == "p_notes"
+
+    def test_bug_note_routes_to_notes(self):
+        assert self._run("bug-note") == "p_notes"
+
+    def test_helpful_note_routes_to_notes(self):
+        assert self._run("helpful-note") == "p_notes"
+
+    def test_plain_doc_type_still_routes_to_doc(self):
+        assert self._run("datasheet") == "p_doc"
+
+    def test_image_description_still_routes_to_doc(self):
+        assert self._run("image_description") == "p_doc"

--- a/carta/tests/test_induct.py
+++ b/carta/tests/test_induct.py
@@ -67,3 +67,45 @@ class TestGenerateSidecarStub:
 
         assert isinstance(stub["version_history"], list)
         assert len(stub["version_history"]) == 0
+
+
+class TestDocTypeResolution:
+    """Frontmatter doc_type wins over parent-dir inference; quirks/notes dirs map;
+    the stub's collection field routes via collection_for_doc_type."""
+
+    def _stub(self, tmp_path, rel, content="# T"):
+        fp = tmp_path / rel
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content)
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333"}
+        return generate_sidecar_stub(fp, tmp_path, cfg)
+
+    def test_frontmatter_doc_type_wins_over_path(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/reference/x.md",
+                          "---\ndoc_type: quirk\n---\n\nBody text")
+        assert stub["doc_type"] == "quirk"
+        assert stub["collection"] == "p_notes"
+
+    def test_quirks_dir_maps_to_quirk(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/quirks/x.md")
+        assert stub["doc_type"] == "quirk"
+        assert stub["collection"] == "p_notes"
+
+    def test_notes_dir_maps_to_helpful_note(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/notes/x.md")
+        assert stub["doc_type"] == "helpful-note"
+        assert stub["collection"] == "p_notes"
+
+    def test_unmapped_dir_no_frontmatter_unchanged(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/misc/x.md")
+        assert stub["doc_type"] == "unknown"
+        assert stub["collection"] == "p_doc"
+
+    def test_mapped_dir_without_frontmatter_still_routes_doc(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/reference/datasheets/x.md")
+        assert stub["doc_type"] == "datasheet"
+        assert stub["collection"] == "p_doc"
+
+    def test_malformed_frontmatter_falls_back_to_path(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/quirks/x.md", "---\n: : bad yaml [\n---\nBody")
+        assert stub["doc_type"] == "quirk"

--- a/carta/tests/test_mcp_server.py
+++ b/carta/tests/test_mcp_server.py
@@ -157,3 +157,31 @@ class TestDiscoverStaleFilesIntegration:
             # Should return only the stale file
             assert len(results) == 1
             assert results[0] == stale_file
+
+
+def test_remember_returns_ok_shape(tmp_path):
+    from carta.mcp import server
+    with patch.object(server, "_load_cfg", return_value={"project_name": "p"}), \
+         patch.object(server, "_repo_root_from_cfg", return_value=tmp_path), \
+         patch("carta.memory.capture.capture_note",
+               return_value={"path": "docs/quirks/x.md", "collection": "p_notes", "chunks": 1}):
+        out = server._remember("the bench PSU must be on", note_type="quirk")
+    assert out == {"status": "ok", "path": "docs/quirks/x.md",
+                   "collection": "p_notes", "chunks": 1}
+
+
+def test_remember_invalid_type_maps_to_invalid_request(tmp_path):
+    from carta.mcp import server
+    with patch.object(server, "_load_cfg", return_value={"project_name": "p"}), \
+         patch.object(server, "_repo_root_from_cfg", return_value=tmp_path), \
+         patch("carta.memory.capture.capture_note", side_effect=ValueError("bad note_type")):
+        out = server._remember("x", note_type="nope")
+    assert out["error"] == "invalid_request"
+
+
+def test_remember_no_config_maps_to_service_unavailable():
+    from carta.mcp import server
+    from carta.config import ConfigError
+    with patch.object(server, "_load_cfg", side_effect=ConfigError("no .carta")):
+        out = server._remember("x")
+    assert out["error"] == "service_unavailable"

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1115,3 +1115,28 @@ class TestRunSearchRerankStats:
         """No stats dict passed: run_search works exactly as before."""
         results = self._run(self._cfg(rerank_enabled=False), None)
         assert isinstance(results, list)
+
+
+class TestRunSearchDocType:
+    def test_text_hits_carry_doc_type_from_payload(self):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_search
+
+        point = MagicMock()
+        point.score = 0.9
+        point.payload = {"file_path": "docs/quirks/x.md", "text": "alpha",
+                         "doc_type": "quirk"}
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = MagicMock(points=[point])
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "u", "ollama_model": "m", "colpali_enabled": False},
+               "search": {"top_n": 5}, "modules": {"doc_search": True}}
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=mock_client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.search.scoped.get_search_collections", return_value=["p_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_search("q", cfg)
+
+        assert results and results[0]["doc_type"] == "quirk"

--- a/docs/quirks/2026-06-11-pypi-index-lag-after-release-tagging.md
+++ b/docs/quirks/2026-06-11-pypi-index-lag-after-release-tagging.md
@@ -1,0 +1,11 @@
+---
+doc_type: quirk
+title: PyPI index lag after release tagging
+created: '2026-06-11'
+tags:
+- release
+- pypi
+- pipx
+---
+
+Right after a release is tagged, PyPI's simple index can lag for a minute — 'pipx upgrade carta-cc' may report 'already latest' while the GitHub Release and pypi.org JSON already show the new version. Use 'pipx install --force carta-cc==X.Y.Z' to pin the explicit version instead of waiting.

--- a/docs/superpowers/plans/2026-06-11-note-capture.md
+++ b/docs/superpowers/plans/2026-06-11-note-capture.md
@@ -1,0 +1,914 @@
+# Note Capture (Quirks & Notes, v0.10.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `carta_remember` (MCP) + `carta remember` (CLI) so curated project notes (quirk / bug-note / helpful-note) are written as repo markdown files and embedded into `{project}_notes` — fixing the dead `collection_for_doc_type` routing end-to-end on the way.
+
+**Architecture:** A new `carta/memory/capture.py` core writes a frontmatter'd markdown file into `docs/quirks/` or `docs/notes/` and reuses `run_embed_file()` for sidecar/chunk/upsert. Three routing fixes make doc_type actually mean something: frontmatter override in induct, doc_type-aware collection selection in `upsert_chunks` (currently hardcoded `_doc`), and bootstrap creating `_notes`. Search/hook output labels note hits `[quirk]` etc.
+
+**Tech Stack:** Python 3.10+, pytest, unittest.mock, PyYAML. Spec: `docs/superpowers/specs/2026-06-10-note-capture-design.md` (in this worktree).
+
+**Conventions:** strict TDD; patch function-local imports at their SOURCE module (e.g. `carta.embed.pipeline.run_embed_file`) — this works because the import executes at call time. All commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Frontmatter doc_type override + path map (induct)
+
+**Files:**
+- Modify: `carta/embed/induct.py` (lines 9, 13-20, 37-42, 59-60, 75)
+- Test: `carta/tests/test_induct.py` (append class)
+
+- [ ] **Step 1: Write the failing tests** — append to `carta/tests/test_induct.py`:
+
+```python
+class TestDocTypeResolution:
+    """Frontmatter doc_type wins over parent-dir inference; quirks/notes dirs map;
+    the stub's collection field routes via collection_for_doc_type."""
+
+    def _stub(self, tmp_path, rel, content="# T"):
+        fp = tmp_path / rel
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content)
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333"}
+        return generate_sidecar_stub(fp, tmp_path, cfg)
+
+    def test_frontmatter_doc_type_wins_over_path(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/reference/x.md",
+                          "---\ndoc_type: quirk\n---\n\nBody text")
+        assert stub["doc_type"] == "quirk"
+        assert stub["collection"] == "p_notes"
+
+    def test_quirks_dir_maps_to_quirk(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/quirks/x.md")
+        assert stub["doc_type"] == "quirk"
+        assert stub["collection"] == "p_notes"
+
+    def test_notes_dir_maps_to_helpful_note(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/notes/x.md")
+        assert stub["doc_type"] == "helpful-note"
+        assert stub["collection"] == "p_notes"
+
+    def test_unmapped_dir_no_frontmatter_unchanged(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/misc/x.md")
+        assert stub["doc_type"] == "unknown"
+        assert stub["collection"] == "p_doc"
+
+    def test_mapped_dir_without_frontmatter_still_routes_doc(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/reference/datasheets/x.md")
+        assert stub["doc_type"] == "datasheet"
+        assert stub["collection"] == "p_doc"
+
+    def test_malformed_frontmatter_falls_back_to_path(self, tmp_path):
+        stub = self._stub(tmp_path, "docs/quirks/x.md", "---\n: : bad yaml [\n---\nBody")
+        assert stub["doc_type"] == "quirk"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest carta/tests/test_induct.py::TestDocTypeResolution -v`
+Expected: FAIL — `stub["doc_type"]` is `"unknown"` for frontmatter/quirks cases, `collection` is `"p_doc"`.
+
+- [ ] **Step 3: Implement** in `carta/embed/induct.py`:
+
+Import (line 9): `from carta.config import collection_name, collection_for_doc_type`
+
+Extend the map (lines 13-20):
+
+```python
+_PATH_TYPE_MAP = {
+    "datasheets": "datasheet",
+    "manuals": "manual",
+    "schematics": "schematic",
+    "reference": "reference",
+    "specs": "spec",
+    "guides": "guide",
+    "quirks": "quirk",
+    "notes": "helpful-note",
+}
+```
+
+Add after `infer_doc_type` (line 42):
+
+```python
+def resolve_doc_type(file_path: Path, rel_path: Path) -> str:
+    """Resolve a file's doc_type: explicit frontmatter wins, else parent-dir inference.
+
+    Args:
+        file_path: absolute path (read for frontmatter when markdown).
+        rel_path: repo-relative path (parent names drive inference).
+    """
+    if file_path.suffix == ".md":
+        from carta.scanner.scanner import parse_frontmatter
+        try:
+            fm = parse_frontmatter(file_path) or {}
+        except Exception:
+            fm = {}
+        fm_type = fm.get("doc_type")
+        if isinstance(fm_type, str) and fm_type.strip():
+            return fm_type.strip()
+    return infer_doc_type(rel_path)
+```
+
+In `generate_sidecar_stub`, change line 60 `doc_type = infer_doc_type(rel_path)` to
+`doc_type = resolve_doc_type(file_path, rel_path)`, and line 75
+`"collection": collection_name(cfg, "doc"),` to
+`"collection": collection_for_doc_type(cfg, doc_type),`.
+
+(If importing `carta.scanner.scanner` at module level were circular, the function-local
+import above avoids it; keep it function-local regardless.)
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_induct.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/induct.py carta/tests/test_induct.py
+git commit -m "feat(induct): frontmatter doc_type override + quirks/notes path mapping"
+```
+
+---
+
+### Task 2: `upsert_chunks` routes by doc_type (the dead-code fix)
+
+**Files:**
+- Modify: `carta/embed/embed.py:184` (and its `from carta.config import ...` line)
+- Test: `carta/tests/test_embed.py` (append class)
+
+- [ ] **Step 1: Write the failing tests** — append to `carta/tests/test_embed.py`:
+
+```python
+class TestUpsertChunksRouting:
+    """upsert_chunks must route by the chunks' doc_type via collection_for_doc_type —
+    it previously hardcoded {project}_doc, making note types unreachable."""
+
+    def _run(self, doc_type):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.embed import upsert_chunks
+        chunks = [{"slug": "s", "text": "hello world", "chunk_index": 0,
+                   "doc_type": doc_type}]
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "http://localhost:11434",
+                          "ollama_model": "m", "embedding_workers": 1}}
+        client = MagicMock()
+        with patch("carta.embed.embed.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.embed.collection_is_hybrid", return_value=False), \
+             patch("carta.embed.embed.ensure_collection") as ens:
+            upsert_chunks(chunks, cfg, client=client)
+        ensured = ens.call_args[0][1]
+        # the same name must be used for the actual upsert call
+        assert ensured in str(client.upsert.call_args)
+        return ensured
+
+    def test_quirk_routes_to_notes(self):
+        assert self._run("quirk") == "p_notes"
+
+    def test_bug_note_routes_to_notes(self):
+        assert self._run("bug-note") == "p_notes"
+
+    def test_helpful_note_routes_to_notes(self):
+        assert self._run("helpful-note") == "p_notes"
+
+    def test_plain_doc_type_still_routes_to_doc(self):
+        assert self._run("datasheet") == "p_doc"
+
+    def test_image_description_still_routes_to_doc(self):
+        assert self._run("image_description") == "p_doc"
+```
+
+(If `get_embedding` lives behind a different internal name in `upsert_chunks` — e.g. a
+batch helper — adjust the patch target to whatever `upsert_chunks` actually calls, keeping
+the assertions identical.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest carta/tests/test_embed.py::TestUpsertChunksRouting -v`
+Expected: the three note-type tests FAIL with `'p_doc' == 'p_notes'` mismatches.
+
+- [ ] **Step 3: Implement** in `carta/embed/embed.py`:
+
+Add `collection_for_doc_type` to the existing `from carta.config import ...` line, then
+replace line 184 `coll_name = collection_name(cfg, "doc")` with:
+
+```python
+    # Route by the batch's doc_type (batches come from a single file, so they are
+    # doc_type-homogeneous). Note types (quirk/bug-note/helpful-note) land in
+    # {project}_notes; everything else (incl. image/visual chunk types) stays in _doc.
+    batch_doc_type = chunks[0].get("doc_type", "unknown") if chunks else "unknown"
+    coll_name = collection_for_doc_type(cfg, batch_doc_type)
+```
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_embed.py -v` → all PASS (zero regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/embed.py carta/tests/test_embed.py
+git commit -m "fix(embed): upsert_chunks routes by doc_type — collection_for_doc_type was dead code"
+```
+
+---
+
+### Task 3: Bootstrap creates `_notes` (not `_quirk`)
+
+**Files:**
+- Modify: `carta/install/bootstrap.py:13` (VECTOR_DIMENSIONS), `:255` (summary string), `:359` (creation list)
+- Test: `carta/tests/test_bootstrap.py` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `carta/tests/test_bootstrap.py`:
+
+```python
+def test_bootstrap_creates_notes_not_quirk(monkeypatch):
+    """Init must create {project}_notes (what routing/search use), not legacy _quirk."""
+    from unittest.mock import MagicMock
+    from carta.install import bootstrap as bs
+
+    calls = []
+
+    def fake_put(url, json=None, timeout=None):
+        calls.append(url)
+        r = MagicMock()
+        r.status_code = 200
+        return r
+
+    monkeypatch.setattr(bs.requests, "put", fake_put)
+    ok = bs._create_qdrant_collections("p", "http://localhost:6333")
+    assert ok
+    assert any(u.endswith("/collections/p_notes") for u in calls)
+    assert any(u.endswith("/collections/p_doc") for u in calls)
+    assert any(u.endswith("/collections/p_session") for u in calls)
+    assert not any(u.endswith("/collections/p_quirk") for u in calls)
+```
+
+- [ ] **Step 2: Run to verify failure** — `python3 -m pytest carta/tests/test_bootstrap.py::test_bootstrap_creates_notes_not_quirk -v` → FAIL (p_quirk created, p_notes not).
+
+- [ ] **Step 3: Implement** in `carta/install/bootstrap.py`:
+
+Line 13: `VECTOR_DIMENSIONS = {"doc": 768, "session": 768, "notes": 768}`
+Line 359: `for type_ in ["doc", "session", "notes"]:`
+Line 255: `colls = f"{project_name}_doc, {project_name}_session, {project_name}_notes"`
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_bootstrap.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/install/bootstrap.py carta/tests/test_bootstrap.py
+git commit -m "fix(bootstrap): create {project}_notes collection (routing/search target), drop _quirk"
+```
+
+---
+
+### Task 4: Capture core (`carta/memory/capture.py`) + config defaults
+
+**Files:**
+- Create: `carta/memory/__init__.py` (empty), `carta/memory/capture.py`
+- Modify: `carta/config.py` (DEFAULTS gains `memory:` block; add `NOTE_DOC_TYPES`; `collection_for_doc_type` uses it)
+- Test: `carta/tests/test_capture.py` (new)
+
+- [ ] **Step 1: Write the failing tests** — create `carta/tests/test_capture.py`:
+
+```python
+"""Tests for carta/memory/capture.py — note capture core."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from carta.memory.capture import capture_note
+
+
+def _cfg():
+    return {
+        "project_name": "p",
+        "qdrant_url": "http://localhost:6333",
+        "memory": {"quirks_dir": "docs/quirks", "notes_dir": "docs/notes"},
+        "embed": {"ollama_url": "http://localhost:11434", "ollama_model": "m"},
+    }
+
+
+def _capture(tmp_path, text="The bench PSU must be on for CAN tests", **kw):
+    kw.setdefault("note_type", "quirk")
+    with patch("carta.embed.pipeline.run_embed_file",
+               return_value={"status": "ok", "chunks": 2}) as emb:
+        out = capture_note(_cfg(), tmp_path, text, **kw)
+    return out, emb
+
+
+class TestCaptureNote:
+    def test_quirk_file_written_with_frontmatter(self, tmp_path):
+        out, emb = _capture(tmp_path, title="Bench PSU quirk", tags=["bench", "can"])
+        p = tmp_path / out["path"]
+        assert p.parent == tmp_path / "docs" / "quirks"
+        content = p.read_text()
+        assert content.startswith("---\n")
+        fm = yaml.safe_load(content.split("---")[1])
+        assert fm["doc_type"] == "quirk"
+        assert fm["title"] == "Bench PSU quirk"
+        assert fm["tags"] == ["bench", "can"]
+        assert "created" in fm
+        assert "The bench PSU must be on" in content
+        assert out["collection"] == "p_notes"
+        assert out["chunks"] == 2
+        emb.assert_called_once()
+
+    def test_bug_note_and_helpful_note_go_to_notes_dir(self, tmp_path):
+        for nt in ("bug-note", "helpful-note"):
+            out, _ = _capture(tmp_path, note_type=nt)
+            assert (tmp_path / out["path"]).parent == tmp_path / "docs" / "notes"
+
+    def test_title_drives_slug_else_first_words(self, tmp_path):
+        out, _ = _capture(tmp_path, title="EZKontrol CAN Handshake!")
+        assert "ezkontrol-can-handshake" in out["path"]
+        out2, _ = _capture(tmp_path, text="Always check the shunt resistor first", title="")
+        assert "always-check-the-shunt" in out2["path"]
+
+    def test_filename_collision_appends_suffix(self, tmp_path):
+        out1, _ = _capture(tmp_path, title="Same Title")
+        out2, _ = _capture(tmp_path, title="Same Title")
+        assert out1["path"] != out2["path"]
+        assert out2["path"].endswith("-2.md")
+
+    def test_invalid_note_type_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="note_type"):
+            capture_note(_cfg(), tmp_path, "x", note_type="session")
+
+    def test_empty_text_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="empty"):
+            capture_note(_cfg(), tmp_path, "   ", note_type="quirk")
+
+    def test_embed_failure_keeps_file_and_raises(self, tmp_path):
+        with patch("carta.embed.pipeline.run_embed_file",
+                   side_effect=RuntimeError("qdrant down")):
+            with pytest.raises(RuntimeError, match="carta embed"):
+                capture_note(_cfg(), tmp_path, "important fact", note_type="quirk")
+        written = list((tmp_path / "docs" / "quirks").glob("*.md"))
+        assert len(written) == 1, "the note file must survive an embed failure"
+
+    def test_custom_dirs_from_config(self, tmp_path):
+        cfg = _cfg()
+        cfg["memory"]["quirks_dir"] = "docs/carta/quirks"
+        with patch("carta.embed.pipeline.run_embed_file",
+                   return_value={"status": "ok", "chunks": 1}):
+            out = capture_note(cfg, tmp_path, "fact", note_type="quirk")
+        assert out["path"].startswith("docs/carta/quirks/")
+```
+
+- [ ] **Step 2: Run to verify failure** — `python3 -m pytest carta/tests/test_capture.py -v` → FAIL with `ModuleNotFoundError: carta.memory`.
+
+- [ ] **Step 3: Implement.**
+
+`carta/config.py` — add near `REQUIRED_FIELDS`:
+
+```python
+# Curated note types — routed to {project}_notes and labeled in search output.
+NOTE_DOC_TYPES = ("quirk", "bug-note", "helpful-note")
+```
+
+In `collection_for_doc_type`, replace `if doc_type in ("quirk", "bug-note", "helpful-note"):`
+with `if doc_type in NOTE_DOC_TYPES:`.
+
+In `DEFAULTS`, add (top level, after `"contradiction_types"`):
+
+```python
+    "memory": {
+        "quirks_dir": "docs/quirks",     # note_type: quirk
+        "notes_dir": "docs/notes",       # note_type: bug-note, helpful-note
+    },
+```
+
+`carta/memory/__init__.py`: empty file.
+
+`carta/memory/capture.py`:
+
+```python
+"""Note capture — write a curated note as a repo markdown file and embed it.
+
+Notes are knowledge artifacts: content-named files in the user's docs tree
+(docs/quirks/, docs/notes/ by default), plain markdown with generic frontmatter,
+useful with or without Carta. See the repo footprint policy in
+docs/superpowers/specs/2026-06-10-note-capture-design.md.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from carta.config import NOTE_DOC_TYPES, collection_for_doc_type
+
+
+def _slugify(text: str, max_words: int = 6) -> str:
+    words = re.sub(r"[^a-zA-Z0-9\s-]", "", text).split()[:max_words]
+    slug = "-".join(w.lower() for w in words)
+    return slug or "note"
+
+
+def _note_dir(cfg: dict, note_type: str) -> str:
+    mem = cfg.get("memory", {})
+    if note_type == "quirk":
+        return mem.get("quirks_dir", "docs/quirks")
+    return mem.get("notes_dir", "docs/notes")
+
+
+def capture_note(cfg: dict, repo_root: Path, text: str, *,
+                 note_type: str, title: str = "",
+                 tags: list[str] | None = None) -> dict:
+    """Write a note file with frontmatter and embed it via the standard pipeline.
+
+    Args:
+        cfg: carta config dict.
+        repo_root: absolute repo root path.
+        text: the note body (stored verbatim).
+        note_type: one of NOTE_DOC_TYPES.
+        title: optional title; drives the filename slug and frontmatter title.
+        tags: optional list of tags for the frontmatter.
+
+    Returns:
+        {"path": <repo-relative str>, "collection": <name>, "chunks": <int>}
+
+    Raises:
+        ValueError: invalid note_type or empty text.
+        RuntimeError: file written but embedding failed (file is kept).
+    """
+    if note_type not in NOTE_DOC_TYPES:
+        raise ValueError(
+            f"invalid note_type {note_type!r} — must be one of {', '.join(NOTE_DOC_TYPES)}"
+        )
+    if not text or not text.strip():
+        raise ValueError("note text is empty")
+
+    target_dir = Path(repo_root) / _note_dir(cfg, note_type)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    slug = _slugify(title or text)
+    today = date.today().isoformat()
+    path = target_dir / f"{today}-{slug}.md"
+    n = 2
+    while path.exists():
+        path = target_dir / f"{today}-{slug}-{n}.md"
+        n += 1
+
+    frontmatter = {
+        "doc_type": note_type,
+        "title": title or " ".join(text.split()[:8]),
+        "created": today,
+    }
+    if tags:
+        frontmatter["tags"] = list(tags)
+
+    content = (
+        "---\n"
+        + yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
+        + "---\n\n"
+        + text.strip()
+        + "\n"
+    )
+    path.write_text(content)
+    rel = str(path.relative_to(repo_root))
+
+    from carta.embed.pipeline import run_embed_file
+    try:
+        result = run_embed_file(path, cfg) or {}
+    except Exception as e:
+        raise RuntimeError(
+            f"note written to {rel} but embedding failed: {e} — "
+            f"run `carta embed` to index it"
+        ) from e
+
+    return {
+        "path": rel,
+        "collection": collection_for_doc_type(cfg, note_type),
+        "chunks": result.get("chunks", 0),
+    }
+```
+
+Note: `run_embed_file` derives repo_root from `find_config()` internally, so callers must
+run with cwd inside the project — true for both CLI and MCP surfaces.
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_capture.py carta/tests/test_config.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/memory/ carta/config.py carta/tests/test_capture.py
+git commit -m "feat(memory): capture_note core — frontmatter'd note files embedded via the standard pipeline"
+```
+
+---
+
+### Task 5: MCP tool `carta_remember`
+
+**Files:**
+- Modify: `carta/mcp/server.py` (new tool after `carta_scan`)
+- Test: `carta/tests/test_mcp_server.py` (append)
+
+- [ ] **Step 1: Write the failing tests** — append to `carta/tests/test_mcp_server.py` (the file already mocks the `mcp` modules at import; `_remember` is a plain function so it stays testable):
+
+```python
+def test_remember_returns_ok_shape(tmp_path):
+    from carta.mcp import server
+    with patch.object(server, "_load_cfg", return_value={"project_name": "p"}), \
+         patch.object(server, "_repo_root_from_cfg", return_value=tmp_path), \
+         patch("carta.memory.capture.capture_note",
+               return_value={"path": "docs/quirks/x.md", "collection": "p_notes", "chunks": 1}):
+        out = server._remember("the bench PSU must be on", note_type="quirk")
+    assert out == {"status": "ok", "path": "docs/quirks/x.md",
+                   "collection": "p_notes", "chunks": 1}
+
+
+def test_remember_invalid_type_maps_to_invalid_request(tmp_path):
+    from carta.mcp import server
+    with patch.object(server, "_load_cfg", return_value={"project_name": "p"}), \
+         patch.object(server, "_repo_root_from_cfg", return_value=tmp_path), \
+         patch("carta.memory.capture.capture_note", side_effect=ValueError("bad note_type")):
+        out = server._remember("x", note_type="nope")
+    assert out["error"] == "invalid_request"
+
+
+def test_remember_no_config_maps_to_service_unavailable():
+    from carta.mcp import server
+    from carta.config import ConfigError
+    with patch.object(server, "_load_cfg", side_effect=ConfigError("no .carta")):
+        out = server._remember("x")
+    assert out["error"] == "service_unavailable"
+```
+
+- [ ] **Step 2: Run to verify failure** — `python3 -m pytest carta/tests/test_mcp_server.py -v` → new tests FAIL (`AttributeError: _remember`).
+
+- [ ] **Step 3: Implement** in `carta/mcp/server.py`, after the `carta_scan` tool:
+
+```python
+def _remember(text: str, *, note_type: str = "helpful-note", title: str = "",
+              tags: list[str] | None = None) -> dict:
+    """Plain-function core for carta_remember (kept undecorated for testability)."""
+    try:
+        cfg = _load_cfg()
+        repo_root = _repo_root_from_cfg()
+    except (ConfigError, FileNotFoundError) as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+    try:
+        from carta.memory.capture import capture_note
+        result = capture_note(cfg, repo_root, text, note_type=note_type,
+                              title=title, tags=tags)
+        return {"status": "ok", **result}
+    except ValueError as e:
+        return {"error": "invalid_request", "detail": str(e)}
+    except Exception as e:
+        _logger.warning("carta_remember error: %s", e)
+        return {"error": "service_unavailable", "detail": str(e)}
+
+
+@mcp_server.tool()
+def carta_remember(
+    text: str,
+    note_type: str = "helpful-note",
+    title: str = "",
+    tags: list[str] | None = None,
+) -> dict:
+    """Save a curated project note as a repo markdown file and embed it for search.
+
+    Use when you learn something durable about THIS project worth remembering across
+    sessions: note_type="quirk" for surprising system/hardware behavior,
+    "bug-note" for bug-investigation findings, "helpful-note" for other durable
+    knowledge. The note lands in docs/quirks/ or docs/notes/ (git-shareable) and is
+    immediately retrievable via carta_search and proactive recall.
+
+    Returns:
+        {"status": "ok", "path", "collection", "chunks"} or {"error", "detail"}.
+    """
+    return _remember(text, note_type=note_type, title=title, tags=tags)
+```
+
+(Match the file's existing import of `ConfigError` — add it to the `from carta.config
+import ...` line if not already imported.)
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_mcp_server.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/mcp/server.py carta/tests/test_mcp_server.py
+git commit -m "feat(mcp): carta_remember tool — capture quirks/notes from Claude mid-session"
+```
+
+---
+
+### Task 6: CLI `carta remember` + AGENTS.md bootstrap text
+
+**Files:**
+- Modify: `carta/cli.py` (new `cmd_remember` near `cmd_eval`; subparser near the eval parser; dispatch dict)
+- Modify: `carta/install/bootstrap.py:487-493` (AGENTS.md template text)
+- Test: `carta/tests/test_cli.py` (append class)
+
+- [ ] **Step 1: Write the failing tests** — append to `carta/tests/test_cli.py`:
+
+```python
+class TestCmdRemember:
+    def _args(self, **kw):
+        import argparse
+        kw.setdefault("text", "the bench PSU must be on")
+        kw.setdefault("type", "quirk")
+        kw.setdefault("title", "")
+        kw.setdefault("tags", "")
+        return argparse.Namespace(**kw)
+
+    def _run(self, args, capture_result=None, capture_error=None):
+        from unittest.mock import patch
+        from carta.cli import cmd_remember
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333"}
+        kwargs = {}
+        if capture_error:
+            kwargs["side_effect"] = capture_error
+        else:
+            kwargs["return_value"] = capture_result or {
+                "path": "docs/quirks/2026-06-11-x.md", "collection": "p_notes", "chunks": 2}
+        with patch("carta.cli.find_config", return_value=Path("/fake/.carta/config.yaml")), \
+             patch("carta.config.load_config", return_value=cfg), \
+             patch("carta.memory.capture.capture_note", **kwargs) as cap:
+            try:
+                cmd_remember(args)
+            except SystemExit as e:
+                return e.code, cap
+        return None, cap
+
+    def test_happy_path_prints_path_and_collection(self, capsys):
+        code, cap = self._run(self._args(tags="bench, can"))
+        out = capsys.readouterr().out
+        assert code is None
+        assert "docs/quirks/2026-06-11-x.md" in out
+        assert "p_notes" in out
+        # comma-string tags become a list
+        assert cap.call_args.kwargs["tags"] == ["bench", "can"]
+
+    def test_no_tags_passes_none(self):
+        code, cap = self._run(self._args(tags=""))
+        assert cap.call_args.kwargs["tags"] is None
+
+    def test_capture_error_exits_1(self, capsys):
+        code, _ = self._run(self._args(), capture_error=ValueError("bad"))
+        assert code == 1
+        assert "bad" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run to verify failure** — `python3 -m pytest carta/tests/test_cli.py::TestCmdRemember -v` → FAIL (`ImportError: cmd_remember`).
+
+- [ ] **Step 3: Implement** in `carta/cli.py`.
+
+Command handler (after `cmd_eval`):
+
+```python
+def cmd_remember(args):
+    """Save a curated project note (quirk/bug-note/helpful-note) and embed it."""
+    from carta.config import load_config
+    from carta.memory.capture import capture_note
+    cfg_path = find_config()
+    cfg = load_config(cfg_path)
+    repo_root = cfg_path.parent.parent
+    tags = [t.strip() for t in (args.tags or "").split(",") if t.strip()] or None
+    try:
+        result = capture_note(cfg, repo_root, args.text, note_type=args.type,
+                              title=args.title, tags=tags)
+    except (ValueError, RuntimeError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"✓ Note saved: {result['path']} → {result['collection']} "
+          f"({result['chunks']} chunks)")
+```
+
+Subparser (next to the eval parser registration):
+
+```python
+    remember_p = sub.add_parser(
+        "remember",
+        help="Save a project note (quirk/bug-note/helpful-note) and embed it",
+    )
+    remember_p.add_argument("text", help="The note text")
+    remember_p.add_argument(
+        "--type", choices=["quirk", "bug-note", "helpful-note"],
+        default="helpful-note", help="Note type (default: helpful-note)",
+    )
+    remember_p.add_argument("--title", default="", help="Optional title (drives the filename slug)")
+    remember_p.add_argument("--tags", default="", help="Comma-separated tags")
+```
+
+Dispatch dict: add `"remember": cmd_remember,`.
+
+`carta/install/bootstrap.py` (~line 487) — replace the `### /session-memory <text>` AGENTS.md
+block (heading, description, example) with:
+
+```markdown
+### Saving project notes
+
+Use the `carta_remember` MCP tool (or `carta remember "text" --type quirk`) to save durable
+project knowledge — surprising quirks, bug-investigation findings, helpful notes. Notes are
+written to docs/quirks/ or docs/notes/ (git-shareable) and are immediately searchable.
+```
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_cli.py carta/tests/test_bootstrap.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/cli.py carta/install/bootstrap.py carta/tests/test_cli.py
+git commit -m "feat(cli): carta remember command; AGENTS.md documents real capture surfaces"
+```
+
+---
+
+### Task 7: Recall labeling (`[quirk]` prefixes in search + hook)
+
+**Files:**
+- Modify: `carta/embed/pipeline.py:1613-1620` (text-hit dict gains `doc_type`)
+- Modify: `carta/cli.py` `cmd_search` result loop
+- Modify: `carta/hook/hook.py` `_inject`
+- Test: `carta/tests/test_pipeline.py`, `carta/hook/tests/test_hook.py` (append)
+
+- [ ] **Step 1: Write the failing tests.**
+
+Append to `carta/tests/test_pipeline.py` (inside `TestRunSearchRerankStats` is wrong scope —
+add a standalone test next to `TestRunSearch`, reusing the same mock pattern):
+
+```python
+class TestRunSearchDocType:
+    def test_text_hits_carry_doc_type_from_payload(self):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_search
+
+        point = MagicMock()
+        point.score = 0.9
+        point.payload = {"file_path": "docs/quirks/x.md", "text": "alpha",
+                         "doc_type": "quirk"}
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = MagicMock(points=[point])
+        cfg = {"project_name": "p", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "u", "ollama_model": "m", "colpali_enabled": False},
+               "search": {"top_n": 5}, "modules": {"doc_search": True}}
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=mock_client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.search.scoped.get_search_collections", return_value=["p_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_search("q", cfg)
+
+        assert results and results[0]["doc_type"] == "quirk"
+```
+
+Append to `carta/hook/tests/test_hook.py`:
+
+```python
+def test_inject_labels_note_hits():
+    """Recalled notes are labeled with their type so Claude can tell curated memory
+    from plain docs; plain docs stay unlabeled."""
+    hits = [
+        {"score": 0.92, "source": "docs/quirks/2026-06-11-psu.md",
+         "excerpt": "bench PSU must be on", "doc_type": "quirk"},
+        {"score": 0.91, "source": "docs/CAN/TOPOLOGY.md",
+         "excerpt": "two CAN buses", "doc_type": ""},
+    ]
+    cfg = _make_cfg()
+    with (
+        patch("sys.stdin", _stdin("query")),
+        patch("carta.hook.hook.find_config", return_value=Path("/fake/.carta/config.yaml")),
+        patch("carta.hook.hook.load_config", return_value=cfg),
+        patch("carta.hook.hook.run_search", return_value=hits),
+    ):
+        out = _capture_main()
+    data = json.loads(out.strip())
+    assert "[quirk] docs/quirks/2026-06-11-psu.md" in data["context"]
+    assert "[" not in data["context"].split("TOPOLOGY.md")[0].split("Source: ")[-1] or \
+           "Source: docs/CAN/TOPOLOGY.md" in data["context"]
+```
+
+(Simplify the second assertion to `assert "Source: docs/CAN/TOPOLOGY.md" in data["context"]`
+— the plain doc keeps its unprefixed form.)
+
+- [ ] **Step 2: Run to verify failure** — both new tests FAIL (`doc_type` key missing / no `[quirk]` label).
+
+- [ ] **Step 3: Implement.**
+
+`carta/embed/pipeline.py` — in the text-collection result loop (~line 1615), add the key:
+
+```python
+                    coll_results.append({
+                        "score": r.score,
+                        "source": payload.get("file_path", payload.get("slug", "")),
+                        "excerpt": payload.get("text", ""),
+                        "type": "text",
+                        "doc_type": payload.get("doc_type", ""),
+                    })
+```
+
+`carta/hook/hook.py` — extend the config import line to
+`from carta.config import find_config, load_config, NOTE_DOC_TYPES`, and in `_inject`:
+
+```python
+    context_lines = ["## Relevant documentation\n"]
+    for h in hits:
+        tag = f"[{h['doc_type']}] " if h.get("doc_type") in NOTE_DOC_TYPES else ""
+        context_lines.append(
+            f"**Source: {tag}{h['source']} (score: {h['score']:.2f})**\n"
+            f"> {h['excerpt'][:200]}\n"
+        )
+```
+
+`carta/cli.py` `cmd_search` — replace the result loop:
+
+```python
+    from carta.config import NOTE_DOC_TYPES
+    for r in results:
+        tag = f"[{r['doc_type']}] " if r.get("doc_type") in NOTE_DOC_TYPES else ""
+        print(f"[{r['score']:.2f}] {tag}{r['source']} — {r['excerpt']}")
+```
+
+- [ ] **Step 4: Run tests** — `python3 -m pytest carta/tests/test_pipeline.py carta/hook/tests/ carta/tests/test_cli.py -v` → all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/hook/hook.py carta/cli.py carta/tests/test_pipeline.py carta/hook/tests/test_hook.py
+git commit -m "feat(search,hook): label recalled notes ([quirk]/[bug-note]/[helpful-note])"
+```
+
+---
+
+### Task 8: README + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (new 0.10.0 section above 0.9.1)
+- Modify: `README.md` (new "Capturing notes" section; place it after the search/reranking material, before "Graph-aware retrieval" or another natural seam — read the surrounding structure first)
+
+- [ ] **Step 1: CHANGELOG** — insert above `## [0.9.1]`:
+
+```markdown
+## [0.10.0] — 2026-06-11
+
+### Added
+- **Note capture — the write side of session memory.** `carta_remember` (MCP tool) and
+  `carta remember` (CLI) save curated project knowledge as plain markdown files with
+  `doc_type` frontmatter — `quirk` → `docs/quirks/`, `bug-note`/`helpful-note` →
+  `docs/notes/` (paths configurable via `memory.quirks_dir`/`memory.notes_dir`) — and embed
+  them into `{project}_notes` through the standard pipeline. Notes are git-shareable repo
+  docs: they show up in `carta scan`/audit, export with `carta export`, and survive
+  re-embeds. Search results and proactive-recall injections label them (`[quirk] …`).
+- **Frontmatter `doc_type` override.** A `doc_type:` key in markdown frontmatter now wins
+  over parent-directory inference, and `quirks/` / `notes/` directories map to note types —
+  hand-written notes route correctly on (re-)embed.
+
+### Fixed
+- **`collection_for_doc_type` was dead code — note types never reached `_notes`.**
+  `upsert_chunks` hardcoded the `_doc` collection; it now routes by the batch's doc_type.
+  `carta init` creates `{project}_notes` (instead of the never-used `_quirk`); existing
+  projects need no migration — the collection is auto-created on first capture.
+```
+
+- [ ] **Step 2: README** — add a section (and a one-line mention in the features/skills table if one lists capabilities):
+
+```markdown
+### Capturing notes (quirks, bug notes, helpful notes)
+
+The write side of session memory. When you (or Claude) learn something durable about the
+project, save it:
+
+​```bash
+carta remember "EZKontrol bench tests silently fail unless motor CAN is powered" \
+  --type quirk --title "EZKontrol bench power" --tags can,bench
+​```
+
+or from Claude via the `carta_remember` MCP tool. Notes are plain markdown files with
+`doc_type` frontmatter — `quirk` → `docs/quirks/`, `bug-note`/`helpful-note` → `docs/notes/`
+(configurable via `memory.quirks_dir` / `memory.notes_dir`) — embedded into
+`{project}_notes` and retrieved by the same hybrid search, reranker, and proactive-recall
+hook as your docs. Search output labels them: `[quirk] docs/quirks/2026-06-11-….md`.
+
+Notes are knowledge artifacts, not tool state: git-shareable, audited by `carta scan`
+(staleness, links), exported by `carta export`, and still useful if you remove Carta.
+Hand-written files work too — drop a markdown file in `docs/quirks/` (or set
+`doc_type: quirk` in frontmatter anywhere) and `carta embed` routes it correctly.
+```
+
+(Strip the zero-width characters around the inner code fence when inserting.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: README + CHANGELOG for 0.10.0 note capture"
+```
+
+---
+
+### Task 9: Full suite, review, live validation, release
+
+- [ ] **Step 1: Full suite** — `python3 -m pytest carta/ -q` → all pass (baseline 770 passed, 2 skipped + new tests).
+- [ ] **Step 2: Final code review** of `git diff main...HEAD` (superpowers:requesting-code-review); fix findings.
+- [ ] **Step 3: Live validation** (in this repo, which has a live `.carta` + Qdrant):
+  - `PYTHONPATH=<worktree> ~/.local/pipx/venvs/carta-cc/bin/python -m carta remember "test quirk from live validation" --type quirk --title "Live validation quirk"` → file in `docs/quirks/`, output names `doc-audit-cc_notes`.
+  - Verify vectors: scroll `doc-audit-cc_notes` for the new file_path.
+  - `... -m carta search "live validation quirk"` → result labeled `[quirk]`.
+  - Remove the test note file + its sidecar and delete the test points (or leave the note if it documents something real).
+- [ ] **Step 4: Release** — push branch, open PR (`gh pr create`), wait CI green, squash-merge, `git -C /Users/ian/dev/doc-audit-cc pull`, tag `v0.10.0` on the merge commit, push tag, watch release.yml, verify PyPI `carta-cc` 0.10.0 + GitHub Release, `pipx install --force carta-cc==0.10.0`.

--- a/docs/superpowers/specs/2026-06-10-note-capture-design.md
+++ b/docs/superpowers/specs/2026-06-10-note-capture-design.md
@@ -70,28 +70,40 @@ def capture_note(cfg: dict, repo_root: Path, text: str, *,
 - File content: YAML frontmatter (`doc_type`, `title`, `created` ISO date, `tags` when
   given) + blank line + `text` verbatim.
 - Embeds via the existing `run_embed_file(path, cfg)` (pipeline.py:1035) — sidecar stub,
-  chunking, upsert all reuse the standard pipeline.
-- **Ensures the target Qdrant collection exists** before embedding (so capture works on
-  projects bootstrapped before this release, without re-init).
+  chunking, upsert all reuse the standard pipeline. (Collection auto-creation is already
+  handled by `ensure_collection()` inside `upsert_chunks` — no extra plumbing.)
 - Returns `{"path": <repo-relative>, "collection": <name>, "chunks": <int>}`; raises with a
   clear message on failure (callers map to their error shape). If embedding fails after the
   file was written, the file is kept and the error says so — the note is not lost, and a
   later `carta embed` picks it up.
 
-### 2. Prerequisite fix: frontmatter `doc_type` override (induct.py)
+### 2. Prerequisite fixes: doc_type routing end-to-end
 
-- `generate_sidecar_stub()` / doc-type inference: a `doc_type:` key in the file's YAML
-  frontmatter **wins** over parent-directory inference.
-- Add `quirks` → `quirk` and `notes` → `helpful-note` to `_PATH_TYPE_MAP` so
-  frontmatter-less hand-written files in those directories route correctly on (re-)embed.
-- Existing behavior unchanged for files with neither frontmatter nor a mapped parent.
+Planning investigation found the routing gap is wider than bootstrap — `collection_for_doc_type`
+(config.py:150) is currently **dead code**; nothing in the embed path calls it. Three fixes:
 
-### 3. Prerequisite fix: `_notes` collection (bootstrap + doctor)
+- **Frontmatter override (induct.py):** a `doc_type:` key in a markdown file's YAML
+  frontmatter **wins** over parent-directory inference (reuses `scanner.parse_frontmatter`).
+  Add `quirks` → `quirk` and `notes` → `helpful-note` to `_PATH_TYPE_MAP` so frontmatter-less
+  hand-written files route correctly. Existing behavior unchanged otherwise. The sidecar
+  stub's informational `collection` field uses `collection_for_doc_type` instead of
+  hardcoded `_doc`.
+- **Upsert routing (embed.py:184):** `upsert_chunks` hardcodes
+  `coll_name = collection_name(cfg, "doc")`; change to
+  `collection_for_doc_type(cfg, chunks[0].get("doc_type", "unknown"))` (batches are
+  per-file, hence doc_type-homogeneous; image/visual doc_types still map to `_doc`, so all
+  current behavior is preserved except note types, which now route to `_notes`).
+- **Bootstrap (bootstrap.py:13,359,255):** create `["doc", "session", "notes"]` (replacing
+  `quirk` in the list and in `VECTOR_DIMENSIONS`; `_session` stays — deployed projects have
+  it and scoped search lists it). Update the success-message string.
 
-- Bootstrap creates `["doc", "session", "notes"]` (replacing `quirk` in the list; `_session`
-  stays — it exists in deployed projects and scoped search lists it).
-- `carta doctor`: new check — if `{project}_notes` is missing, create it (report as a fix);
-  if a legacy empty `{project}_quirk` exists, report it as removable (do not auto-delete).
+### 3. Migration: none needed
+
+`ensure_collection()` inside `upsert_chunks` auto-creates missing collections with the
+correct schema, so the first capture on a pre-0.10.0 project creates `{project}_notes`
+automatically. Legacy `{project}_quirk` collections are inert empties (the old routing never
+wrote to them) and can be ignored or manually deleted. No doctor check is added (YAGNI —
+revisit only if real confusion shows up).
 
 ### 4. Surfaces
 
@@ -102,6 +114,8 @@ def capture_note(cfg: dict, repo_root: Path, text: str, *,
 - **CLI**: `carta remember "text..." --type quirk --title "..." --tags a,b` — prints the
   created path and collection; exit 1 with stderr message on error. Registered in the
   existing subparser block (cli.py).
+- **Bootstrap AGENTS.md text** (bootstrap.py:487): replace the phantom `/session-memory`
+  skeleton with guidance for the real `carta_remember` MCP tool / `carta remember` CLI.
 
 ### 5. Recall labeling
 
@@ -128,9 +142,10 @@ TDD per component:
   collision suffixing; type→directory routing; invalid type/empty text rejected; collection
   ensured when missing; embed failure keeps the file and reports.
 - **induct**: frontmatter doc_type beats path inference; `quirks/`/`notes/` path mapping;
-  no frontmatter + unmapped path ⇒ unchanged behavior.
-- **bootstrap/doctor**: collection list includes `notes`, not `quirk`; doctor creates
-  missing `_notes`, flags legacy `_quirk`.
+  no frontmatter + unmapped path ⇒ unchanged behavior; stub collection field routed.
+- **upsert routing**: chunks with doc_type quirk/bug-note/helpful-note upsert into
+  `{project}_notes`; plain docs and image/visual chunks still go to `{project}_doc`.
+- **bootstrap**: collection list includes `notes`, not `quirk`.
 - **MCP + CLI wiring**: happy path and error shape for both surfaces.
 - **labeling**: hook injection and search output prefix `[quirk]` etc.; plain docs
   unaffected.

--- a/docs/superpowers/specs/2026-06-10-note-capture-design.md
+++ b/docs/superpowers/specs/2026-06-10-note-capture-design.md
@@ -59,6 +59,12 @@ def capture_note(cfg: dict, repo_root: Path, text: str, *,
     quirks_dir: docs/quirks      # note_type: quirk
     notes_dir: docs/notes        # note_type: bug-note, helpful-note
   ```
+  **Repo footprint policy (recorded rationale):** knowledge artifacts are content-named and
+  blend into the user's docs tree (like `docs/adr/` convention; they must remain useful if
+  Carta is removed — hence generic `doc_type:` frontmatter, not a carta-branded schema or a
+  `docs/carta/` namespace). Tool artifacts stay contained in the single `.carta/` machine
+  dir (the sidecar-relocation precedent). Containment-minded users can point these config
+  keys at a namespaced dir. Nothing new is ever added at repo root.
 - Filename `YYYY-MM-DD-<slug>.md` — slug from `title` (or first ~6 words of `text`),
   lowercase kebab-case; on collision append `-2`, `-3`, …
 - File content: YAML frontmatter (`doc_type`, `title`, `created` ISO date, `tags` when

--- a/docs/superpowers/specs/2026-06-10-note-capture-design.md
+++ b/docs/superpowers/specs/2026-06-10-note-capture-design.md
@@ -1,0 +1,141 @@
+# Note Capture — Quirks & Notes (v0.10.0) — Design
+
+**Date:** 2026-06-10
+**Status:** Approved (design discussed and trimmed in session)
+**Target version:** 0.10.0 (new feature surface)
+
+## Problem
+
+Carta's pitch is "documentation **and session memory**," and the read side exists — the
+`{project}_notes` collection is searched by scoped search, quirk/bug-note/helpful-note are
+`PROTECTED_DOC_TYPES` in lifecycle cleanup — but **nothing can write a note**. There is no MCP
+tool, CLI command, or skill that records a piece of knowledge and embeds it. Hand-writing a
+quirk file doesn't work either, because of two pre-existing bugs:
+
+1. **Collection mismatch:** `collection_for_doc_type()` (config.py:150) routes
+   quirk/bug-note/helpful-note → `{project}_notes`, but bootstrap
+   (install/bootstrap.py:359) creates `{project}_quirk` and never creates `_notes`.
+2. **No frontmatter doc_type:** `infer_doc_type()` (induct.py:37) only maps parent
+   directories (`datasheets/`, `manuals/`, `reference/`, `specs/`, `guides/`); a hand-written
+   `docs/quirks/*.md` file infers `"unknown"` and lands in `_doc` (this happened in the
+   ET-embed deployment).
+
+## Positioning (why this and not claude-mem / Claude Code built-in memory)
+
+Three memory systems coexist and must stay in **disjoint content lanes**:
+
+| Lane | System | Content |
+|---|---|---|
+| What happened | claude-mem (personal, machine-local, auto) | Session history, observations |
+| How to work with the user | Claude Code built-in memory | Preferences, feedback |
+| **What's true about the project** | **Carta notes (this feature)** | Curated facts: quirks, bug notes, helpful notes |
+
+Carta notes are **repo-resident markdown files** — git-versioned, team-shared (via git or
+`carta export`), retrieved by the *same* hybrid search/reranker/hook as the project docs,
+and maintained by `carta scan`/audit. The capture flow is a **promotion** ("graduation")
+model: a discovery starts as ephemeral session history; when it proves durable, it is
+promoted once into a Carta note and becomes project truth. This *reduces* cross-tool
+duplication over time rather than adding a parallel store.
+
+**Out of scope (explicitly):** a `session` note type (cut — session history is claude-mem's
+lane; `modules.session_memory` remains a dormant placeholder for a possible future Stop-hook
+auto-capture, which is a separate design problem). No automatic capture this cycle. No
+coupling to claude-mem.
+
+## Design
+
+### 1. Core: `carta/memory/capture.py`
+
+```python
+def capture_note(cfg: dict, repo_root: Path, text: str, *,
+                 note_type: str, title: str = "", tags: list[str] | None = None) -> dict
+```
+
+- Validates `note_type` ∈ {`quirk`, `bug-note`, `helpful-note`} (ValueError otherwise) and
+  rejects empty/whitespace `text`.
+- Destination directories from a new `memory:` config block (deep-merged defaults):
+  ```yaml
+  memory:
+    quirks_dir: docs/quirks      # note_type: quirk
+    notes_dir: docs/notes        # note_type: bug-note, helpful-note
+  ```
+- Filename `YYYY-MM-DD-<slug>.md` — slug from `title` (or first ~6 words of `text`),
+  lowercase kebab-case; on collision append `-2`, `-3`, …
+- File content: YAML frontmatter (`doc_type`, `title`, `created` ISO date, `tags` when
+  given) + blank line + `text` verbatim.
+- Embeds via the existing `run_embed_file(path, cfg)` (pipeline.py:1035) — sidecar stub,
+  chunking, upsert all reuse the standard pipeline.
+- **Ensures the target Qdrant collection exists** before embedding (so capture works on
+  projects bootstrapped before this release, without re-init).
+- Returns `{"path": <repo-relative>, "collection": <name>, "chunks": <int>}`; raises with a
+  clear message on failure (callers map to their error shape). If embedding fails after the
+  file was written, the file is kept and the error says so — the note is not lost, and a
+  later `carta embed` picks it up.
+
+### 2. Prerequisite fix: frontmatter `doc_type` override (induct.py)
+
+- `generate_sidecar_stub()` / doc-type inference: a `doc_type:` key in the file's YAML
+  frontmatter **wins** over parent-directory inference.
+- Add `quirks` → `quirk` and `notes` → `helpful-note` to `_PATH_TYPE_MAP` so
+  frontmatter-less hand-written files in those directories route correctly on (re-)embed.
+- Existing behavior unchanged for files with neither frontmatter nor a mapped parent.
+
+### 3. Prerequisite fix: `_notes` collection (bootstrap + doctor)
+
+- Bootstrap creates `["doc", "session", "notes"]` (replacing `quirk` in the list; `_session`
+  stays — it exists in deployed projects and scoped search lists it).
+- `carta doctor`: new check — if `{project}_notes` is missing, create it (report as a fix);
+  if a legacy empty `{project}_quirk` exists, report it as removable (do not auto-delete).
+
+### 4. Surfaces
+
+- **MCP tool** (mcp/server.py, FastMCP decorator pattern, alongside `carta_search`):
+  `carta_remember(text: str, note_type: str = "helpful-note", title: str = "", tags: list[str] | None = None) -> dict`
+  — returns the capture_note result or `{"error", "detail"}` matching the existing tools'
+  error shape. Docstring guides the model on when to use which note_type.
+- **CLI**: `carta remember "text..." --type quirk --title "..." --tags a,b` — prints the
+  created path and collection; exit 1 with stderr message on error. Registered in the
+  existing subparser block (cli.py).
+
+### 5. Recall labeling
+
+Search results and hook-injected context label note-typed hits so recalled memory is
+distinguishable from docs: `**Source: [quirk] docs/quirks/2026-06-10-….md (score: 0.91)**`.
+Implementation: `run_search` already builds hit dicts from Qdrant payloads — include the
+payload's `doc_type` in the hit dict; `cmd_search` output and hook `_inject()` prefix
+`[<doc_type>]` for doc_types in {quirk, bug-note, helpful-note}. No change for plain docs.
+
+### 6. Lifecycle / compatibility
+
+- quirk/bug-note/helpful-note are already `PROTECTED_DOC_TYPES` — vectors survive source
+  deletion (existing behavior, now reachable).
+- `docs/quirks/` & `docs/notes/` are inside `docs_root`, so normal `carta embed` discovery,
+  staleness scanning, and the audit cover captured notes with zero extra plumbing.
+- `carta export`/`import` already include `_notes` by prefix discovery.
+- `modules.session_memory` untouched (dormant).
+
+## Testing
+
+TDD per component:
+
+- **capture core**: file written with exact frontmatter shape; slug from title vs text;
+  collision suffixing; type→directory routing; invalid type/empty text rejected; collection
+  ensured when missing; embed failure keeps the file and reports.
+- **induct**: frontmatter doc_type beats path inference; `quirks/`/`notes/` path mapping;
+  no frontmatter + unmapped path ⇒ unchanged behavior.
+- **bootstrap/doctor**: collection list includes `notes`, not `quirk`; doctor creates
+  missing `_notes`, flags legacy `_quirk`.
+- **MCP + CLI wiring**: happy path and error shape for both surfaces.
+- **labeling**: hook injection and search output prefix `[quirk]` etc.; plain docs
+  unaffected.
+
+**Live validation:** in a real project, `carta_remember` a quirk via MCP and one via CLI;
+confirm file lands in `docs/quirks/`, vectors in `{project}_notes`, `carta search` returns
+it labeled, and the hook surfaces it for a related prompt.
+
+## Out of scope
+
+- `session` note type, Stop-hook auto-capture, claude-mem bridges (`carta distill`).
+- Plugin skill (`/remember`) — revisit after the MCP/CLI UX settles.
+- Note editing/deletion commands (files are plain markdown; edit with any editor,
+  re-embed handles updates).


### PR DESCRIPTION
## Summary

Closes the session/quirk capture loop — the write side of Carta's memory. Until now the `_notes` collection was searched but nothing could write to it (and three routing bugs meant nothing ever would have).

- **`carta/memory/capture.py`** — `capture_note` writes a frontmatter'd markdown note (`quirk` → `docs/quirks/`, `bug-note`/`helpful-note` → `docs/notes/`; configurable via `memory.quirks_dir`/`notes_dir`) and embeds it through the standard pipeline. Notes are knowledge artifacts per the repo footprint policy: git-shareable, audited by `carta scan`, exported by `carta export`, useful without Carta.
- **Surfaces:** `carta_remember` MCP tool (Claude captures mid-session) + `carta remember` CLI. Bootstrap's AGENTS.md now documents the real surfaces instead of the phantom `/session-memory`.
- **Routing fixes (pre-existing bugs):** frontmatter `doc_type:` now overrides parent-dir inference (+ `quirks/`/`notes/` path mapping); `upsert_chunks` routes by doc_type — `collection_for_doc_type` was dead code, hardcoded to `_doc`; bootstrap creates `{project}_notes` instead of the never-used `_quirk`. No migration needed: `ensure_collection` auto-creates `_notes` on first capture.
- **Recall labeling:** search results and hook injections prefix note hits — `[quirk] docs/quirks/…`.

## Live validation (dogfooded)

Captured a real quirk in this repo via the new CLI: file written with exact frontmatter, `doc-audit-cc_notes` auto-created on a pre-0.10.0 project (zero-migration path proven), and `carta search` returned it at rank 1 labeled `[quirk]`. The note ships in this PR (`docs/quirks/2026-06-11-pypi-index-lag-after-release-tagging.md`).

## Test plan

- 798 passed, 2 skipped locally (28 new tests: 6 induct, 5 upsert routing, 1 bootstrap, 8 capture core, 3 MCP, 3 CLI, 2 labeling)
- Per-task spec + quality reviews, final whole-branch integration review (2 follow-up fixes applied: visual-hit doc_type, constant cross-refs)
- Live end-to-end validation above

🤖 Generated with [Claude Code](https://claude.com/claude-code)