### PR TITLE
Data integrity: path-based point IDs, empty-chunk guard, doctor/repair (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to **carta-cc** are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.0] — 2026-06-12
+
+### Fixed
+- **Point-ID collision (data loss).** Point IDs were hashed from the filename stem only, so
+  two files with the same stem (e.g. multiple `README.md` in different subdirectories) silently
+  overwrote each other's Qdrant points on every embed. IDs now hash the repo-relative file path;
+  visual page IDs fixed identically.
+- **Stale-generation cleanup.** Re-embeds stamped old points `stale` but left them searchable
+  forever. Old-generation points are now deleted after a **complete** upsert; partial upserts
+  keep the previous generation and print a warning. Pass-2 OCR chunks carry the file's
+  generation; `visual_done` resets on content change so affected pages re-queue.
+- **Empty-chunk guard.** PDF extraction failures produced points with identical
+  embedding-of-empty-string vectors (1,400+ observed in a real corpus). Empty chunks are dropped
+  at upsert; files yielding zero usable text are flagged `extraction_failed` with a loud warning
+  and counted separately in the embed summary.
+- **Sidecar status bookkeeping.** A successful re-embed now ends with `status: embedded`
+  instead of permanently `stale` (169/971 sidecars stuck in a real corpus). `carta embed FILE`
+  (force) now truly re-embeds even when the file hash is unchanged.
+
+### Added
+- **`carta doctor` corpus-integrity section.** Detects slug collisions, empty-text points,
+  sidecar/Qdrant chunk-count mismatches, and stuck-stale sidecars; findings merged into
+  doctor's JSON output alongside the existing environment checks.
+- **`carta embed --repair`.** Purges and force re-embeds files with integrity issues; fixes
+  stuck-stale sidecars in place. Summary distinguishes: repaired / purged / flagged
+  `extraction_failed` / queued-for-visual / failed.
+
 ## [0.10.0] — 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -466,6 +466,34 @@ carta embed --visual
 
 ---
 
+## Corpus integrity
+
+`carta doctor` includes a corpus-integrity section that checks your embedded knowledge base for
+data-quality issues — no Ollama calls required:
+
+- **Slug collisions** — multiple files with the same filename stem that would have silently
+  overwritten each other's Qdrant points (fixed in the embed pipeline; doctor flags any legacy cases).
+- **Empty-text points** — points stored with an embedding-of-empty-string (common after PDF
+  extraction failures) that are unfindable in practice.
+- **Chunk-count mismatches** — sidecar says N chunks but Qdrant holds a different count, indicating
+  a partial embed.
+- **Stuck-stale sidecars** — files whose sidecar never transitioned back to `embedded` after a
+  successful re-embed.
+
+Findings are included in `carta doctor`'s JSON output alongside the existing environment checks.
+
+**Repairing a corpus:**
+
+```bash
+carta embed --repair
+```
+
+Purges and force re-embeds all files flagged by the integrity checks, and fixes stuck-stale sidecars
+in place. The summary reports: repaired / purged / flagged `extraction_failed` / queued-for-visual /
+failed.
+
+---
+
 ## Status-line progress widget
 
 While `carta embed` runs, it writes `.carta/embed-status.json` with live progress. The `carta statusline` command reads that file and prints a compact segment for the Claude Code status line:

--- a/carta/__init__.py
+++ b/carta/__init__.py
@@ -3,4 +3,4 @@ from carta._compat import apply_macos_blas_workaround as _apply_macos_blas_worka
 
 _apply_macos_blas_workaround()
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -483,10 +483,10 @@ def cmd_doctor(args):
     except Exception:
         cfg_path = None
     if cfg_path is not None:
+        import json as _json
         try:
             from carta.config import load_config
             from carta.embed.integrity import scan_corpus_integrity
-            import json as _json
             cfg = load_config(cfg_path)
             repo_root = cfg_path.parent.parent
             report = scan_corpus_integrity(cfg, repo_root)
@@ -515,7 +515,6 @@ def cmd_doctor(args):
             if args.json:
                 # Still emit one valid JSON document; note the skipped check
                 # instead of leaving consumers with empty stdout.
-                import json as _json
                 doc = result.to_dict()
                 doc["corpus_integrity"] = {"skipped": str(e)}
                 print(_json.dumps(doc, indent=2))

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -454,10 +454,8 @@ def cmd_doctor(args):
     checker = PreflightChecker(interactive=interactive, verbose=args.verbose, project_root=Path.cwd())
     result = checker.run()
 
-    # Print report
-    if args.json:
-        print(result.to_json())
-    else:
+    # Print human-readable report (JSON deferred until after corpus-integrity merge)
+    if not args.json:
         result.print_report(verbose=args.verbose)
 
     # Offer to fix fixable failures (always interactive, --fix just auto-confirms)
@@ -478,6 +476,47 @@ def cmd_doctor(args):
             result.print_report(verbose=args.verbose)
     elif args.fix and not args.json:
         print("\n✅ No fixable issues found.")
+
+    # Corpus integrity (project-scoped, read-only). Never break doctor itself.
+    try:
+        cfg_path = find_config()
+    except Exception:
+        cfg_path = None
+    if cfg_path is not None:
+        try:
+            from carta.config import load_config
+            from carta.embed.integrity import scan_corpus_integrity
+            import json as _json
+            cfg = load_config(cfg_path)
+            repo_root = cfg_path.parent.parent
+            report = scan_corpus_integrity(cfg, repo_root)
+            if args.json:
+                doc = result.to_dict()
+                doc["corpus_integrity"] = report
+                print(_json.dumps(doc, indent=2))
+            else:
+                print("\n📦 Corpus integrity")
+                if not report["affected_files"] and not report["stuck_stale"]:
+                    print("  ✅ no issues found")
+                else:
+                    for slug, files in report["slug_collisions"].items():
+                        print(f"  ⚠️  slug collision '{slug}': {', '.join(files)}")
+                    for fp in report["empty_files"]:
+                        print(f"  ⚠️  all chunks empty: {fp}")
+                    for fp, n in report["partial_empty_files"].items():
+                        print(f"  ⚠️  {n} empty chunk(s): {fp}")
+                    for fp, c in report["count_mismatches"].items():
+                        print(f"  ⚠️  count mismatch: {fp} (sidecar {c['sidecar']} vs qdrant {c['qdrant']})")
+                    if report["stuck_stale"]:
+                        print(f"  ⚠️  {len(report['stuck_stale'])} sidecar(s) stuck 'stale' with unchanged files")
+                    print(f"  → run `carta embed --repair` to fix "
+                          f"({len(report['affected_files'])} file(s) affected)")
+        except Exception as e:
+            if not getattr(args, "json", False):
+                print(f"\n📦 Corpus integrity: check skipped ({e})")
+    elif args.json:
+        # Outside a project: emit the preflight JSON with no corpus_integrity key
+        print(result.to_json())
 
     # Exit with error code if critical failures remain
     if not result.can_proceed():

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -512,7 +512,14 @@ def cmd_doctor(args):
                     print(f"  → run `carta embed --repair` to fix "
                           f"({len(report['affected_files'])} file(s) affected)")
         except Exception as e:
-            if not getattr(args, "json", False):
+            if args.json:
+                # Still emit one valid JSON document; note the skipped check
+                # instead of leaving consumers with empty stdout.
+                import json as _json
+                doc = result.to_dict()
+                doc["corpus_integrity"] = {"skipped": str(e)}
+                print(_json.dumps(doc, indent=2))
+            else:
                 print(f"\n📦 Corpus integrity: check skipped ({e})")
     elif args.json:
         # Outside a project: emit the preflight JSON with no corpus_integrity key

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -193,6 +193,15 @@ def cmd_embed(args):
     if timeout_override is not None:
         cfg.setdefault("embed", {})["file_timeout_s"] = timeout_override
 
+    # --repair: detect and fix corpus-integrity issues, then exit.
+    # `is True` (not `if args.repair`) — rejects truthy MagicMocks in tests.
+    if getattr(args, "repair", False) is True:
+        from carta.embed.repair import run_repair
+        repo_root = cfg_path.parent.parent
+        summary = run_repair(repo_root, cfg, verbose=True)
+        _notify_if_update(cfg_path, cfg)
+        sys.exit(1 if summary["failed"] else 0)
+
     # --visual: slow pass-2 drainer — OCR text + ColPali per pending page, then exit.
     # `is True` (not `if args.visual`) — rejects truthy MagicMocks in tests.
     if getattr(args, "visual", False) is True:
@@ -732,6 +741,12 @@ def main():
         "--visual",
         action="store_true",
         help="Run the slow visual pass: drain visual_pending pages (OCR text + ColPali).",
+    )
+    embed_p.add_argument(
+        "--repair",
+        action="store_true",
+        help="Detect and repair corpus-integrity issues (point-ID collisions, "
+             "empty chunks, count mismatches), then exit.",
     )
 
     audit_p = sub.add_parser(

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -269,6 +269,14 @@ def cmd_embed(args):
         skipped=summary["skipped"],
         errors=len(summary["errors"]),
     )
+    failed_extractions = summary.get("extraction_failed", 0)
+    if failed_extractions:
+        print(
+            f"\nWarning: {failed_extractions} file(s) yielded no extractable text "
+            f"(scanned PDFs? OCR may be required) — flagged extraction_failed, "
+            f"nothing embedded for them.",
+            file=sys.stderr,
+        )
     timed_out = summary.get("timed_out", [])
     if timed_out:
         current = cfg.get("embed", {}).get("file_timeout_s", 600)

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -2,6 +2,7 @@
 
 import concurrent.futures
 import hashlib
+import sys
 import uuid
 
 import requests
@@ -173,7 +174,8 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
 
     Args:
         chunks: list of chunk dicts with at minimum keys:
-            "slug", "text", "chunk_index".
+            "slug", "text", "chunk_index"; "file_path" (repo-relative) should
+            also be set — it is the primary point-ID key (slug is a fallback).
             Any additional keys are stored as Qdrant payload.
         cfg: carta config dict (must contain qdrant_url, embed.ollama_url,
              embed.ollama_model, and project_name).
@@ -202,19 +204,28 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     is_hybrid = collection_is_hybrid(client, coll_name)
 
     def build_point(chunk: dict, vec: list[float]) -> PointStruct:
+        # The payload's doc_generation and the generation baked into the point
+        # ID must agree — generation cleanup deletes by payload value.
+        generation = chunk.get("doc_generation", 1)
         payload = {k: v for k, v in chunk.items() if k != "text"}
         payload["text"] = chunk["text"]
-        payload["doc_generation"] = chunk.get("doc_generation", 1)
+        payload["doc_generation"] = generation
         payload["stale_as_of"] = None
         payload["superseded_at"] = None
         payload["orphaned_at"] = None
         payload["sidecar_id"] = chunk.get("sidecar_id", "")
         payload["chunk_source_hash"] = chunk.get("chunk_source_hash", "")
 
-        id_key = chunk.get("file_path") or chunk["slug"]
-        point_id = _point_id_versioned(
-            id_key, chunk["chunk_index"], chunk.get("doc_generation", 1)
-        )
+        id_key = chunk.get("file_path")
+        if not id_key:
+            # Slug-keyed IDs collide across same-stem files; make a regression loud.
+            print(
+                f"Warning: chunk {chunk.get('slug', '?')}[{chunk.get('chunk_index', '?')}] "
+                f"has no file_path — falling back to slug-keyed point ID",
+                file=sys.stderr, flush=True,
+            )
+            id_key = chunk["slug"]
+        point_id = _point_id_versioned(id_key, chunk["chunk_index"], generation)
 
         if is_hybrid:
             from carta.embed.sparse import embed_sparse_document

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -191,7 +191,7 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     chunks = [c for c in chunks if (c.get("text") or "").strip()]
     n_dropped = n_total - len(chunks)
     if n_dropped:
-        src = chunks[0].get("file_path") if chunks else original_chunks[0].get("file_path", "(unknown)")
+        src = (chunks[0] if chunks else original_chunks[0]).get("file_path", "(unknown)")
         print(
             f"Warning: dropped {n_dropped} empty chunk(s) for {src} — "
             f"extraction produced no text for them",

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -184,6 +184,22 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     Returns:
         Number of points upserted.
     """
+    # Drop empty/whitespace-only chunks before doing any work. Empty chunks produce
+    # identical embedding-of-empty-string vectors — unfindable noise in the index.
+    n_total = len(chunks)
+    original_chunks = chunks  # keep reference for warning message when all are empty
+    chunks = [c for c in chunks if (c.get("text") or "").strip()]
+    n_dropped = n_total - len(chunks)
+    if n_dropped:
+        src = chunks[0].get("file_path") if chunks else original_chunks[0].get("file_path", "(unknown)")
+        print(
+            f"Warning: dropped {n_dropped} empty chunk(s) for {src} — "
+            f"extraction produced no text for them",
+            flush=True,
+        )
+    if not chunks:
+        return 0
+
     # Route by the batch's doc_type (batches come from a single file, so they are
     # doc_type-homogeneous). Note types (quirk/bug-note/helpful-note) land in
     # {project}_notes; everything else (incl. image/visual chunk types) stays in _doc.

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -151,19 +151,20 @@ def collection_is_hybrid(client: QdrantClient, coll_name: str) -> bool:
     return has_named_dense and has_sparse
 
 
-def _point_id(slug: str, chunk_index: int) -> str:
-    """Deterministic UUID from slug + chunk_index for idempotent upserts."""
-    raw = f"{slug}:{chunk_index}"
+def _point_id_versioned(key: str, chunk_index: int, generation: int) -> str:
+    """Deterministic UUID from key + chunk_index + generation.
+
+    `key` is the repo-relative file_path (collision-free); legacy points used
+    the filename-stem slug, which collided across same-stem files. Different
+    generations produce different UUIDs, enabling retries without collisions.
+    """
+    raw = f"{key}:{chunk_index}:g{generation}"
     return str(uuid.UUID(hashlib.md5(raw.encode()).hexdigest()))
 
 
-def _point_id_versioned(slug: str, chunk_index: int, generation: int) -> str:
-    """Deterministic UUID from slug + chunk_index + generation for generation-aware upserts.
-
-    Used when chunks carry doc_generation metadata (Plan 999.1-02+).
-    Different generations produce different UUIDs, enabling retries without collisions.
-    """
-    raw = f"{slug}:{chunk_index}:g{generation}"
+def _visual_point_id(key: str, page_num: int) -> str:
+    """Deterministic UUID for visual page embeddings, keyed by file path."""
+    raw = f"{key}:visual:{page_num}"
     return str(uuid.UUID(hashlib.md5(raw.encode()).hexdigest()))
 
 
@@ -210,12 +211,10 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
         payload["sidecar_id"] = chunk.get("sidecar_id", "")
         payload["chunk_source_hash"] = chunk.get("chunk_source_hash", "")
 
-        if chunk.get("doc_generation") is not None:
-            point_id = _point_id_versioned(
-                chunk["slug"], chunk["chunk_index"], chunk["doc_generation"]
-            )
-        else:
-            point_id = _point_id(chunk["slug"], chunk["chunk_index"])
+        id_key = chunk.get("file_path") or chunk["slug"]
+        point_id = _point_id_versioned(
+            id_key, chunk["chunk_index"], chunk.get("doc_generation", 1)
+        )
 
         if is_hybrid:
             from carta.embed.sparse import embed_sparse_document
@@ -309,20 +308,6 @@ def ensure_visual_collection(client: QdrantClient, coll_name: str) -> None:
         )
 
 
-def _visual_point_id(slug: str, page_num: int) -> str:
-    """Deterministic UUID for visual page embeddings.
-
-    Args:
-        slug: Document slug identifier.
-        page_num: 1-indexed page number.
-
-    Returns:
-        UUID string for the point ID.
-    """
-    raw = f"{slug}:visual:{page_num}"
-    return str(uuid.UUID(hashlib.md5(raw.encode()).hexdigest()))
-
-
 def upsert_visual_pages(
     pages: list[dict],
     cfg: dict,
@@ -376,7 +361,8 @@ def upsert_visual_pages(
             }
             payload["doc_type"] = page.get("doc_type", "visual_page")
 
-            point_id = _visual_point_id(page["slug"], page["page_num"])
+            id_key = page.get("file_path") or page["slug"]
+            point_id = _visual_point_id(id_key, page["page_num"])
 
             point = PointStruct(
                 id=point_id,

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -92,13 +92,20 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
     sidecars_root = repo_root / ".carta" / "sidecars"
     if sidecars_root.exists():
         for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
-            sc = read_sidecar(sc_path) or {}
+            sc = read_sidecar(sc_path)
+            if not isinstance(sc, dict):
+                # Corrupt sidecar (valid YAML but not a mapping) — one bad file
+                # must not blind the whole scan.
+                continue
             rel = sc.get("current_path")
             if not rel:
                 continue
 
             status = sc.get("status")
-            qdrant_count = per_file_counts.get(rel)
+            # Missing entry means ZERO surviving points — a fully-lost file
+            # (e.g. every chunk shadowed by a legacy ID collision) is the
+            # strongest mismatch of all, not an exemption.
+            qdrant_count = per_file_counts.get(rel, 0)
             sidecar_count = sc.get("chunk_count")
 
             # Stuck-stale: status is "stale" but file hash matches disk — a bug
@@ -120,7 +127,6 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
             # sidecars (hash differs) are expected to be out of sync and exempt.
             if (
                 (status == "embedded" or is_stuck)
-                and qdrant_count is not None
                 and sidecar_count is not None
                 and sidecar_count != qdrant_count
             ):

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -1,0 +1,139 @@
+"""Corpus-integrity scanning: detect point-ID collisions, empty-text points,
+sidecar/Qdrant count mismatches, and stuck-stale sidecars.
+
+Read-only — used by `carta doctor` (report) and `carta embed --repair`
+(which re-embeds/purges what this module finds).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from qdrant_client import QdrantClient
+
+from carta.config import collection_name
+from carta.embed.lifecycle import compute_file_hash
+from carta.embed.induct import read_sidecar
+
+
+def _scroll_all(client, coll: str):
+    """Yield every point payload in a collection (no vectors)."""
+    offset = None
+    while True:
+        points, offset = client.scroll(
+            coll, limit=1000, offset=offset, with_payload=True, with_vectors=False
+        )
+        for p in points:
+            yield p.payload or {}
+        if offset is None:
+            return
+
+
+def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
+    """Scan the project's _doc collection and sidecars for integrity issues.
+
+    Args:
+        cfg:       Carta config dict (must contain project_name, qdrant_url).
+        repo_root: Absolute path to the repository root.
+        client:    Optional pre-built QdrantClient (for testing / injection).
+
+    Returns a dict with keys:
+        slug_collisions:      {slug: [file_path, ...]} — slugs with >1 file_path
+        empty_files:          [file_path] — every point for the file has empty text
+        partial_empty_files:  {file_path: n_empty} — some (not all) points empty
+        count_mismatches:     {file_path: {"sidecar": n, "qdrant": n}}
+        stuck_stale:          [rel_path] — status="stale" but file hash matches disk
+        affected_files:       sorted union of files needing re-embed/purge
+                              (slug collision + empty + partial + mismatches;
+                               stuck_stale excluded — repair handles those separately)
+    """
+    if client is None:
+        client = QdrantClient(url=cfg["qdrant_url"], timeout=30)
+
+    coll = collection_name(cfg, "doc")
+
+    # Per-file tallies gathered from Qdrant payloads
+    slug_files: dict[str, set] = defaultdict(set)
+    per_file_counts: dict[str, int] = defaultdict(int)
+    per_file_empty: dict[str, int] = defaultdict(int)
+
+    if client.collection_exists(coll):
+        for payload in _scroll_all(client, coll):
+            fp = payload.get("file_path", "")
+            slug = payload.get("slug", "")
+            slug_files[slug].add(fp)
+            per_file_counts[fp] += 1
+            if not (payload.get("text") or "").strip():
+                per_file_empty[fp] += 1
+
+    # Slug collisions: same slug mapped to more than one file_path
+    slug_collisions = {
+        slug: sorted(files)
+        for slug, files in slug_files.items()
+        if len(files) > 1
+    }
+
+    # Files where every point has empty text
+    empty_files = sorted(
+        fp for fp, n in per_file_empty.items() if n == per_file_counts[fp]
+    )
+
+    # Files where some (but not all) points have empty text
+    partial_empty_files = {
+        fp: n
+        for fp, n in sorted(per_file_empty.items())
+        if 0 < n < per_file_counts[fp]
+    }
+
+    # Sidecar-side checks
+    count_mismatches: dict[str, dict] = {}
+    stuck_stale: list[str] = []
+
+    sidecars_root = repo_root / ".carta" / "sidecars"
+    if sidecars_root.exists():
+        for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
+            sc = read_sidecar(sc_path) or {}
+            rel = sc.get("current_path")
+            if not rel:
+                continue
+
+            # Count mismatch: sidecar chunk_count differs from Qdrant point count.
+            # Only meaningful for "embedded" status — stale/pending sidecars are
+            # expected to be out of sync with Qdrant.
+            qdrant_count = per_file_counts.get(rel)
+            sidecar_count = sc.get("chunk_count")
+            if (
+                sc.get("status") == "embedded"
+                and qdrant_count is not None
+                and sidecar_count is not None
+                and sidecar_count != qdrant_count
+            ):
+                count_mismatches[rel] = {
+                    "sidecar": sidecar_count,
+                    "qdrant": qdrant_count,
+                }
+
+            # Stuck-stale: status is "stale" but file hash matches disk
+            if sc.get("status") == "stale":
+                src = repo_root / rel
+                if src.exists():
+                    try:
+                        if compute_file_hash(src) == sc.get("file_hash"):
+                            stuck_stale.append(rel)
+                    except OSError:
+                        pass
+
+    # affected_files: union of everything needing re-embed or purge
+    # (stuck_stale excluded — repair marks them pending without full re-embed)
+    affected: set[str] = set(empty_files) | set(partial_empty_files) | set(count_mismatches)
+    for files in slug_collisions.values():
+        affected.update(files)
+
+    return {
+        "slug_collisions": slug_collisions,
+        "empty_files": empty_files,
+        "partial_empty_files": partial_empty_files,
+        "count_mismatches": count_mismatches,
+        "stuck_stale": sorted(stuck_stale),
+        "affected_files": sorted(affected),
+    }

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -97,13 +97,29 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
             if not rel:
                 continue
 
-            # Count mismatch: sidecar chunk_count differs from Qdrant point count.
-            # Only meaningful for "embedded" status — stale/pending sidecars are
-            # expected to be out of sync with Qdrant.
+            status = sc.get("status")
             qdrant_count = per_file_counts.get(rel)
             sidecar_count = sc.get("chunk_count")
+
+            # Stuck-stale: status is "stale" but file hash matches disk — a bug
+            # artifact, not a pending re-embed.
+            is_stuck = False
+            if status == "stale":
+                src = repo_root / rel
+                if src.exists():
+                    try:
+                        if compute_file_hash(src) == sc.get("file_hash"):
+                            is_stuck = True
+                            stuck_stale.append(rel)
+                    except OSError:
+                        pass
+
+            # Count mismatch: sidecar chunk_count differs from Qdrant point count.
+            # Checked for "embedded" sidecars AND stuck-stale ones (their counts
+            # should agree with Qdrant — nothing is pending). Genuinely-stale
+            # sidecars (hash differs) are expected to be out of sync and exempt.
             if (
-                sc.get("status") == "embedded"
+                (status == "embedded" or is_stuck)
                 and qdrant_count is not None
                 and sidecar_count is not None
                 and sidecar_count != qdrant_count
@@ -112,16 +128,6 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
                     "sidecar": sidecar_count,
                     "qdrant": qdrant_count,
                 }
-
-            # Stuck-stale: status is "stale" but file hash matches disk
-            if sc.get("status") == "stale":
-                src = repo_root / rel
-                if src.exists():
-                    try:
-                        if compute_file_hash(src) == sc.get("file_hash"):
-                            stuck_stale.append(rel)
-                    except OSError:
-                        pass
 
     # affected_files: union of everything needing re-embed or purge
     # (stuck_stale excluded — repair marks them pending without full re-embed)

--- a/carta/embed/lifecycle.py
+++ b/carta/embed/lifecycle.py
@@ -14,7 +14,7 @@ import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from qdrant_client.models import FieldCondition, Filter, MatchValue, DatetimeRange
+from qdrant_client.models import FieldCondition, Filter, HasIdCondition, MatchValue, DatetimeRange
 
 
 def compute_file_hash(path: Path) -> str:
@@ -168,24 +168,25 @@ def is_protected_doc_type(doc_type: str) -> bool:
     return doc_type in PROTECTED_DOC_TYPES
 
 
-def delete_other_generations(
-    client, collection_name: str, rel_path: str, keep_generation: int
+def delete_other_points(
+    client, collection_name: str, rel_path: str, keep_ids: list[str]
 ) -> None:
-    """Delete a file's points from every generation except keep_generation.
+    """Delete every point for a file except the ones just written.
 
-    Runs after a successful upsert so stale-generation chunks (and any
-    legacy slug-keyed points for this file) stop appearing in search.
-    Best-effort: errors are reported but never fail the embed that
-    just succeeded.
+    Runs after a successful, complete upsert. Catches everything the
+    generation arithmetic missed: legacy slug-keyed points (different IDs),
+    stale generations, and tail chunks of files that shrank — regardless of
+    what doc_generation they carry.  Best-effort: errors are reported but
+    never fail the embed that just succeeded.
     """
     selector = Filter(
         must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))],
-        must_not=[FieldCondition(key="doc_generation", match=MatchValue(value=keep_generation))],
+        must_not=[HasIdCondition(has_id=keep_ids)],
     )
     try:
         client.delete(collection_name=collection_name, points_selector=selector)
     except Exception as e:
-        print(f"Warning: stale-generation cleanup failed for {rel_path} — {e}", flush=True)
+        print(f"Warning: stale-point cleanup failed for {rel_path} — {e}", flush=True)
 
 
 def check_stale_alert(stale_count: int, total_count: int, threshold: float) -> str | None:

--- a/carta/embed/lifecycle.py
+++ b/carta/embed/lifecycle.py
@@ -168,6 +168,26 @@ def is_protected_doc_type(doc_type: str) -> bool:
     return doc_type in PROTECTED_DOC_TYPES
 
 
+def delete_other_generations(
+    client, collection_name: str, rel_path: str, keep_generation: int
+) -> None:
+    """Delete a file's points from every generation except keep_generation.
+
+    Runs after a successful upsert so stale-generation chunks (and any
+    legacy slug-keyed points for this file) stop appearing in search.
+    Best-effort: errors are reported but never fail the embed that
+    just succeeded.
+    """
+    selector = Filter(
+        must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))],
+        must_not=[FieldCondition(key="doc_generation", match=MatchValue(value=keep_generation))],
+    )
+    try:
+        client.delete(collection_name=collection_name, points_selector=selector)
+    except Exception as e:
+        print(f"Warning: stale-generation cleanup failed for {rel_path} — {e}", flush=True)
+
+
 def check_stale_alert(stale_count: int, total_count: int, threshold: float) -> str | None:
     """Generate a warning if stale chunk percentage exceeds threshold.
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -349,6 +349,9 @@ def _embed_one_file(
         metadata["frontmatter"] = frontmatter_meta
 
     enriched = [{**metadata, **chunk} for chunk in raw_chunks]
+    # NOTE: expected_text tracks what upsert_chunks attempts. If a later task drops
+    # empty chunks inside upsert_chunks, this line must be updated to match.
+    expected_text = len(enriched)
     count = upsert_chunks(enriched, cfg, client=client)
 
     # Vision progress tracking — events collected by callback, passed to caller via sidecar_updates
@@ -377,6 +380,7 @@ def _embed_one_file(
     # Vision: extract image descriptions for PDF files (fail-open per D-11, D-12)
     image_count = 0
     image_chunk_count = 0
+    expected_images = 0  # tracks chunks attempted; must equal image_chunk_count for cleanup gate
     vision_metadata = None
     visual_pages_count = 0  # NEW: Count of pages embedded via ColPali
     _visual_queue_updates: dict = {}  # populated by two_pass_visual pass-1 for PDFs
@@ -479,6 +483,7 @@ def _embed_one_file(
                                 "model_used": desc.get("model_used", "llava"),
                                 "content_type": desc.get("content_type", "visual"),
                             })
+                    expected_images = len(image_chunks)
                     image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                     if verbose:
                         print(f"    embedded {image_chunk_count} image description chunk(s)", flush=True)
@@ -511,6 +516,7 @@ def _embed_one_file(
                                 "chunk_index": len(raw_chunks) + len(image_chunks),
                                 "text": desc["text"],
                             })
+                        expected_images = len(image_chunks)
                         image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                         if verbose:
                             print(f"    embedded {image_chunk_count} image description chunk(s) (legacy)", flush=True)
@@ -556,12 +562,19 @@ def _embed_one_file(
         except OSError:
             pass
 
-    # Delete stale-generation points for this file (best-effort; errors are logged not raised).
+    # Delete stale-generation points for this file only when the upsert was complete.
+    # A partial upsert (batch failure) leaves the new generation incomplete; deleting the
+    # old generation would then lose chunks from BOTH generations. Require exact counts.
     # Also organically removes any legacy slug-keyed points that share the same file_path.
-    if count + image_chunk_count > 0:
+    rel_path = str(file_path.relative_to(repo_root))
+    if count + image_chunk_count > 0 and count == expected_text and image_chunk_count == expected_images:
         coll = collection_for_doc_type(cfg, file_info.get("doc_type", "unknown"))
-        delete_other_generations(
-            client, coll, str(file_path.relative_to(repo_root)), generation
+        delete_other_generations(client, coll, rel_path, generation)
+    elif count + image_chunk_count > 0:
+        print(
+            f"Warning: partial upsert for {rel_path} ({count}/{expected_text} text, "
+            f"{image_chunk_count}/{expected_images} image) — keeping previous generation's points",
+            flush=True,
         )
 
     return count + image_chunk_count, sidecar_updates
@@ -816,6 +829,10 @@ def _visual_embed_one_page(
 
     if chunks:
         image_chunks = []
+        # Stamp the sidecar's current generation onto every pass-2 chunk so
+        # delete_other_generations (keyed on doc_generation) does not delete them
+        # when the file is re-embedded at a later generation.
+        doc_generation = int(sidecar.get("generation") or 1)
         for chunk in chunks:
             for part_text in _split_vision_text(chunk.get("text", ""), max_tokens):
                 i = len(image_chunks)
@@ -823,6 +840,7 @@ def _visual_embed_one_page(
                     "slug": slug,
                     "file_path": current_path,
                     "doc_type": "image_description",
+                    "doc_generation": doc_generation,
                     "page_num": page,
                     "image_index": chunk.get("image_index", 0),
                     # Use a pass-2-specific chunk_index token so the Qdrant point
@@ -1122,6 +1140,10 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
         version_history = version_history[-max_gens:]
 
     # Prepare lifecycle updates
+    # VISUAL_DONE_KEY is reset to [] so add_pending_pages no longer excludes these pages;
+    # pass-1 re-queues image-heavy pages and the visual drainer re-processes them.
+    # VISUAL_PENDING_KEY is intentionally omitted — pass-1's fresh queuing merges into it
+    # and any stale pending pages re-drain idempotently (point IDs overwrite in place).
     lifecycle_updates = {
         "generation": new_generation,
         "status": "stale",
@@ -1130,6 +1152,7 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
         "file_mtime": current_mtime,
         "last_hash_check_at": now.isoformat(),
         "version_history": version_history,
+        VISUAL_DONE_KEY: [],
     }
 
     # Mark chunks as stale in Qdrant (with migration boundary guard)

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -349,9 +349,29 @@ def _embed_one_file(
         metadata["frontmatter"] = frontmatter_meta
 
     enriched = [{**metadata, **chunk} for chunk in raw_chunks]
-    # NOTE: expected_text tracks what upsert_chunks attempts. If a later task drops
-    # empty chunks inside upsert_chunks, this line must be updated to match.
-    expected_text = len(enriched)
+    # expected_text counts only non-empty chunks — upsert_chunks drops empty ones
+    # before embedding, so the cleanup gate must compare against the same set.
+    expected_text = sum(1 for c in enriched if (c.get("text") or "").strip())
+
+    # Zero usable text: for non-PDF files there's no image-chunk rescue path, so
+    # flag immediately. PDFs may still produce content via the vision path below.
+    if expected_text == 0 and file_path.suffix != ".pdf":
+        print(
+            f"Warning: {file_path.name}: 0 extractable characters — "
+            f"skipped (empty or unreadable file)",
+            flush=True,
+        )
+        return 0, {
+            "status": "extraction_failed",
+            "indexed_at": datetime.now(timezone.utc).isoformat(),
+            "chunk_count": 0,
+            "image_count": 0,
+            "image_chunks": 0,
+            "file_mtime": os.path.getmtime(str(file_path)),
+            "visual_pages": 0,
+            "_vision_events": [],
+        }
+
     count = upsert_chunks(enriched, cfg, client=client)
 
     # Vision progress tracking — events collected by callback, passed to caller via sidecar_updates
@@ -553,6 +573,18 @@ def _embed_one_file(
         sidecar_updates.update(_visual_queue_updates)
 
     sidecar_updates["_vision_events"] = _page_events
+
+    # Nothing extractable anywhere: no text was attempted, no image chunks were
+    # attempted, and no pages are queued for pass-2 visual embedding. Flag the
+    # file instead of recording a silent no-op as "embedded".
+    if (expected_text == 0 and expected_images == 0
+            and not (_visual_queue_updates.get(VISUAL_PENDING_KEY) or [])):
+        sidecar_updates["status"] = "extraction_failed"
+        print(
+            f"Warning: {file_path.name}: 0 extractable characters — skipped "
+            f"(scanned PDF? OCR may be required)",
+            flush=True,
+        )
 
     # File fully embedded — clear any per-page resume checkpoint.
     if file_path.suffix == ".pdf":
@@ -1195,9 +1227,11 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
         verbose: if True, print progress to stdout. If False, stdout is silent.
 
     Returns:
-        {"embedded": int, "skipped": int, "errors": list[str], "timed_out": list[str]}
+        {"embedded": int, "skipped": int, "extraction_failed": int,
+         "errors": list[str], "timed_out": list[str]}
     """
-    summary: dict = {"embedded": 0, "skipped": 0, "errors": [], "timed_out": []}
+    summary: dict = {"embedded": 0, "skipped": 0, "extraction_failed": 0,
+                     "errors": [], "timed_out": []}
 
     # Migrate any co-located sidecars from old format to .carta/sidecars/
     migrate_sidecars(repo_root, verbose=verbose)
@@ -1367,7 +1401,10 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
                         progress.vision_done(vision_events)
                 elif verbose:
                     print(f"  [{idx}/{total}] OK: {file_path.name} — {count} chunk(s) in {elapsed:.1f}s", flush=True)
-                summary["embedded"] += 1
+                if sidecar_updates.get("status") == "extraction_failed":
+                    summary["extraction_failed"] += 1
+                else:
+                    summary["embedded"] += 1
                 _write_perf_log_entry(perf_log_path, {
                     **perf_context, "file": rel_file, "status": "ok",
                     "chunks": count, "elapsed_s": round(elapsed, 2),

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -503,7 +503,11 @@ def _embed_one_file(
                                 "model_used": desc.get("model_used", "llava"),
                                 "content_type": desc.get("content_type", "visual"),
                             })
-                    expected_images = len(image_chunks)
+                    # Count only non-empty chunks — upsert_chunks drops empty ones,
+                    # and a clean drop must not read as a partial upsert to the gate.
+                    expected_images = sum(
+                        1 for c in image_chunks if (c.get("text") or "").strip()
+                    )
                     image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                     if verbose:
                         print(f"    embedded {image_chunk_count} image description chunk(s)", flush=True)
@@ -536,7 +540,9 @@ def _embed_one_file(
                                 "chunk_index": len(raw_chunks) + len(image_chunks),
                                 "text": desc["text"],
                             })
-                        expected_images = len(image_chunks)
+                        expected_images = sum(
+                            1 for c in image_chunks if (c.get("text") or "").strip()
+                        )
                         image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                         if verbose:
                             print(f"    embedded {image_chunk_count} image description chunk(s) (legacy)", flush=True)

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -759,8 +759,8 @@ def _visual_embed_one_page(
     """OCR text + ColPali for a single 1-indexed page. Raise on failure.
 
     (a) glm-ocr text for the page via SmartRouter → upsert_chunks (hybrid text index).
-        Pass-2 chunks receive point IDs from _visual_point_id_pass2() so they are
-        disjoint from pass-1 text chunks for the same slug.
+        Pass-2 chunks receive a pass-2-specific chunk_index token so their point
+        IDs are disjoint from pass-1 text chunks for the same file.
     (b) ColPali for the page via ColPaliEmbedder.embed_pdf_pages(page_nums=[page])
         → upsert_visual_pages (_visual collection).
 
@@ -814,7 +814,7 @@ def _visual_embed_one_page(
                     "page_num": page,
                     "image_index": chunk.get("image_index", 0),
                     # Use a pass-2-specific chunk_index token so the Qdrant point
-                    # ID (derived by upsert_chunks as md5("{slug}:{chunk_index}"))
+                    # ID (derived by upsert_chunks as md5("{file_path}:{chunk_index}:g{gen}"))
                     # is disjoint from pass-1 text chunks (which use integer indices).
                     "chunk_index": _visual_chunk_index_pass2(page, i),
                     "text": part_text,

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -734,12 +734,13 @@ def _visual_chunk_index_pass2(page: int, i: int) -> str:
 
     Pass-2 chunks set ``chunk_index`` to this string (e.g. ``"visual:1:0"``).
     ``upsert_chunks`` then derives the Qdrant point ID via
-    ``_point_id(slug, chunk_index)`` → ``md5("{slug}:visual:{page}:{i}")``.
+    ``_point_id_versioned(file_path, chunk_index, generation)``
+    → ``md5("{file_path}:visual:{page}:{i}:g{gen}")``.
 
     This namespace is structurally disjoint from pass-1 text chunks, which
-    always use integer chunk_index values (e.g. ``md5("{slug}:0")``).  An
-    integer can never equal the string ``"visual:{page}:{i}"``, so collision
-    between pass-1 and pass-2 chunks for the same slug is impossible by
+    always use integer chunk_index values (e.g. ``md5("{file_path}:0:g1")``).
+    An integer can never equal the string ``"visual:{page}:{i}"``, so collision
+    between pass-1 and pass-2 chunks for the same file is impossible by
     construction.
     """
     return f"visual:{page}:{i}"

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1148,7 +1148,7 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
     old_hash = sidecar_data.get("file_hash")
     current_mtime = os.path.getmtime(str(file_path))
 
-    if current_hash == old_hash and old_hash is not None:
+    if not force and current_hash == old_hash and old_hash is not None:
         # Hash unchanged: just update mtime and fast-path fields
         _update_sidecar(sc_path, {
             "file_mtime": current_mtime,
@@ -1177,15 +1177,15 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
     if len(version_history) > max_gens:
         version_history = version_history[-max_gens:]
 
-    # Prepare lifecycle updates
+    # Prepare lifecycle updates.
     # VISUAL_DONE_KEY is reset to [] so add_pending_pages no longer excludes these pages;
     # pass-1 re-queues image-heavy pages and the visual drainer re-processes them.
     # VISUAL_PENDING_KEY is intentionally omitted — pass-1's fresh queuing merges into it
     # and any stale pending pages re-drain idempotently (point IDs overwrite in place).
+    # NOTE: "status" and "stale_as_of" are intentionally excluded here — they are set
+    # after the embed completes based on what _embed_one_file returns (Bug A fix).
     lifecycle_updates = {
         "generation": new_generation,
-        "status": "stale",
-        "stale_as_of": now.isoformat(),
         "file_hash": current_hash,
         "file_mtime": current_mtime,
         "last_hash_check_at": now.isoformat(),
@@ -1217,10 +1217,14 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
     count, sidecar_updates = _embed_one_file(
         file_path, file_info, cfg, client, repo_root, max_tokens, overlap_fraction, verbose, progress
     )
-    # Merge lifecycle updates with embedding updates
-    sidecar_updates.update(lifecycle_updates)
-    sidecar_updates.pop("_vision_events", None)  # temp key — never written to sidecar
-    _update_sidecar(sc_path, sidecar_updates)
+    # Merge lifecycle updates with embedding updates.
+    # lifecycle_updates must NOT clobber the status _embed_one_file chose ("embedded"
+    # or "extraction_failed") — apply lifecycle fields first, then let embed results win.
+    merged = {**lifecycle_updates, **sidecar_updates}
+    merged.setdefault("status", "embedded")   # belt-and-braces: _embed_one_file always sets it
+    merged["stale_as_of"] = None              # re-embed completed — no longer stale
+    merged.pop("_vision_events", None)        # temp key — never written to sidecar
+    _update_sidecar(sc_path, merged)
     return {"status": "ok", "chunks": count}
 
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -878,9 +878,9 @@ def _visual_embed_one_page(
 
     if chunks:
         image_chunks = []
-        # Stamp the sidecar's current generation onto every pass-2 chunk so
-        # delete_other_generations (keyed on doc_generation) does not delete them
-        # when the file is re-embedded at a later generation.
+        # Stamp the sidecar's current generation onto every pass-2 chunk
+        # (observability metadata). Cleanup is ID-set-based: a text re-embed
+        # deletes these points and re-queues the pages for re-drain.
         doc_generation = int(sidecar.get("generation") or 1)
         for chunk in chunks:
             for part_text in _split_vision_text(chunk.get("text", ""), max_tokens):

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -25,12 +25,13 @@ from carta.embed.embed import (
     get_embedding,
     upsert_visual_pages,
     collection_is_hybrid,
+    _point_id_versioned,
     DENSE_VECTOR_NAME,
     SPARSE_VECTOR_NAME,
 )
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
-from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert, delete_other_generations
+from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert, delete_other_points
 from carta.embed.visual_queue import add_pending_pages, move_to_done, VISUAL_PENDING_KEY, VISUAL_DONE_KEY, queue_summary, format_summary_line
 from carta.embed.colpali import is_colpali_available
 from carta.embed.status import StatusWriter
@@ -351,7 +352,9 @@ def _embed_one_file(
     enriched = [{**metadata, **chunk} for chunk in raw_chunks]
     # expected_text counts only non-empty chunks — upsert_chunks drops empty ones
     # before embedding, so the cleanup gate must compare against the same set.
-    expected_text = sum(1 for c in enriched if (c.get("text") or "").strip())
+    # kept_text_chunks mirrors the same filter so we can derive their point IDs.
+    kept_text_chunks = [c for c in enriched if (c.get("text") or "").strip()]
+    expected_text = len(kept_text_chunks)
 
     # Zero usable text: for non-PDF files there's no image-chunk rescue path, so
     # flag immediately. PDFs may still produce content via the vision path below.
@@ -401,6 +404,7 @@ def _embed_one_file(
     image_count = 0
     image_chunk_count = 0
     expected_images = 0  # tracks chunks attempted; must equal image_chunk_count for cleanup gate
+    kept_image_chunks: list[dict] = []  # non-empty image chunks actually upserted (for ID derivation)
     vision_metadata = None
     visual_pages_count = 0  # NEW: Count of pages embedded via ColPali
     _visual_queue_updates: dict = {}  # populated by two_pass_visual pass-1 for PDFs
@@ -505,9 +509,8 @@ def _embed_one_file(
                             })
                     # Count only non-empty chunks — upsert_chunks drops empty ones,
                     # and a clean drop must not read as a partial upsert to the gate.
-                    expected_images = sum(
-                        1 for c in image_chunks if (c.get("text") or "").strip()
-                    )
+                    kept_image_chunks = [c for c in image_chunks if (c.get("text") or "").strip()]
+                    expected_images = len(kept_image_chunks)
                     image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                     if verbose:
                         print(f"    embedded {image_chunk_count} image description chunk(s)", flush=True)
@@ -540,9 +543,8 @@ def _embed_one_file(
                                 "chunk_index": len(raw_chunks) + len(image_chunks),
                                 "text": desc["text"],
                             })
-                        expected_images = sum(
-                            1 for c in image_chunks if (c.get("text") or "").strip()
-                        )
+                        kept_image_chunks = [c for c in image_chunks if (c.get("text") or "").strip()]
+                        expected_images = len(kept_image_chunks)
                         image_chunk_count = upsert_chunks(image_chunks, cfg, client=client)
                         if verbose:
                             print(f"    embedded {image_chunk_count} image description chunk(s) (legacy)", flush=True)
@@ -561,6 +563,7 @@ def _embed_one_file(
         "image_chunks": image_chunk_count,
         "file_mtime": os.path.getmtime(str(file_path)),
         "visual_pages": visual_pages_count,  # NEW: ColPali visual pages
+        "generation": generation,  # persist generation so bulk sidecars don't stay at 0
     }
 
     # Add vision metadata if available (Phase 999.4-04)
@@ -600,14 +603,22 @@ def _embed_one_file(
         except OSError:
             pass
 
-    # Delete stale-generation points for this file only when the upsert was complete.
-    # A partial upsert (batch failure) leaves the new generation incomplete; deleting the
-    # old generation would then lose chunks from BOTH generations. Require exact counts.
-    # Also organically removes any legacy slug-keyed points that share the same file_path.
+    # Delete every point for this file except the ones just written, but only when the
+    # upsert was complete.  A partial upsert leaves the new chunks incomplete; removing
+    # existing points would then lose data from BOTH old and new.  Require exact counts.
+    # ID-set-based cleanup (HasIdCondition) subsumes generation arithmetic and additionally
+    # removes: legacy slug-keyed duplicates, tail chunks of shrunken files, and any points
+    # from a same-generation re-embed that the old doc_generation!=g filter would have spared.
     rel_path = str(file_path.relative_to(repo_root))
     if count + image_chunk_count > 0 and count == expected_text and image_chunk_count == expected_images:
         coll = collection_for_doc_type(cfg, file_info.get("doc_type", "unknown"))
-        delete_other_generations(client, coll, rel_path, generation)
+        keep_ids = [
+            _point_id_versioned(
+                c.get("file_path") or c["slug"], c["chunk_index"], c.get("doc_generation", 1)
+            )
+            for c in kept_text_chunks + kept_image_chunks
+        ]
+        delete_other_points(client, coll, rel_path=rel_path, keep_ids=keep_ids)
     elif count + image_chunk_count > 0:
         print(
             f"Warning: partial upsert for {rel_path} ({count}/{expected_text} text, "

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -17,7 +17,7 @@ from qdrant_client import models as qmodels
 from qdrant_client.models import Filter
 
 from carta import __version__ as _CARTA_VERSION
-from carta.config import collection_name, find_config
+from carta.config import collection_name, collection_for_doc_type, find_config
 from carta.embed.parse import extract_pdf_text, extract_pdf_text_and_classify, extract_markdown_text, chunk_text, _estimate_tokens
 from carta.embed.embed import (
     ensure_collection,
@@ -30,7 +30,7 @@ from carta.embed.embed import (
 )
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
-from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert
+from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert, delete_other_generations
 from carta.embed.visual_queue import add_pending_pages, move_to_done, VISUAL_PENDING_KEY, VISUAL_DONE_KEY, queue_summary, format_summary_line
 from carta.embed.colpali import is_colpali_available
 from carta.embed.status import StatusWriter
@@ -338,10 +338,12 @@ def _embed_one_file(
         print(f"    built {len(raw_chunks)} chunk(s); embedding + upserting...", flush=True)
 
     slug = file_info.get("slug", file_path.stem)
+    generation = int(file_info.get("generation") or 1)
     metadata = {
         "slug": slug,
         "file_path": str(file_path.relative_to(repo_root)),
         "doc_type": file_info.get("doc_type", "unknown"),
+        "doc_generation": generation,
     }
     if frontmatter_meta:
         metadata["frontmatter"] = frontmatter_meta
@@ -468,6 +470,7 @@ def _embed_one_file(
                                 "slug": slug,
                                 "file_path": str(file_path.relative_to(repo_root)),
                                 "doc_type": "image_description",
+                                "doc_generation": generation,
                                 "page_num": desc["page_num"],
                                 "image_index": desc["image_index"],
                                 "chunk_index": len(raw_chunks) + len(image_chunks),
@@ -502,6 +505,7 @@ def _embed_one_file(
                                 "slug": slug,
                                 "file_path": str(file_path.relative_to(repo_root)),
                                 "doc_type": "image_description",
+                                "doc_generation": generation,
                                 "page_num": desc["page_num"],
                                 "image_index": desc["image_index"],
                                 "chunk_index": len(raw_chunks) + len(image_chunks),
@@ -551,6 +555,14 @@ def _embed_one_file(
             cp.unlink(missing_ok=True)
         except OSError:
             pass
+
+    # Delete stale-generation points for this file (best-effort; errors are logged not raised).
+    # Also organically removes any legacy slug-keyed points that share the same file_path.
+    if count + image_chunk_count > 0:
+        coll = collection_for_doc_type(cfg, file_info.get("doc_type", "unknown"))
+        delete_other_generations(
+            client, coll, str(file_path.relative_to(repo_root)), generation
+        )
 
     return count + image_chunk_count, sidecar_updates
 
@@ -1131,6 +1143,7 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
         "doc_type": sidecar_data.get("doc_type", "unknown"),
         "sidecar_path": sc_path,
         "file_path": file_path,
+        "generation": new_generation,
     }
 
     client = QdrantClient(url=cfg["qdrant_url"], timeout=5)

--- a/carta/embed/repair.py
+++ b/carta/embed/repair.py
@@ -1,0 +1,92 @@
+"""carta embed --repair: fix corpus-integrity issues found by integrity.scan.
+
+Per affected file: delete ALL of its points (any generation, any legacy ID),
+then force re-embed through the fixed pipeline. Files that no longer exist on
+disk, or whose extraction yields nothing, end up purged + flagged rather than
+re-upserted. Stuck-stale sidecars get their status corrected in place.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+from carta.config import collection_name
+from carta.embed.integrity import scan_corpus_integrity
+from carta.embed.pipeline import run_embed_file
+
+
+def _delete_file_points(client, coll: str, rel_path: str) -> None:
+    selector = Filter(
+        must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))]
+    )
+    client.delete(collection_name=coll, points_selector=selector)
+
+
+def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
+    """Detect and repair corpus-integrity issues. Returns a summary dict."""
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=30)
+    report = scan_corpus_integrity(cfg, repo_root, client=client)
+    coll = collection_name(cfg, "doc")
+
+    if not report["affected_files"] and not report["stuck_stale"]:
+        if verbose:
+            print("Corpus integrity: nothing to repair.", flush=True)
+        return {"affected": 0, "repaired": 0, "purged_only": 0,
+                "flagged": 0, "failed": 0, "stale_fixed": 0}
+
+    repaired = purged_only = flagged = failed = 0
+    for rel in report["affected_files"]:
+        src = repo_root / rel
+        if verbose:
+            print(f"  repairing {rel}...", flush=True)
+        try:
+            _delete_file_points(client, coll, rel)
+        except Exception as e:
+            print(f"  Warning: could not purge points for {rel} — {e}", flush=True)
+        if not src.exists():
+            purged_only += 1
+            if verbose:
+                print("    purged (file no longer on disk)", flush=True)
+            continue
+        try:
+            result = run_embed_file(src, cfg, force=True)
+            if result.get("chunks", 0) > 0:
+                repaired += 1
+            else:
+                flagged += 1   # extraction_failed: purged + sidecar flagged
+        except Exception as e:
+            failed += 1
+            print(f"  Error: re-embed failed for {rel} — {e}", flush=True)
+
+    # Stuck-stale sidecars not otherwise affected: fix status in place.
+    stale_fixed = 0
+    affected = set(report["affected_files"])
+    if report["stuck_stale"]:
+        from carta.embed.induct import sidecar_path
+        from carta.embed.pipeline import _update_sidecar
+        for rel in report["stuck_stale"]:
+            if rel in affected:
+                continue  # re-embed above already rewrote it
+            sc = sidecar_path(repo_root / rel, repo_root)
+            if sc.exists():
+                _update_sidecar(sc, {"status": "embedded", "stale_as_of": None})
+                stale_fixed += 1
+
+    summary = {
+        "affected": len(report["affected_files"]),
+        "repaired": repaired,
+        "purged_only": purged_only,
+        "flagged": flagged,
+        "failed": failed,
+        "stale_fixed": stale_fixed,
+    }
+    if verbose:
+        print(
+            f"Repair complete: {repaired} re-embedded, {purged_only} purged, "
+            f"{flagged} flagged extraction_failed, {failed} failed, "
+            f"{stale_fixed} stale sidecar(s) corrected.",
+            flush=True,
+        )
+    return summary

--- a/carta/embed/repair.py
+++ b/carta/embed/repair.py
@@ -13,6 +13,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import FieldCondition, Filter, MatchValue
 
 from carta.config import collection_name
+from carta.embed.induct import read_sidecar, sidecar_path
 from carta.embed.integrity import scan_corpus_integrity
 from carta.embed.pipeline import run_embed_file
 
@@ -34,9 +35,9 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
         if verbose:
             print("Corpus integrity: nothing to repair.", flush=True)
         return {"affected": 0, "repaired": 0, "purged_only": 0,
-                "flagged": 0, "failed": 0, "stale_fixed": 0}
+                "flagged": 0, "queued_visual": 0, "failed": 0, "stale_fixed": 0}
 
-    repaired = purged_only = flagged = failed = 0
+    repaired = purged_only = flagged = queued_visual = failed = 0
     for rel in report["affected_files"]:
         src = repo_root / rel
         if verbose:
@@ -55,7 +56,20 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
             if result.get("chunks", 0) > 0:
                 repaired += 1
             else:
-                flagged += 1   # extraction_failed: purged + sidecar flagged
+                # Zero chunks: distinguish a genuine extraction failure from a
+                # healthy two-pass-visual PDF whose pages were queued for the
+                # --visual drainer (sidecar stays "embedded" in that case).
+                sc = read_sidecar(sidecar_path(src, repo_root)) or {}
+                if sc.get("status") == "extraction_failed":
+                    flagged += 1
+                else:
+                    queued_visual += 1
+                    if verbose:
+                        print(
+                            "    re-embedded; visual pages queued for pass-2 "
+                            "(run `carta embed --visual` to drain)",
+                            flush=True,
+                        )
         except Exception as e:
             failed += 1
             print(f"  Error: re-embed failed for {rel} — {e}", flush=True)
@@ -64,7 +78,6 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
     stale_fixed = 0
     affected = set(report["affected_files"])
     if report["stuck_stale"]:
-        from carta.embed.induct import sidecar_path
         from carta.embed.pipeline import _update_sidecar
         for rel in report["stuck_stale"]:
             if rel in affected:
@@ -79,13 +92,15 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
         "repaired": repaired,
         "purged_only": purged_only,
         "flagged": flagged,
+        "queued_visual": queued_visual,
         "failed": failed,
         "stale_fixed": stale_fixed,
     }
     if verbose:
         print(
             f"Repair complete: {repaired} re-embedded, {purged_only} purged, "
-            f"{flagged} flagged extraction_failed, {failed} failed, "
+            f"{flagged} flagged extraction_failed, {queued_visual} queued for "
+            f"visual pass, {failed} failed, "
             f"{stale_fixed} stale sidecar(s) corrected.",
             flush=True,
         )

--- a/carta/embed/repair.py
+++ b/carta/embed/repair.py
@@ -1,9 +1,10 @@
 """carta embed --repair: fix corpus-integrity issues found by integrity.scan.
 
-Per affected file: delete ALL of its points (any generation, any legacy ID),
-then force re-embed through the fixed pipeline. Files that no longer exist on
-disk, or whose extraction yields nothing, end up purged + flagged rather than
-re-upserted. Stuck-stale sidecars get their status corrected in place.
+Per affected file: delete ALL of its points from the _doc collection (any
+generation, any legacy ID), then force re-embed through the fixed pipeline.
+Files that no longer exist on disk, or whose extraction yields nothing, end up
+purged + flagged rather than re-upserted. Stuck-stale sidecars get their status
+corrected in place.
 """
 from __future__ import annotations
 

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -19,7 +19,7 @@ from carta.embed.induct import (
     write_sidecar,
     sidecar_path,
 )
-from carta.embed.embed import _point_id, ensure_collection, get_embedding, upsert_chunks
+from carta.embed.embed import _point_id_versioned, ensure_collection, get_embedding, upsert_chunks
 from carta.embed.parse import extract_pdf_text
 from carta.embed.pipeline import (
     discover_pending_files,
@@ -360,24 +360,24 @@ def test_extract_pdf_text_multi_page(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# embed.py — _point_id determinism
+# embed.py — _point_id_versioned determinism
 # ---------------------------------------------------------------------------
 
 def test_point_id_deterministic():
-    a = _point_id("my-slug", 0)
-    b = _point_id("my-slug", 0)
+    a = _point_id_versioned("docs/my-slug.md", 0, 1)
+    b = _point_id_versioned("docs/my-slug.md", 0, 1)
     assert a == b
 
 
 def test_point_id_unique_per_chunk():
-    a = _point_id("my-slug", 0)
-    b = _point_id("my-slug", 1)
+    a = _point_id_versioned("docs/my-slug.md", 0, 1)
+    b = _point_id_versioned("docs/my-slug.md", 1, 1)
     assert a != b
 
 
-def test_point_id_unique_per_slug():
-    a = _point_id("slug-a", 0)
-    b = _point_id("slug-b", 0)
+def test_point_id_unique_per_key():
+    a = _point_id_versioned("docs/a/slug.md", 0, 1)
+    b = _point_id_versioned("docs/b/slug.md", 0, 1)
     assert a != b
 
 

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -1131,8 +1131,8 @@ def test_visual_point_id_deterministic():
     """_visual_point_id should produce deterministic UUIDs."""
     from carta.embed.embed import _visual_point_id
 
-    a = _visual_point_id("datasheet", 42)
-    b = _visual_point_id("datasheet", 42)
+    a = _visual_point_id("docs/ref/datasheet.pdf", 42)
+    b = _visual_point_id("docs/ref/datasheet.pdf", 42)
     assert a == b
 
 
@@ -1140,8 +1140,8 @@ def test_visual_point_id_unique_per_page():
     """_visual_point_id should be unique per page number."""
     from carta.embed.embed import _visual_point_id
 
-    a = _visual_point_id("datasheet", 1)
-    b = _visual_point_id("datasheet", 2)
+    a = _visual_point_id("docs/ref/datasheet.pdf", 1)
+    b = _visual_point_id("docs/ref/datasheet.pdf", 2)
     assert a != b
 
 

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -81,6 +81,83 @@ def test_drainer_preflight_when_visual_unavailable(monkeypatch, tmp_path):
     assert summary["pages_embedded"] == 0
 
 
+def test_pass2_chunks_carry_sidecar_generation(monkeypatch, tmp_path):
+    """Pass-2 OCR chunks upserted by _visual_embed_one_page must carry doc_generation
+    equal to the sidecar's 'generation' field (not default to 1).
+
+    Regression: before fix, the chunk literal in _visual_embed_one_page omitted
+    doc_generation, so build_point defaulted those points to generation 1 and the
+    next re-embed's cleanup deleted them permanently.
+    """
+    from carta.embed.pipeline import _visual_embed_one_page
+    from carta.embed import pipeline
+
+    # Sidecar says this file is generation 3
+    sidecar = {
+        "current_path": "docs/x.pdf",
+        "slug": "x",
+        "generation": 3,
+        VISUAL_PENDING_KEY: [2],
+        VISUAL_DONE_KEY: [],
+    }
+
+    # Patch out heavy I/O — we only care what upsert_chunks receives
+    captured_chunks: list[list[dict]] = []
+
+    def fake_upsert(chunks, cfg, client=None):
+        captured_chunks.append(list(chunks))
+        return len(chunks)
+
+    monkeypatch.setattr(pipeline, "upsert_chunks", fake_upsert)
+
+    # Fake fitz so no real PDF is opened
+    fake_page = MagicMock()
+    fake_page.__len__ = lambda self: 5
+    fake_doc = MagicMock()
+    fake_doc.__len__ = MagicMock(return_value=5)
+    fake_doc.__getitem__ = MagicMock(return_value=fake_page)
+    fake_doc.__enter__ = MagicMock(return_value=fake_doc)
+    fake_doc.__exit__ = MagicMock(return_value=False)
+    fake_fitz = MagicMock()
+    fake_fitz.open.return_value = fake_doc
+
+    monkeypatch.setattr("carta.embed.pipeline.upsert_visual_pages", lambda *a, **k: None)
+
+    # Router that returns one OCR chunk for the page
+    fake_router = MagicMock()
+    fake_router.analyzer.analyze.return_value = MagicMock()
+    fake_router._route.return_value = [{"text": "ocr text here", "image_index": 0, "model_used": "glm-ocr", "content_type": "visual"}]
+
+    # ColPali embedder that returns nothing (keep test focused on text chunks)
+    fake_embedder = MagicMock()
+    fake_embedder.embed_pdf_pages.return_value = []
+
+    # Patch fitz import inside the function
+    import sys
+    sys.modules["fitz"] = fake_fitz
+
+    cfg = {"project_name": "test", "qdrant_url": "x", "embed": {"chunking": {"max_tokens": 400}}}
+    # Create a real tmp file so file_path exists
+    pdf_file = tmp_path / "docs" / "x.pdf"
+    pdf_file.parent.mkdir(parents=True)
+    pdf_file.write_bytes(b"%PDF-1.4 fake")
+
+    sidecar["current_path"] = str(pdf_file.relative_to(tmp_path))
+
+    _visual_embed_one_page(sidecar, 2, cfg, MagicMock(), tmp_path, fake_router, fake_embedder)
+
+    sys.modules.pop("fitz", None)
+
+    assert captured_chunks, "upsert_chunks was never called — no OCR chunks were produced"
+    all_chunks = [c for batch in captured_chunks for c in batch]
+    assert all_chunks, "upsert_chunks was called but with empty chunk list"
+    bad = [c for c in all_chunks if c.get("doc_generation") != 3]
+    assert not bad, (
+        f"Expected all pass-2 chunks to have doc_generation=3 (sidecar generation), "
+        f"but got: {[c.get('doc_generation') for c in all_chunks]}"
+    )
+
+
 def test_pass2_point_ids_disjoint_from_pass1():
     """Pass-2 visual/OCR chunk IDs must never collide with pass-1 text chunk IDs.
 

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 from carta.embed import pipeline
 from carta.embed.pipeline import _visual_chunk_index_pass2
-from carta.embed.embed import _point_id
+from carta.embed.embed import _point_id_versioned
 from carta.embed.visual_queue import VISUAL_PENDING_KEY, VISUAL_DONE_KEY
 
 
@@ -84,27 +84,27 @@ def test_drainer_preflight_when_visual_unavailable(monkeypatch, tmp_path):
 def test_pass2_point_ids_disjoint_from_pass1():
     """Pass-2 visual/OCR chunk IDs must never collide with pass-1 text chunk IDs.
 
-    upsert_chunks derives the Qdrant point ID as _point_id(slug, chunk_index),
-    i.e. md5("{slug}:{chunk_index}").
+    upsert_chunks derives the Qdrant point ID as _point_id_versioned(file_path,
+    chunk_index, generation), i.e. md5("{file_path}:{chunk_index}:g{gen}").
 
-    Pass-1 uses integer chunk_index values  → md5("{slug}:0"), md5("{slug}:1"), …
-    Pass-2 uses _visual_chunk_index_pass2() → md5("{slug}:visual:{page}:{i}")
+    Pass-1 uses integer chunk_index values  → md5("{key}:0:g1"), md5("{key}:1:g1"), …
+    Pass-2 uses _visual_chunk_index_pass2() → md5("{key}:visual:{page}:{i}:g1")
 
     An integer string can never equal "visual:{page}:{i}" so the two namespaces
     are provably disjoint.  This test confirms the MD5 outputs don't collide in
     practice across a representative sample.
     """
-    slug = "my-doc"
+    key = "docs/my-doc.md"
 
     # Pass-1: simulate up to 1000 text chunks (generous upper bound)
-    pass1_ids = {_point_id(slug, ci) for ci in range(1000)}
+    pass1_ids = {_point_id_versioned(key, ci, 1) for ci in range(1000)}
 
     # Pass-2: pages 1..5, sub-indices 0..9 each
     pass2_ids = set()
     for page in range(6):  # includes page 0 edge case
         for i in range(10):
             ci = _visual_chunk_index_pass2(page, i)
-            pass2_ids.add(_point_id(slug, ci))
+            pass2_ids.add(_point_id_versioned(key, ci, 1))
 
     assert pass1_ids.isdisjoint(pass2_ids), (
         "Pass-1 and pass-2 point IDs collide — namespace isolation is broken"

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -551,3 +551,35 @@ class TestDoctorIntegrityJsonScanError:
         out = capsys.readouterr().out
         doc = json.loads(out)
         assert doc["corpus_integrity"] == {"skipped": "qdrant unreachable"}
+
+
+class TestDoctorJsonOutsideProject:
+    def test_json_outside_project_emits_preflight_only(self, capsys):
+        import json
+        from unittest.mock import MagicMock, patch
+        from carta import cli
+
+        with patch("carta.cli.find_config", side_effect=FileNotFoundError("no project")), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            result = MagicMock()
+            result.fixable_failures = []
+            result.critical_failures = []
+            result.can_proceed.return_value = True
+            result.is_healthy.return_value = True
+            result.warnings = []
+            result.to_json.return_value = '{"checks": []}'
+            MockChecker.return_value.run.return_value = result
+
+            args = MagicMock()
+            args.json = True
+            args.fix = False
+            args.yes = True
+            args.verbose = False
+            try:
+                cli.cmd_doctor(args)
+            except SystemExit:
+                pass
+
+        doc = json.loads(capsys.readouterr().out)
+        assert "corpus_integrity" not in doc

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -507,3 +507,47 @@ class TestDoctorCorpusIntegrity:
         assert "corpus_integrity" in parsed
         assert "slug_collisions" in parsed["corpus_integrity"]
         assert "readme" in parsed["corpus_integrity"]["slug_collisions"]
+
+
+class TestDoctorIntegrityJsonScanError:
+    """JSON mode must emit exactly one valid JSON document even when the
+    integrity scan fails — empty stdout would break consumers."""
+
+    def test_json_scan_error_still_emits_json(self, tmp_path, capsys):
+        import json
+        from unittest.mock import MagicMock, patch
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   side_effect=RuntimeError("qdrant unreachable")), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            result = MagicMock()
+            result.fixable_failures = []
+            result.critical_failures = []
+            result.can_proceed.return_value = True
+            result.is_healthy.return_value = True
+            result.warnings = []
+            result.to_dict.return_value = {"checks": []}
+            MockChecker.return_value.run.return_value = result
+
+            args = MagicMock()
+            args.json = True
+            args.fix = False
+            args.yes = True
+            args.verbose = False
+            try:
+                cli.cmd_doctor(args)
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        doc = json.loads(out)
+        assert doc["corpus_integrity"] == {"skipped": "qdrant unreachable"}

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -316,3 +316,194 @@ class TestCmdRemember:
         code, _ = self._run(self._args(), capture_error=ValueError("bad"))
         assert code == 1
         assert "bad" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# cmd_doctor — Corpus integrity section (Task 6)
+# ---------------------------------------------------------------------------
+
+class TestDoctorCorpusIntegrity:
+    """cmd_doctor wires in a read-only corpus-integrity section."""
+
+    _ISSUES_REPORT = {
+        "slug_collisions": {"readme": ["docs/a/README.md", "docs/b/README.md"]},
+        "empty_files": ["docs/scan.pdf"],
+        "partial_empty_files": {},
+        "count_mismatches": {},
+        "stuck_stale": [],
+        "affected_files": ["docs/a/README.md", "docs/b/README.md", "docs/scan.pdf"],
+    }
+
+    _CLEAN_REPORT = {
+        "slug_collisions": {},
+        "empty_files": [],
+        "partial_empty_files": {},
+        "count_mismatches": {},
+        "stuck_stale": [],
+        "affected_files": [],
+    }
+
+    def _make_args(self, json_flag=False):
+        from unittest.mock import MagicMock
+        args = MagicMock()
+        args.json = json_flag
+        args.fix = False
+        args.yes = True
+        args.verbose = False
+        return args
+
+    def _make_preflight_mock(self, MockChecker):
+        from unittest.mock import MagicMock
+        result = MagicMock()
+        result.fixable_failures = []
+        result.critical_failures = []
+        result.can_proceed.return_value = True
+        result.is_healthy.return_value = True
+        result.warnings = []
+        instance = MagicMock()
+        instance.run.return_value = result
+        MockChecker.return_value = instance
+        return result
+
+    def test_doctor_prints_integrity_section_inside_project(self, tmp_path, capsys):
+        from unittest.mock import patch, MagicMock
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   return_value=self._ISSUES_REPORT) as mock_scan, \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            self._make_preflight_mock(MockChecker)
+            try:
+                cli.cmd_doctor(self._make_args())
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "Corpus integrity" in out
+        assert "readme" in out
+        assert "docs/scan.pdf" in out
+        assert "carta embed --repair" in out
+
+    def test_doctor_integrity_clean(self, tmp_path, capsys):
+        from unittest.mock import patch
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   return_value=self._CLEAN_REPORT), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            self._make_preflight_mock(MockChecker)
+            try:
+                cli.cmd_doctor(self._make_args())
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "Corpus integrity" in out
+        assert "no issues found" in out
+        assert "carta embed --repair" not in out
+
+    def test_doctor_outside_project(self, capsys):
+        """find_config raises FileNotFoundError — doctor finishes, no integrity section."""
+        from unittest.mock import patch
+        from carta import cli
+
+        with patch("carta.cli.find_config",
+                   side_effect=FileNotFoundError("no config")), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            self._make_preflight_mock(MockChecker)
+            try:
+                cli.cmd_doctor(self._make_args())
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "Corpus integrity" not in out
+
+    def test_doctor_integrity_scan_error(self, tmp_path, capsys):
+        """scan_corpus_integrity raises — doctor prints 'check skipped' and does not crash."""
+        from unittest.mock import patch
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   side_effect=RuntimeError("qdrant unreachable")), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            self._make_preflight_mock(MockChecker)
+            try:
+                cli.cmd_doctor(self._make_args())
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "check skipped" in out
+
+    def test_doctor_json_includes_corpus_integrity(self, tmp_path, capsys):
+        """With --json, corpus_integrity key is merged into the single JSON document."""
+        import json
+        from unittest.mock import patch, MagicMock
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        preflight_dict = {
+            "status": "healthy",
+            "can_proceed": True,
+            "summary": {"total": 1, "passed": 1, "failed": 0,
+                        "warnings": 0, "skipped": 0, "fixable": 0},
+            "checks": [],
+        }
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   return_value=self._ISSUES_REPORT), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            mock_result = MagicMock()
+            mock_result.fixable_failures = []
+            mock_result.critical_failures = []
+            mock_result.can_proceed.return_value = True
+            mock_result.is_healthy.return_value = True
+            mock_result.warnings = []
+            mock_result.to_dict.return_value = preflight_dict
+            mock_result.to_json.return_value = json.dumps(preflight_dict)
+            instance = MagicMock()
+            instance.run.return_value = mock_result
+            MockChecker.return_value = instance
+            try:
+                cli.cmd_doctor(self._make_args(json_flag=True))
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "corpus_integrity" in parsed
+        assert "slug_collisions" in parsed["corpus_integrity"]
+        assert "readme" in parsed["corpus_integrity"]["slug_collisions"]

--- a/carta/tests/test_embed.py
+++ b/carta/tests/test_embed.py
@@ -2,22 +2,18 @@
 
 import pytest
 from unittest.mock import MagicMock, patch
-from carta.embed.embed import _point_id, _point_id_versioned, upsert_chunks
+from carta.embed.embed import _point_id_versioned, _visual_point_id, upsert_chunks
 from carta.config import collection_for_doc_type
 
 
 class TestPointIdVersioned:
     """Test PAYLOAD-01: _point_id_versioned generates generation-aware UUIDs."""
 
-    def test_point_id_versioned_differs_from_point_id(self):
-        """_point_id_versioned produces different UUID than _point_id for same slug/chunk_index."""
-        slug = "test-doc"
-        chunk_index = 0
-
-        legacy_id = _point_id(slug, chunk_index)
-        versioned_id = _point_id_versioned(slug, chunk_index, 1)
-
-        assert legacy_id != versioned_id
+    def test_point_id_versioned_differs_per_key(self):
+        """Different keys produce different UUIDs."""
+        id_a = _point_id_versioned("docs/a/test-doc.md", 0, 1)
+        id_b = _point_id_versioned("docs/b/test-doc.md", 0, 1)
+        assert id_a != id_b
 
     def test_point_id_versioned_differs_per_generation(self):
         """Different generations produce different UUIDs."""
@@ -60,6 +56,7 @@ class TestUpsertChunksPayload:
         chunks = [
             {
                 "slug": "doc1",
+                "file_path": "docs/sub/doc1.md",
                 "chunk_index": 0,
                 "text": "chunk text",
                 "doc_generation": 2,
@@ -69,20 +66,19 @@ class TestUpsertChunksPayload:
 
         upsert_chunks(chunks, cfg, client=mock_client)
 
-        # Verify upsert was called with versioned ID
+        # Verify upsert was called with versioned ID derived from file_path
         mock_client.upsert.assert_called_once()
         points = mock_client.upsert.call_args[1]["points"]
         assert len(points) == 1
         point = points[0]
 
-        # Versioned ID should differ from legacy ID
-        legacy_id = _point_id("doc1", 0)
-        assert str(point.id) != legacy_id
+        expected_id = _point_id_versioned("docs/sub/doc1.md", 0, 2)
+        assert str(point.id) == expected_id
 
     @patch("carta.embed.embed.requests.post")
     @patch("carta.embed.embed.QdrantClient")
-    def test_upsert_chunks_without_doc_generation_uses_legacy_id(self, mock_client_class, mock_post):
-        """When chunk lacks doc_generation, upsert_chunks uses _point_id (backward compat)."""
+    def test_upsert_chunks_without_doc_generation_uses_file_path_id(self, mock_client_class, mock_post):
+        """When chunk lacks doc_generation, upsert_chunks uses _point_id_versioned with generation=1."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.collection_exists.return_value = True
@@ -102,9 +98,10 @@ class TestUpsertChunksPayload:
         chunks = [
             {
                 "slug": "doc1",
+                "file_path": "docs/sub/doc1.md",
                 "chunk_index": 0,
                 "text": "chunk text",
-                # No doc_generation key
+                # No doc_generation key — defaults to generation=1
             }
         ]
 
@@ -114,8 +111,8 @@ class TestUpsertChunksPayload:
         points = mock_client.upsert.call_args[1]["points"]
         point = points[0]
 
-        # Should use legacy ID
-        expected_id = _point_id("doc1", 0)
+        # Should use path-based versioned ID with generation=1
+        expected_id = _point_id_versioned("docs/sub/doc1.md", 0, 1)
         assert str(point.id) == expected_id
 
     @patch("carta.embed.embed.requests.post")
@@ -282,3 +279,47 @@ class TestUpsertChunksRouting:
 
     def test_image_description_still_routes_to_doc(self):
         assert self._run("image_description") == "p_doc"
+
+
+class TestPathBasedPointIds:
+    """Same-stem files must never share point IDs (the README-collision bug)."""
+
+    def test_same_stem_different_paths_get_distinct_ids(self):
+        id_a = _point_id_versioned("docs/ci/README.md", 0, 1)
+        id_b = _point_id_versioned("docs/diagrams/README.md", 0, 1)
+        assert id_a != id_b
+
+    def test_id_is_deterministic(self):
+        assert (_point_id_versioned("docs/ci/README.md", 3, 2)
+                == _point_id_versioned("docs/ci/README.md", 3, 2))
+
+    def test_visual_same_stem_different_paths_distinct(self):
+        id_a = _visual_point_id("docs/a/spec.pdf", 1)
+        id_b = _visual_point_id("docs/b/spec.pdf", 1)
+        assert id_a != id_b
+
+    @patch("carta.embed.embed.requests.post")
+    @patch("carta.embed.embed.collection_is_hybrid", return_value=False)
+    @patch("carta.embed.embed.ensure_collection")
+    def test_upsert_uses_file_path_for_point_id(self, mock_ensure, mock_hybrid, mock_post):
+        """build_point derives the ID from chunk['file_path'], not slug."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"embedding": [0.1] * 768}
+        mock_client = MagicMock()
+
+        cfg = {
+            "project_name": "test",
+            "qdrant_url": "http://localhost:6333",
+            "embed": {
+                "ollama_url": "http://localhost:11434",
+                "ollama_model": "nomic-embed-text:latest",
+                "embedding_workers": 1,
+            },
+        }
+        chunk = {"slug": "readme", "file_path": "docs/ci/README.md",
+                 "chunk_index": 0, "text": "hello world", "doc_type": "unknown"}
+        upsert_chunks([chunk], cfg, client=mock_client)
+
+        points = mock_client.upsert.call_args.kwargs["points"]
+        expected = _point_id_versioned("docs/ci/README.md", 0, 1)
+        assert points[0].id == expected

--- a/carta/tests/test_embed.py
+++ b/carta/tests/test_embed.py
@@ -323,3 +323,49 @@ class TestPathBasedPointIds:
         points = mock_client.upsert.call_args.kwargs["points"]
         expected = _point_id_versioned("docs/ci/README.md", 0, 1)
         assert points[0].id == expected
+
+
+class TestEmptyChunkGuard:
+    """upsert_chunks must drop empty/whitespace-only chunks before embedding."""
+
+    @patch("carta.embed.embed.requests.post")
+    @patch("carta.embed.embed.collection_is_hybrid", return_value=False)
+    @patch("carta.embed.embed.ensure_collection")
+    def test_empty_chunks_are_not_upserted(self, mock_ensure, mock_hybrid, mock_post):
+        """Empty and whitespace-only chunks are dropped; only real content is upserted."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"embedding": [0.1] * 768}
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = True
+        info = MagicMock()
+        info.config.params.vectors = None
+        info.config.params.sparse_vectors = None
+        mock_client.get_collection.return_value = info
+        cfg = {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                      "embedding_workers": 1},
+        }
+        chunks = [
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 0, "text": ""},
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 1, "text": "   \n"},
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 2, "text": "real content"},
+        ]
+        count = upsert_chunks(chunks, cfg, client=mock_client)
+        assert count == 1
+        points = mock_client.upsert.call_args.kwargs["points"]
+        assert len(points) == 1
+        assert points[0].payload["text"] == "real content"
+
+    def test_all_empty_returns_zero_without_upsert(self):
+        """When all chunks are empty, upsert is never called and 0 is returned."""
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = True
+        cfg = {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+        }
+        chunks = [{"slug": "d", "file_path": "d.pdf", "chunk_index": 0, "text": ""}]
+        count = upsert_chunks(chunks, cfg, client=mock_client)
+        assert count == 0
+        mock_client.upsert.assert_not_called()

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -273,3 +273,125 @@ def test_partial_upsert_skips_cleanup_and_warns(mock_upsert, mock_del, tmp_path,
         f"  stdout: {captured.out!r}\n"
         f"  stderr: {captured.err!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: zero-usable-chunks files are flagged extraction_failed
+# ---------------------------------------------------------------------------
+
+@patch("carta.embed.pipeline.upsert_chunks", return_value=0)
+def test_zero_usable_chunks_marks_extraction_failed(mock_upsert, tmp_path, capsys):
+    """A file that yields zero usable text chunks gets status=extraction_failed.
+
+    An empty markdown file produces zero chunks (not empty-text chunks), so the
+    check must handle the case where len(enriched) == 0 directly.
+    """
+    from carta.embed.pipeline import _embed_one_file
+
+    repo = tmp_path
+    doc = repo / "docs" / "scan.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("")  # extraction yields nothing
+
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    count, updates = _embed_one_file(
+        doc, {"slug": "scan", "doc_type": "unknown"},
+        cfg, MagicMock(), repo, 800, 0.15,
+    )
+    assert count == 0
+    assert updates["status"] == "extraction_failed"
+    captured = capsys.readouterr()
+    assert "0 extractable characters" in captured.out or "0 extractable characters" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test 5: partial-empty enriched list — cleanup gate uses non-empty count
+# ---------------------------------------------------------------------------
+
+@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.upsert_chunks", return_value=2)
+def test_partial_empty_chunks_cleanup_gate_uses_nonempty_count(mock_upsert, mock_del, tmp_path):
+    """When some chunks are empty and upsert_chunks returns 2 (non-empty count),
+    cleanup SHOULD be called — expected_text must count only non-empty chunks.
+
+    This verifies that the expected_text fix doesn't accidentally break the gate
+    for files where some (but not all) chunks are empty.
+    """
+    from carta.embed.pipeline import _embed_one_file
+
+    repo = tmp_path
+    doc = repo / "docs" / "c.md"
+    doc.parent.mkdir(parents=True)
+    # Write content that produces chunks; upsert_chunks is patched to return 2
+    # (simulating 3 raw chunks of which 1 was empty and dropped by the guard).
+    doc.write_text("# Title\n\nsome content\n\nmore content\n\neven more content\n")
+
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    file_info = {"slug": "c", "doc_type": "unknown", "generation": 1}
+
+    # Patch chunk_text to return 3 chunks where 1 is empty-text, 2 are real.
+    # This simulates the scenario where upsert_chunks drops 1 empty, returns 2.
+    with patch("carta.embed.pipeline.chunk_text") as mock_chunk:
+        mock_chunk.return_value = [
+            {"chunk_index": 0, "text": "real content one"},
+            {"chunk_index": 1, "text": ""},  # empty — will be dropped by guard
+            {"chunk_index": 2, "text": "real content two"},
+        ]
+        _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+
+    # With expected_text = 2 (non-empty) and upsert returning 2, gate must pass
+    mock_del.assert_called_once()
+
+
+@patch("carta.embed.pipeline.upsert_chunks", return_value=0)
+@patch("carta.embed.pipeline.extract_pdf_text_and_classify")
+@patch("carta.embed.pipeline.PageAnalyzer")
+def test_pdf_zero_usable_no_queue_marks_extraction_failed(
+        mock_analyzer, mock_extract, mock_upsert, tmp_path, capsys):
+    """A PDF with no extractable text and no pages queued for pass-2 is flagged."""
+    from carta.embed.pipeline import _embed_one_file
+    repo = tmp_path
+    doc = repo / "docs" / "scan.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4 fake")
+    mock_extract.return_value = ([{"page": 1, "text": ""}], [])
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    count, updates = _embed_one_file(doc, {"slug": "scan", "doc_type": "unknown"},
+                                     cfg, MagicMock(), repo, 800, 0.15)
+    assert count == 0
+    assert updates["status"] == "extraction_failed"
+    assert "0 extractable characters" in capsys.readouterr().out
+
+
+@patch("carta.embed.pipeline._mark_or_collect_visual_pages")
+@patch("carta.embed.pipeline.upsert_chunks", return_value=0)
+@patch("carta.embed.pipeline.extract_pdf_text_and_classify")
+@patch("carta.embed.pipeline.PageAnalyzer")
+def test_pdf_zero_text_with_queued_visual_pages_not_flagged(
+        mock_analyzer, mock_extract, mock_upsert, mock_mark, tmp_path):
+    """A PDF awaiting pass-2 visual embedding is NOT extraction_failed."""
+    from carta.embed.pipeline import _embed_one_file
+    from carta.embed.visual_queue import VISUAL_PENDING_KEY
+    repo = tmp_path
+    doc = repo / "docs" / "scan.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4 fake")
+    mock_extract.return_value = ([{"page": 1, "text": ""}], [object()])
+    mock_mark.return_value = {VISUAL_PENDING_KEY: [1]}
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    count, updates = _embed_one_file(doc, {"slug": "scan", "doc_type": "unknown"},
+                                     cfg, MagicMock(), repo, 800, 0.15)
+    assert count == 0
+    assert updates["status"] != "extraction_failed"

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -118,7 +118,7 @@ def test_targeted_multiple_files_all_processed(mock_find_config, mock_load_confi
         assert mock_run_embed_file.call_count == 3
 
 
-@patch("carta.embed.pipeline.upsert_chunks", return_value=2)
+@patch("carta.embed.pipeline.upsert_chunks", return_value=1)
 @patch("carta.embed.pipeline.delete_other_generations")
 def test_embed_one_file_cleans_other_generations(mock_del, mock_upsert, tmp_path):
     """_embed_one_file calls delete_other_generations with correct file_path and generation."""
@@ -144,3 +144,132 @@ def test_embed_one_file_cleans_other_generations(mock_del, mock_upsert, tmp_path
     # Verify chunks passed to upsert carry doc_generation == 2
     upsert_call_chunks = mock_upsert.call_args.args[0]
     assert all(c.get("doc_generation") == 2 for c in upsert_call_chunks)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: run_embed_file resets visual_done on hash-changed re-embed
+# ---------------------------------------------------------------------------
+
+@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.upsert_chunks", return_value=3)
+@patch("carta.embed.pipeline.mark_sidecar_stale")
+@patch("carta.embed.pipeline.ensure_collection")
+@patch("carta.embed.pipeline.QdrantClient")
+@patch("carta.embed.pipeline._update_sidecar")
+@patch("carta.embed.pipeline.read_sidecar")
+@patch("carta.embed.pipeline.write_sidecar")
+@patch("carta.embed.pipeline.sidecar_path")
+@patch("carta.embed.pipeline.compute_file_hash", return_value="newhash")
+@patch("carta.embed.pipeline.needs_rehash", return_value=True)
+@patch("carta.embed.pipeline.find_config")
+def test_run_embed_file_resets_visual_done_on_hash_change(
+    mock_find_config,
+    mock_needs_rehash,
+    mock_compute_hash,
+    mock_sidecar_path,
+    mock_write_sidecar,
+    mock_read_sidecar,
+    mock_update_sidecar,
+    MockQdrantClient,
+    mock_ensure_collection,
+    mock_mark_stale,
+    mock_upsert,
+    mock_del,
+    tmp_path,
+):
+    """run_embed_file on a hash-changed file must write visual_done: [] into the sidecar.
+
+    Regression: before fix, visual_done was never cleared on re-embed, so
+    add_pending_pages excluded already-done pages and OCR chunks were permanently lost.
+    """
+    from carta.embed.pipeline import run_embed_file
+    from carta.embed.visual_queue import VISUAL_DONE_KEY
+
+    # Set up a real markdown file so _embed_one_file can read it
+    doc = tmp_path / "docs" / "a.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Title\n\nsome content here to chunk\n")
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.touch()
+    mock_find_config.return_value = cfg_path
+
+    sc_path = tmp_path / ".carta" / "sidecars" / "a.embed-meta.yaml"
+    mock_sidecar_path.return_value = sc_path
+    sc_path.parent.mkdir(parents=True)
+    sc_path.touch()
+
+    # Sidecar already has some visual_done pages from a previous visual pass
+    mock_read_sidecar.return_value = {
+        "slug": "a",
+        "doc_type": "unknown",
+        "generation": 1,
+        "file_hash": "oldhash",
+        "sidecar_id": None,
+        VISUAL_DONE_KEY: [1, 2, 3],
+    }
+
+    cfg = {
+        "project_name": "test",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+
+    run_embed_file(doc, cfg)
+
+    # Collect all _update_sidecar calls and merge their updates (last write wins per key)
+    assert mock_update_sidecar.called, "_update_sidecar was never called"
+    merged = {}
+    for c in mock_update_sidecar.call_args_list:
+        merged.update(c.args[1])
+
+    assert VISUAL_DONE_KEY in merged, (
+        f"visual_done key not written to sidecar on hash-change re-embed; "
+        f"sidecar updates keys: {list(merged.keys())}"
+    )
+    assert merged[VISUAL_DONE_KEY] == [], (
+        f"Expected visual_done=[] after hash-change re-embed, got: {merged[VISUAL_DONE_KEY]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: partial upsert skips delete_other_generations and prints warning
+# ---------------------------------------------------------------------------
+
+@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.upsert_chunks", return_value=1)   # partial: returns 1, expected >= 2
+def test_partial_upsert_skips_cleanup_and_warns(mock_upsert, mock_del, tmp_path, capsys):
+    """When upsert_chunks returns fewer chunks than attempted, cleanup must be skipped
+    and a warning mentioning 'partial upsert' must be printed.
+
+    Regression: before fix, cleanup after partial upsert deleted gen-1 points while
+    the failed gen-2 batch left those chunk indexes in neither generation.
+    """
+    from carta.embed.pipeline import _embed_one_file
+
+    repo = tmp_path
+    doc = repo / "docs" / "b.md"
+    doc.parent.mkdir(parents=True)
+    # Write enough content to produce at least 2 chunks
+    doc.write_text("# Title\n\n" + ("word " * 200) + "\n\n" + ("more content " * 200) + "\n")
+
+    cfg = {
+        "project_name": "test",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    file_info = {"slug": "b", "doc_type": "unknown", "generation": 2}
+
+    _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+
+    # Cleanup must NOT have been called
+    mock_del.assert_not_called()
+
+    # Warning must be printed mentioning "partial upsert"
+    captured = capsys.readouterr()
+    assert "partial upsert" in captured.out or "partial upsert" in captured.err, (
+        f"Expected 'partial upsert' warning in stdout/stderr; got:\n"
+        f"  stdout: {captured.out!r}\n"
+        f"  stderr: {captured.err!r}"
+    )

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -471,3 +471,140 @@ def test_empty_image_description_does_not_trip_partial_upsert_gate(
     out = capsys.readouterr()
     assert "partial upsert" not in out.out + out.err
     mock_del.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Sidecar status bookkeeping fix + true force re-embed
+# ---------------------------------------------------------------------------
+
+class TestRunEmbedFileLifecycle:
+    def _cfg(self):
+        return {
+            "project_name": "test",
+            "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+        }
+
+    def _setup_repo(self, tmp_path):
+        """Create a minimal repo with .carta dir and a doc file."""
+        repo = tmp_path
+        (repo / ".carta").mkdir()
+        doc = repo / "docs" / "a.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# hi\n\ncontent\n")
+        return repo, doc
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline.mark_sidecar_stale")
+    @patch("carta.embed.pipeline._embed_one_file",
+           return_value=(3, {"status": "embedded", "chunk_count": 3}))
+    @patch("carta.embed.pipeline.find_config")
+    def test_successful_embed_ends_embedded_not_stale(
+            self, mock_fc, mock_embed, mock_mark, mock_ensure, mock_qc, tmp_path):
+        """After successful re-embed: sidecar status == 'embedded' and stale_as_of is None."""
+        from carta.embed.pipeline import run_embed_file
+        from carta.embed.induct import sidecar_path, read_sidecar
+        repo, doc = self._setup_repo(tmp_path)
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+
+        result = run_embed_file(doc, self._cfg(), force=True)
+
+        assert result["status"] == "ok"
+        sc = read_sidecar(sidecar_path(doc, repo))
+        assert sc["status"] == "embedded", (
+            f"Expected status='embedded' after successful re-embed, got {sc['status']!r}. "
+            f"Bug: lifecycle_updates clobbered _embed_one_file's status."
+        )
+        assert sc["stale_as_of"] is None, (
+            f"Expected stale_as_of=None after successful re-embed, got {sc['stale_as_of']!r}."
+        )
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline.mark_sidecar_stale")
+    @patch("carta.embed.pipeline._embed_one_file",
+           return_value=(0, {"status": "extraction_failed", "chunk_count": 0}))
+    @patch("carta.embed.pipeline.find_config")
+    def test_extraction_failed_status_survives_lifecycle_merge(
+            self, mock_fc, mock_embed, mock_mark, mock_ensure, mock_qc, tmp_path):
+        """extraction_failed from _embed_one_file must not be overwritten by lifecycle_updates."""
+        from carta.embed.pipeline import run_embed_file
+        from carta.embed.induct import sidecar_path, read_sidecar
+        repo, doc = self._setup_repo(tmp_path)
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+
+        result = run_embed_file(doc, self._cfg(), force=True)
+
+        assert result["status"] == "ok"
+        sc = read_sidecar(sidecar_path(doc, repo))
+        assert sc["status"] == "extraction_failed", (
+            f"Expected status='extraction_failed' to survive lifecycle merge, got {sc['status']!r}. "
+            f"Bug: lifecycle_updates clobbered the extraction_failed status."
+        )
+        assert sc["stale_as_of"] is None, (
+            f"Expected stale_as_of=None even on extraction_failed, got {sc['stale_as_of']!r}."
+        )
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline.mark_sidecar_stale")
+    @patch("carta.embed.pipeline.find_config")
+    def test_force_reembeds_even_when_hash_unchanged(
+            self, mock_fc, mock_mark, mock_ensure, mock_qc, tmp_path):
+        """force=True must bypass the hash short-circuit — _embed_one_file called on both runs."""
+        from carta.embed.pipeline import run_embed_file
+        repo, doc = self._setup_repo(tmp_path)
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+        cfg = self._cfg()
+
+        embed_returns = [
+            (3, {"status": "embedded", "chunk_count": 3}),
+            (3, {"status": "embedded", "chunk_count": 3}),
+        ]
+        with patch("carta.embed.pipeline._embed_one_file",
+                   side_effect=embed_returns) as mock_embed:
+            # First run: inducts the file (no existing sidecar)
+            result1 = run_embed_file(doc, cfg, force=True)
+            assert result1["status"] == "ok"
+            assert mock_embed.call_count == 1
+
+            # Second run with force=True: same file, same content — must still re-embed
+            result2 = run_embed_file(doc, cfg, force=True)
+            assert result2["status"] == "ok", (
+                f"Expected force=True to re-embed unchanged file, got status={result2['status']!r}. "
+                f"Bug: hash short-circuit still fires when force=True."
+            )
+            assert mock_embed.call_count == 2, (
+                f"Expected _embed_one_file called twice (force bypasses hash), "
+                f"got {mock_embed.call_count} calls."
+            )
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline.mark_sidecar_stale")
+    @patch("carta.embed.pipeline.find_config")
+    def test_no_force_hash_unchanged_still_skips(
+            self, mock_fc, mock_mark, mock_ensure, mock_qc, tmp_path):
+        """Without force, a file whose hash matches the sidecar must be skipped on the second run."""
+        from carta.embed.pipeline import run_embed_file
+        repo, doc = self._setup_repo(tmp_path)
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+        cfg = self._cfg()
+
+        with patch("carta.embed.pipeline._embed_one_file",
+                   return_value=(3, {"status": "embedded", "chunk_count": 3})) as mock_embed:
+            # First run with force=True to seed the sidecar with the current hash
+            result1 = run_embed_file(doc, cfg, force=True)
+            assert result1["status"] == "ok"
+            assert mock_embed.call_count == 1
+
+            # Second run WITHOUT force: hash is unchanged — must skip
+            result2 = run_embed_file(doc, cfg, force=False)
+            assert result2["status"] == "skipped", (
+                f"Expected 'skipped' when force=False and hash unchanged, got {result2['status']!r}."
+            )
+            # _embed_one_file must NOT have been called again
+            assert mock_embed.call_count == 1, (
+                f"Expected _embed_one_file NOT called on skip, but call count is {mock_embed.call_count}."
+            )

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -116,3 +116,31 @@ def test_targeted_multiple_files_all_processed(mock_find_config, mock_load_confi
 
         assert exc_info.value.code == 1
         assert mock_run_embed_file.call_count == 3
+
+
+@patch("carta.embed.pipeline.upsert_chunks", return_value=2)
+@patch("carta.embed.pipeline.delete_other_generations")
+def test_embed_one_file_cleans_other_generations(mock_del, mock_upsert, tmp_path):
+    """_embed_one_file calls delete_other_generations with correct file_path and generation."""
+    from carta.embed.pipeline import _embed_one_file
+
+    repo = tmp_path
+    doc = repo / "docs" / "a.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Title\n\nsome content here\n")
+    cfg = {
+        "project_name": "test",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    file_info = {"slug": "a", "doc_type": "unknown", "generation": 2}
+    count, updates = _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+
+    mock_del.assert_called_once()
+    args = mock_del.call_args.args
+    assert args[2] == "docs/a.md"
+    assert args[3] == 2
+
+    # Verify chunks passed to upsert carry doc_generation == 2
+    upsert_call_chunks = mock_upsert.call_args.args[0]
+    assert all(c.get("doc_generation") == 2 for c in upsert_call_chunks)

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -395,3 +395,79 @@ def test_pdf_zero_text_with_queued_visual_pages_not_flagged(
                                      cfg, MagicMock(), repo, 800, 0.15)
     assert count == 0
     assert updates["status"] != "extraction_failed"
+
+
+@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline._build_vision_metadata", return_value=None)
+@patch("carta.embed.pipeline.extract_pdf_text_and_classify")
+@patch("carta.embed.pipeline.PageAnalyzer")
+def test_empty_image_chunks_do_not_trip_partial_upsert_gate(
+        mock_analyzer, mock_extract, mock_vmeta, mock_del, tmp_path, capsys):
+    """A dropped (empty-text) image chunk is a clean drop, not a partial failure:
+    the stale-generation cleanup must still run and no partial-upsert warning prints."""
+    from carta.embed import pipeline as pl
+    repo = tmp_path
+    doc = repo / "docs" / "mixed.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4 fake")
+    # Text extraction yields one real chunk; classification fails (None) so the
+    # legacy inline-vision path is skipped — we instead exercise the gate math
+    # directly through upsert_chunks' real drop behaviour via the text path.
+    mock_extract.side_effect = Exception("classify boom")
+
+    real_counts = {}
+    def fake_upsert(chunks, cfg, client=None):
+        # emulate upsert_chunks' drop filter faithfully
+        kept = [c for c in chunks if (c.get("text") or "").strip()]
+        real_counts["attempted"] = len(chunks)
+        real_counts["kept"] = len(kept)
+        return len(kept)
+
+    with patch("carta.embed.pipeline.upsert_chunks", side_effect=fake_upsert), \
+         patch("carta.embed.pipeline.extract_pdf_text",
+               return_value=[{"page": 1, "text": "real text"}, {"page": 2, "text": ""}]):
+        cfg = {"project_name": "test", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                         "two_pass_visual": True}}
+        count, updates = pl._embed_one_file(doc, {"slug": "mixed", "doc_type": "unknown"},
+                                            cfg, MagicMock(), repo, 800, 0.15)
+
+    out = capsys.readouterr()
+    assert "partial upsert" not in out.out + out.err
+    mock_del.assert_called_once()
+
+
+@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline._build_vision_metadata", return_value=None)
+def test_empty_image_description_does_not_trip_partial_upsert_gate(
+        mock_vmeta, mock_del, tmp_path, capsys):
+    """An empty VLM/OCR description yields an empty image chunk that upsert_chunks
+    drops — a clean drop, not a partial failure. Cleanup must still run."""
+    from carta.embed import pipeline as pl
+
+    repo = tmp_path
+    doc = repo / "docs" / "imgs.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4 fake")
+
+    def fake_upsert(chunks, cfg, client=None):
+        return len([c for c in chunks if (c.get("text") or "").strip()])
+
+    descs = [
+        {"text": "a real diagram description", "page_num": 1, "image_index": 0},
+        {"text": "", "page_num": 2, "image_index": 0},  # blank page → empty desc
+    ]
+    with patch("carta.embed.pipeline.upsert_chunks", side_effect=fake_upsert), \
+         patch("carta.embed.pipeline.extract_pdf_text",
+               return_value=[{"page": 1, "text": "real body text"}]), \
+         patch("carta.vision.router.extract_image_descriptions_intelligent",
+               return_value=descs):
+        cfg = {"project_name": "test", "qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                         "two_pass_visual": False}}
+        count, updates = pl._embed_one_file(doc, {"slug": "imgs", "doc_type": "unknown"},
+                                            cfg, MagicMock(), repo, 800, 0.15)
+
+    out = capsys.readouterr()
+    assert "partial upsert" not in out.out + out.err
+    mock_del.assert_called_once()

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -119,10 +119,11 @@ def test_targeted_multiple_files_all_processed(mock_find_config, mock_load_confi
 
 
 @patch("carta.embed.pipeline.upsert_chunks", return_value=1)
-@patch("carta.embed.pipeline.delete_other_generations")
-def test_embed_one_file_cleans_other_generations(mock_del, mock_upsert, tmp_path):
-    """_embed_one_file calls delete_other_generations with correct file_path and generation."""
+@patch("carta.embed.pipeline.delete_other_points")
+def test_embed_one_file_cleans_other_points(mock_del, mock_upsert, tmp_path):
+    """_embed_one_file calls delete_other_points with correct file_path and keep_ids."""
     from carta.embed.pipeline import _embed_one_file
+    from carta.embed.embed import _point_id_versioned
 
     repo = tmp_path
     doc = repo / "docs" / "a.md"
@@ -137,20 +138,104 @@ def test_embed_one_file_cleans_other_generations(mock_del, mock_upsert, tmp_path
     count, updates = _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
 
     mock_del.assert_called_once()
-    args = mock_del.call_args.args
-    assert args[2] == "docs/a.md"
-    assert args[3] == 2
+    kwargs = mock_del.call_args.kwargs
+    assert kwargs["rel_path"] == "docs/a.md"
+    # keep_ids must be path-derived (not slug-derived), at generation 2
+    keep_ids = kwargs["keep_ids"]
+    assert len(keep_ids) >= 1
+    for kid in keep_ids:
+        # Every ID must be derivable from the file_path (not slug) at gen 2
+        assert kid == _point_id_versioned("docs/a.md", 0, 2) or any(
+            kid == _point_id_versioned("docs/a.md", i, 2) for i in range(10)
+        )
 
     # Verify chunks passed to upsert carry doc_generation == 2
     upsert_call_chunks = mock_upsert.call_args.args[0]
     assert all(c.get("doc_generation") == 2 for c in upsert_call_chunks)
 
 
+@patch("carta.embed.pipeline.upsert_chunks", return_value=1)
+@patch("carta.embed.pipeline.delete_other_points")
+def test_c1_regression_same_generation_cleanup(mock_del, mock_upsert, tmp_path):
+    """C1 regression: re-embed without a generation key (bulk path, generation defaults to 1)
+    must still call delete_other_points with the correct path-derived keep_ids.
+
+    Before the fix, bulk sidecars had generation=0 → first re-embed computed
+    new_generation=0+1=1, reusing generation 1, so delete_other_generations skipped
+    all prior gen-1 points. This test pins that cleanup no longer depends on
+    generation arithmetic — it deletes by ID-set.
+    """
+    from carta.embed.pipeline import _embed_one_file
+    from carta.embed.embed import _point_id_versioned
+
+    repo = tmp_path
+    doc = repo / "docs" / "bulk.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Bulk\n\nsome content for bulk embed\n")
+
+    cfg = {
+        "project_name": "test",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    # Bulk path: file_info has NO generation key — defaults to 1 inside _embed_one_file
+    file_info = {"slug": "bulk", "doc_type": "unknown"}
+    count, updates = _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+
+    # delete_other_points MUST be called even when generation stays at 1
+    mock_del.assert_called_once()
+    kwargs = mock_del.call_args.kwargs
+    assert kwargs["rel_path"] == "docs/bulk.md"
+
+    # keep_ids must be path-derived at generation 1
+    keep_ids = kwargs["keep_ids"]
+    assert len(keep_ids) >= 1
+    expected_id_0 = _point_id_versioned("docs/bulk.md", 0, 1)
+    assert expected_id_0 in keep_ids, (
+        f"Expected path-derived ID for chunk 0 gen 1 ({expected_id_0!r}) in keep_ids, "
+        f"but got: {keep_ids}"
+    )
+
+
+@patch("carta.embed.pipeline.upsert_chunks", return_value=1)
+@patch("carta.embed.pipeline.delete_other_points")
+def test_bulk_path_persists_generation_in_sidecar_updates(mock_del, mock_upsert, tmp_path):
+    """Part 2 — bulk path (no generation in file_info) must include generation: 1 in sidecar_updates.
+
+    Before the fix, bulk sidecars stayed at generation=0, so the next targeted
+    re-embed computed new_generation = 0+1 = 1, reusing generation 1, and the
+    old generation-arithmetic cleanup skipped all prior gen-1 points.
+    """
+    from carta.embed.pipeline import _embed_one_file
+
+    repo = tmp_path
+    doc = repo / "docs" / "bulk2.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Bulk Gen Persistence\n\nsome content to embed\n")
+
+    cfg = {
+        "project_name": "test",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    # Bulk path: no generation key in file_info
+    file_info = {"slug": "bulk2", "doc_type": "unknown"}
+    count, sidecar_updates = _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+
+    assert "generation" in sidecar_updates, (
+        "sidecar_updates must include 'generation' so the bulk sidecar tracks the "
+        "correct generation and future re-embeds don't reuse stale generation numbers"
+    )
+    assert sidecar_updates["generation"] == 1, (
+        f"Expected generation=1 in sidecar_updates (bulk default), got {sidecar_updates.get('generation')!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 2: run_embed_file resets visual_done on hash-changed re-embed
 # ---------------------------------------------------------------------------
 
-@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.delete_other_points")
 @patch("carta.embed.pipeline.upsert_chunks", return_value=3)
 @patch("carta.embed.pipeline.mark_sidecar_stale")
 @patch("carta.embed.pipeline.ensure_collection")
@@ -174,7 +259,7 @@ def test_run_embed_file_resets_visual_done_on_hash_change(
     mock_ensure_collection,
     mock_mark_stale,
     mock_upsert,
-    mock_del,
+    mock_del_other_points,
     tmp_path,
 ):
     """run_embed_file on a hash-changed file must write visual_done: [] into the sidecar.
@@ -234,10 +319,10 @@ def test_run_embed_file_resets_visual_done_on_hash_change(
 
 
 # ---------------------------------------------------------------------------
-# Test 3: partial upsert skips delete_other_generations and prints warning
+# Test 3: partial upsert skips delete_other_points and prints warning
 # ---------------------------------------------------------------------------
 
-@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.delete_other_points")
 @patch("carta.embed.pipeline.upsert_chunks", return_value=1)   # partial: returns 1, expected >= 2
 def test_partial_upsert_skips_cleanup_and_warns(mock_upsert, mock_del, tmp_path, capsys):
     """When upsert_chunks returns fewer chunks than attempted, cleanup must be skipped
@@ -311,7 +396,7 @@ def test_zero_usable_chunks_marks_extraction_failed(mock_upsert, tmp_path, capsy
 # Test 5: partial-empty enriched list — cleanup gate uses non-empty count
 # ---------------------------------------------------------------------------
 
-@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.delete_other_points")
 @patch("carta.embed.pipeline.upsert_chunks", return_value=2)
 def test_partial_empty_chunks_cleanup_gate_uses_nonempty_count(mock_upsert, mock_del, tmp_path):
     """When some chunks are empty and upsert_chunks returns 2 (non-empty count),
@@ -397,7 +482,7 @@ def test_pdf_zero_text_with_queued_visual_pages_not_flagged(
     assert updates["status"] != "extraction_failed"
 
 
-@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.delete_other_points")
 @patch("carta.embed.pipeline._build_vision_metadata", return_value=None)
 @patch("carta.embed.pipeline.extract_pdf_text_and_classify")
 @patch("carta.embed.pipeline.PageAnalyzer")
@@ -437,7 +522,7 @@ def test_empty_image_chunks_do_not_trip_partial_upsert_gate(
     mock_del.assert_called_once()
 
 
-@patch("carta.embed.pipeline.delete_other_generations")
+@patch("carta.embed.pipeline.delete_other_points")
 @patch("carta.embed.pipeline._build_vision_metadata", return_value=None)
 def test_empty_image_description_does_not_trip_partial_upsert_gate(
         mock_vmeta, mock_del, tmp_path, capsys):

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -1,10 +1,11 @@
 """Tests for corpus-integrity scanning (doctor + embed --repair)."""
 import yaml
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from carta.embed.integrity import scan_corpus_integrity
 from carta.embed.lifecycle import compute_file_hash
+from carta.embed.repair import run_repair
 
 
 def _point(file_path, slug, chunk_index, text):
@@ -236,3 +237,174 @@ class TestScannerRobustness:
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
         assert report["count_mismatches"] == {"docs/lost.md": {"sidecar": 5, "qdrant": 0}}
         assert "docs/lost.md" in report["affected_files"]
+
+
+class TestRunRepair:
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_repair_deletes_points_then_reembeds_each_affected_file(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {"readme": ["docs/a/README.md", "docs/b/README.md"]},
+            "empty_files": [], "partial_empty_files": {}, "count_mismatches": {},
+            "stuck_stale": [],
+            "affected_files": ["docs/a/README.md", "docs/b/README.md"],
+        }
+        mock_reembed.return_value = {"status": "ok", "chunks": 5}
+        for rel in ("docs/a/README.md", "docs/b/README.md"):
+            f = tmp_path / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("# x\ncontent\n")
+
+        summary = run_repair(tmp_path, CFG)
+
+        client = mock_qc.return_value
+        assert client.delete.call_count == 2          # one purge per file
+        assert mock_reembed.call_count == 2
+        assert summary["repaired"] == 2
+        assert summary["purged_only"] == 0
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_missing_file_is_purged_not_reembedded(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": ["docs/gone.pdf"],
+            "partial_empty_files": {}, "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/gone.pdf"],
+        }
+        summary = run_repair(tmp_path, CFG)
+        assert mock_qc.return_value.delete.call_count == 1
+        mock_reembed.assert_not_called()
+        assert summary["purged_only"] == 1
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_extraction_failed_counts_as_flagged(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": ["docs/scan.pdf"],
+            "partial_empty_files": {}, "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/scan.pdf"],
+        }
+        f = tmp_path / "docs" / "scan.pdf"
+        f.parent.mkdir(parents=True)
+        f.write_bytes(b"%PDF-1.4 fake")
+        mock_reembed.return_value = {"status": "ok", "chunks": 0}
+        summary = run_repair(tmp_path, CFG)
+        assert summary["flagged"] == 1
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_stuck_stale_sidecars_fixed_in_place(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        """Stuck-stale file not in affected_files: sidecar gets status fixed, no delete/re-embed."""
+        from carta.embed.induct import sidecar_path as _sidecar_path
+        # Create the source file
+        src = tmp_path / "docs" / "s.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("content")
+        # Write sidecar at the path sidecar_path() would compute (production path)
+        sc_path = _sidecar_path(src, tmp_path)
+        sc_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(sc_path, "w") as f:
+            yaml.dump({"current_path": "docs/s.md", "chunk_count": 3,
+                       "status": "stale", "file_hash": "abc123"}, f)
+
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {}, "stuck_stale": ["docs/s.md"],
+            "affected_files": [],
+        }
+
+        summary = run_repair(tmp_path, CFG)
+
+        # No delete or re-embed for stuck-stale-only file
+        mock_qc.return_value.delete.assert_not_called()
+        mock_reembed.assert_not_called()
+        assert summary["stale_fixed"] == 1
+
+        # Sidecar YAML should now have status "embedded" and stale_as_of None
+        with open(sc_path) as f:
+            updated = yaml.safe_load(f)
+        assert updated["status"] == "embedded"
+        assert updated.get("stale_as_of") is None
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_stuck_stale_also_affected_not_double_handled(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        """File in BOTH stuck_stale and affected_files → re-embedded once, stale_fixed == 0."""
+        src = tmp_path / "docs" / "both.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("content")
+
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {"docs/both.md": {"sidecar": 5, "qdrant": 2}},
+            "stuck_stale": ["docs/both.md"],
+            "affected_files": ["docs/both.md"],
+        }
+        mock_reembed.return_value = {"status": "ok", "chunks": 5}
+
+        summary = run_repair(tmp_path, CFG)
+
+        # Re-embedded exactly once (via affected_files loop)
+        assert mock_reembed.call_count == 1
+        # stale_fixed == 0: the sidecar was already rewritten by re-embed
+        assert summary["stale_fixed"] == 0
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_reembed_exception_counts_failed(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        """run_embed_file raising RuntimeError → failed count increments, loop continues."""
+        for rel in ("docs/a.md", "docs/b.md"):
+            f = tmp_path / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("content")
+
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/a.md", "docs/b.md"],
+        }
+        # First call raises, second succeeds
+        mock_reembed.side_effect = [RuntimeError("boom"), {"status": "ok", "chunks": 3}]
+
+        summary = run_repair(tmp_path, CFG)
+
+        assert summary["failed"] == 1
+        assert summary["repaired"] == 1   # second file still processed
+        assert mock_reembed.call_count == 2
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_clean_corpus_noop(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path, capsys):
+        """Empty report → all counters 0, no client.delete, friendly message printed."""
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": [],
+        }
+
+        summary = run_repair(tmp_path, CFG)
+
+        mock_qc.return_value.delete.assert_not_called()
+        mock_reembed.assert_not_called()
+        assert summary["affected"] == 0
+        assert summary["repaired"] == 0
+        assert summary["purged_only"] == 0
+        assert summary["flagged"] == 0
+        assert summary["failed"] == 0
+        assert summary["stale_fixed"] == 0
+        out = capsys.readouterr().out
+        assert "nothing to repair" in out.lower()

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -1,0 +1,179 @@
+"""Tests for corpus-integrity scanning (doctor + embed --repair)."""
+import yaml
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from carta.embed.integrity import scan_corpus_integrity
+from carta.embed.lifecycle import compute_file_hash
+
+
+def _point(file_path, slug, chunk_index, text):
+    p = MagicMock()
+    p.payload = {"file_path": file_path, "slug": slug,
+                 "chunk_index": chunk_index, "text": text}
+    return p
+
+
+def _client_with_points(points):
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    client.scroll.return_value = (points, None)  # single page
+    return client
+
+
+CFG = {"project_name": "test", "qdrant_url": "http://localhost:6333",
+       "embed": {"ollama_url": "http://x", "ollama_model": "m"}}
+
+
+def _write_sidecar(tmp_path, rel_path, chunk_count, status, file_hash):
+    """Write a minimal sidecar YAML under tmp_path/.carta/sidecars/."""
+    sc_path = tmp_path / ".carta" / "sidecars" / (rel_path + ".embed-meta.yaml")
+    sc_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "current_path": rel_path,
+        "chunk_count": chunk_count,
+        "status": status,
+        "file_hash": file_hash,
+    }
+    with open(sc_path, "w") as f:
+        yaml.dump(data, f)
+    return sc_path
+
+
+class TestScanCorpusIntegrity:
+    def test_detects_slug_collisions(self, tmp_path):
+        pts = [
+            _point("docs/ci/README.md", "readme", 8, "a"),
+            _point("docs/diagrams/README.md", "readme", 0, "b"),
+            _point("docs/unique.md", "unique", 0, "c"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["slug_collisions"] == {
+            "readme": sorted(["docs/ci/README.md", "docs/diagrams/README.md"])}
+
+    def test_detects_empty_text_files(self, tmp_path):
+        pts = [
+            _point("docs/scan.pdf", "scan", 0, ""),
+            _point("docs/scan.pdf", "scan", 1, ""),
+            _point("docs/partial.pdf", "partial", 0, ""),
+            _point("docs/partial.pdf", "partial", 1, "real"),
+            _point("docs/ok.md", "ok", 0, "fine"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["empty_files"] == ["docs/scan.pdf"]
+        assert report["partial_empty_files"] == {"docs/partial.pdf": 1}
+
+    def test_clean_corpus_reports_nothing(self, tmp_path):
+        pts = [_point("docs/ok.md", "ok", 0, "fine")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["slug_collisions"] == {}
+        assert report["empty_files"] == []
+        assert report["partial_empty_files"] == {}
+        assert report["affected_files"] == []
+
+    def test_detects_count_mismatch(self, tmp_path):
+        # Write a real source file so hash can be computed
+        src = tmp_path / "docs" / "a.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("hello world content")
+        real_hash = compute_file_hash(src)
+
+        # Write sidecar claiming chunk_count=5 with status embedded
+        _write_sidecar(tmp_path, "docs/a.md", 5, "embedded", real_hash)
+
+        # Qdrant has only 2 points for that file
+        pts = [
+            _point("docs/a.md", "a", 0, "hello"),
+            _point("docs/a.md", "a", 1, "world"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["count_mismatches"] == {"docs/a.md": {"sidecar": 5, "qdrant": 2}}
+
+    def test_detects_stuck_stale(self, tmp_path):
+        # File on disk whose hash MATCHES the sidecar → stuck stale
+        src_match = tmp_path / "docs" / "match.md"
+        src_match.parent.mkdir(parents=True, exist_ok=True)
+        src_match.write_text("unchanged content")
+        matching_hash = compute_file_hash(src_match)
+        _write_sidecar(tmp_path, "docs/match.md", 3, "stale", matching_hash)
+
+        # File on disk whose hash DOES NOT match the sidecar → genuinely stale, skip
+        src_diff = tmp_path / "docs" / "diff.md"
+        src_diff.write_text("new content")
+        _write_sidecar(tmp_path, "docs/diff.md", 3, "stale", "0000deadbeef")
+
+        pts = [
+            _point("docs/match.md", "match", 0, "a"),
+            _point("docs/diff.md", "diff", 0, "b"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert "docs/match.md" in report["stuck_stale"]
+        assert "docs/diff.md" not in report["stuck_stale"]
+
+    def test_affected_files_unions_everything(self, tmp_path):
+        # slug collision: two files share slug "readme"
+        # empty: empty.pdf all empty
+        # partial: partial.pdf one empty point
+        # mismatch: mismatch.md sidecar=5, qdrant=1
+        # stuck_stale: stale.md — should NOT be in affected_files
+        src_mm = tmp_path / "docs" / "mismatch.md"
+        src_mm.parent.mkdir(parents=True, exist_ok=True)
+        src_mm.write_text("mismatch content")
+        mm_hash = compute_file_hash(src_mm)
+        _write_sidecar(tmp_path, "docs/mismatch.md", 5, "embedded", mm_hash)
+
+        src_stale = tmp_path / "docs" / "stale.md"
+        src_stale.write_text("stale content")
+        stale_hash = compute_file_hash(src_stale)
+        _write_sidecar(tmp_path, "docs/stale.md", 2, "stale", stale_hash)
+
+        pts = [
+            _point("docs/ci/README.md", "readme", 0, "x"),
+            _point("docs/diagrams/README.md", "readme", 0, "y"),
+            _point("docs/empty.pdf", "empty", 0, ""),
+            _point("docs/partial.pdf", "partial", 0, ""),
+            _point("docs/partial.pdf", "partial", 1, "real"),
+            _point("docs/mismatch.md", "mismatch", 0, "z"),
+            _point("docs/stale.md", "stale", 0, "s"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+
+        expected_affected = sorted([
+            "docs/ci/README.md",
+            "docs/diagrams/README.md",
+            "docs/empty.pdf",
+            "docs/partial.pdf",
+            "docs/mismatch.md",
+        ])
+        assert report["affected_files"] == expected_affected
+        assert "docs/stale.md" not in report["affected_files"]
+
+    def test_missing_collection(self, tmp_path):
+        client = MagicMock()
+        client.collection_exists.return_value = False
+        report = scan_corpus_integrity(CFG, tmp_path, client=client)
+        assert report["slug_collisions"] == {}
+        assert report["empty_files"] == []
+        assert report["partial_empty_files"] == {}
+        assert report["count_mismatches"] == {}
+        assert report["stuck_stale"] == []
+        assert report["affected_files"] == []
+
+    def test_multi_page_scroll(self, tmp_path):
+        """scroll returning two pages — all points must be seen."""
+        page1 = [_point("docs/a.md", "a", 0, "hello")]
+        page2 = [_point("docs/b.md", "b", 0, "world")]
+
+        client = MagicMock()
+        client.collection_exists.return_value = True
+        # First call returns page1 with a non-None offset; second returns page2 with None
+        client.scroll.side_effect = [
+            (page1, "cursor-abc"),
+            (page2, None),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=client)
+        # Both files should appear; no errors
+        assert report["empty_files"] == []
+        assert report["slug_collisions"] == {}
+        # scroll was called twice
+        assert client.scroll.call_count == 2

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -41,6 +41,17 @@ def _write_sidecar(tmp_path, rel_path, chunk_count, status, file_hash):
     return sc_path
 
 
+def _write_sidecar_at_production_path(tmp_path, rel_path, chunk_count, status, file_hash):
+    """Write a sidecar where sidecar_path() will look for it (with_suffix semantics)."""
+    from carta.embed.induct import sidecar_path
+    sc = sidecar_path(tmp_path / rel_path, tmp_path)
+    sc.parent.mkdir(parents=True, exist_ok=True)
+    with open(sc, "w") as f:
+        yaml.dump({"current_path": rel_path, "chunk_count": chunk_count,
+                   "status": status, "file_hash": file_hash}, f)
+    return sc
+
+
 class TestScanCorpusIntegrity:
     def test_detects_slug_collisions(self, tmp_path):
         pts = [
@@ -293,9 +304,37 @@ class TestRunRepair:
         f = tmp_path / "docs" / "scan.pdf"
         f.parent.mkdir(parents=True)
         f.write_bytes(b"%PDF-1.4 fake")
+        # The re-embed wrote an extraction_failed sidecar (zero usable text)
+        _write_sidecar_at_production_path(tmp_path, "docs/scan.pdf",
+                                          0, "extraction_failed", "abc")
         mock_reembed.return_value = {"status": "ok", "chunks": 0}
         summary = run_repair(tmp_path, CFG)
         assert summary["flagged"] == 1
+        assert summary.get("queued_visual", 0) == 0
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_zero_chunks_but_embedded_counts_queued_visual_not_flagged(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path, capsys):
+        """A two-pass-visual PDF re-embeds with 0 chunks but a HEALTHY sidecar
+        (pages queued for pass-2). It must not be reported as extraction_failed."""
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": ["docs/imgheavy.pdf"],
+            "partial_empty_files": {}, "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/imgheavy.pdf"],
+        }
+        f = tmp_path / "docs" / "imgheavy.pdf"
+        f.parent.mkdir(parents=True)
+        f.write_bytes(b"%PDF-1.4 fake")
+        _write_sidecar_at_production_path(tmp_path, "docs/imgheavy.pdf",
+                                          0, "embedded", "abc")
+        mock_reembed.return_value = {"status": "ok", "chunks": 0}
+        summary = run_repair(tmp_path, CFG)
+        assert summary["flagged"] == 0
+        assert summary["queued_visual"] == 1
+        out = capsys.readouterr().out
+        assert "extraction_failed" not in out.split("Repair complete")[0]
 
     @patch("carta.embed.repair.run_embed_file")
     @patch("carta.embed.repair.scan_corpus_integrity")

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -212,3 +212,27 @@ class TestStuckStaleCountMismatch:
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
         assert report["count_mismatches"] == {}
         assert report["stuck_stale"] == []
+
+
+class TestScannerRobustness:
+    def test_non_dict_sidecar_yaml_does_not_abort_scan(self, tmp_path):
+        """A corrupt sidecar that parses to a list/str must be skipped, not crash."""
+        bad = tmp_path / ".carta" / "sidecars" / "docs" / "bad.embed-meta.yaml"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("- a\n- b\n")
+        pts = [_point("docs/ok.md", "ok", 0, "fine")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["affected_files"] == []
+
+    def test_fully_lost_file_is_a_count_mismatch(self, tmp_path):
+        """A sidecar claiming chunks for a file with ZERO surviving points must
+        reach count_mismatches/affected_files (fully shadowed by legacy collisions)."""
+        src = tmp_path / "docs" / "lost.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("content whose points were all overwritten")
+        _write_sidecar(tmp_path, "docs/lost.md", 5, "embedded",
+                       compute_file_hash(src))
+        pts = [_point("docs/other.md", "other", 0, "fine")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["count_mismatches"] == {"docs/lost.md": {"sidecar": 5, "qdrant": 0}}
+        assert "docs/lost.md" in report["affected_files"]

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -122,10 +122,12 @@ class TestScanCorpusIntegrity:
         mm_hash = compute_file_hash(src_mm)
         _write_sidecar(tmp_path, "docs/mismatch.md", 5, "embedded", mm_hash)
 
+        # chunk_count matches Qdrant (1 point) — purely stuck-stale, no mismatch,
+        # so it must NOT reach affected_files (repair fixes its status in place).
         src_stale = tmp_path / "docs" / "stale.md"
         src_stale.write_text("stale content")
         stale_hash = compute_file_hash(src_stale)
-        _write_sidecar(tmp_path, "docs/stale.md", 2, "stale", stale_hash)
+        _write_sidecar(tmp_path, "docs/stale.md", 1, "stale", stale_hash)
 
         pts = [
             _point("docs/ci/README.md", "readme", 0, "x"),
@@ -177,3 +179,36 @@ class TestScanCorpusIntegrity:
         assert report["slug_collisions"] == {}
         # scroll was called twice
         assert client.scroll.call_count == 2
+
+
+class TestStuckStaleCountMismatch:
+    """A stuck-stale sidecar (status stale, hash matches disk) with a count
+    mismatch must appear in BOTH stuck_stale and count_mismatches, so repair
+    re-embeds it in one pass instead of converging over two runs."""
+
+    def test_stuck_stale_with_mismatch_is_in_both(self, tmp_path):
+        src = tmp_path / "docs" / "stuck.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("unchanged content with lost chunks")
+        real_hash = compute_file_hash(src)
+        _write_sidecar(tmp_path, "docs/stuck.md", 5, "stale", real_hash)
+
+        pts = [
+            _point("docs/stuck.md", "stuck", 8, "x"),
+            _point("docs/stuck.md", "stuck", 9, "y"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert "docs/stuck.md" in report["stuck_stale"]
+        assert report["count_mismatches"] == {"docs/stuck.md": {"sidecar": 5, "qdrant": 2}}
+        assert "docs/stuck.md" in report["affected_files"]
+
+    def test_genuinely_stale_mismatch_is_exempt(self, tmp_path):
+        src = tmp_path / "docs" / "pending.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("edited content awaiting re-embed")
+        _write_sidecar(tmp_path, "docs/pending.md", 5, "stale", "0000deadbeef")
+
+        pts = [_point("docs/pending.md", "pending", 0, "old text")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["count_mismatches"] == {}
+        assert report["stuck_stale"] == []

--- a/carta/tests/test_lifecycle.py
+++ b/carta/tests/test_lifecycle.py
@@ -15,7 +15,7 @@ from carta.embed.lifecycle import (
     cleanup_expired_orphans,
     is_protected_doc_type,
     check_stale_alert,
-    delete_other_generations,
+    delete_other_points,
 )
 
 
@@ -294,23 +294,34 @@ class TestCheckStaleAlert:
         assert "carta embed --force-stale" in result
 
 
-class TestDeleteOtherGenerations:
-    def test_deletes_by_file_path_excluding_current_generation(self):
+class TestDeleteOtherPoints:
+    def test_deletes_by_file_path_excluding_keep_ids(self):
+        """Filter: must file_path match; must_not HasIdCondition with keep list."""
+        from qdrant_client.models import HasIdCondition
         client = MagicMock()
-        delete_other_generations(client, "proj_doc", "docs/ci/README.md", keep_generation=3)
+        keep_ids = ["id-a", "id-b"]
+        delete_other_points(client, "proj_doc", "docs/ci/README.md", keep_ids=keep_ids)
 
         client.delete.assert_called_once()
         kwargs = client.delete.call_args.kwargs
         assert kwargs["collection_name"] == "proj_doc"
         sel = kwargs["points_selector"]
-        # must: file_path == docs/ci/README.md ; must_not: doc_generation == 3
+        # must: file_path == docs/ci/README.md
         assert sel.must[0].key == "file_path"
         assert sel.must[0].match.value == "docs/ci/README.md"
-        assert sel.must_not[0].key == "doc_generation"
-        assert sel.must_not[0].match.value == 3
+        # must_not: HasIdCondition with our keep_ids
+        assert len(sel.must_not) == 1
+        assert isinstance(sel.must_not[0], HasIdCondition)
+        assert sel.must_not[0].has_id == keep_ids
 
     def test_swallows_qdrant_errors(self):
         """Cleanup is best-effort: a delete failure must not fail the embed."""
         client = MagicMock()
         client.delete.side_effect = RuntimeError("boom")
-        delete_other_generations(client, "proj_doc", "x.md", keep_generation=1)  # no raise
+        delete_other_points(client, "proj_doc", "x.md", keep_ids=["id-x"])  # no raise
+
+    def test_empty_keep_ids_still_calls_delete(self):
+        """Edge case: if keep_ids is empty, delete is still called (purges all points)."""
+        client = MagicMock()
+        delete_other_points(client, "proj_doc", "x.md", keep_ids=[])
+        client.delete.assert_called_once()

--- a/carta/tests/test_lifecycle.py
+++ b/carta/tests/test_lifecycle.py
@@ -15,6 +15,7 @@ from carta.embed.lifecycle import (
     cleanup_expired_orphans,
     is_protected_doc_type,
     check_stale_alert,
+    delete_other_generations,
 )
 
 
@@ -291,3 +292,25 @@ class TestCheckStaleAlert:
         assert result is not None
         assert isinstance(result, str)
         assert "carta embed --force-stale" in result
+
+
+class TestDeleteOtherGenerations:
+    def test_deletes_by_file_path_excluding_current_generation(self):
+        client = MagicMock()
+        delete_other_generations(client, "proj_doc", "docs/ci/README.md", keep_generation=3)
+
+        client.delete.assert_called_once()
+        kwargs = client.delete.call_args.kwargs
+        assert kwargs["collection_name"] == "proj_doc"
+        sel = kwargs["points_selector"]
+        # must: file_path == docs/ci/README.md ; must_not: doc_generation == 3
+        assert sel.must[0].key == "file_path"
+        assert sel.must[0].match.value == "docs/ci/README.md"
+        assert sel.must_not[0].key == "doc_generation"
+        assert sel.must_not[0].match.value == 3
+
+    def test_swallows_qdrant_errors(self):
+        """Cleanup is best-effort: a delete failure must not fail the embed."""
+        client = MagicMock()
+        client.delete.side_effect = RuntimeError("boom")
+        delete_other_generations(client, "proj_doc", "x.md", keep_generation=1)  # no raise

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -493,7 +493,7 @@ class TestVisionIntegration:
             with patch("carta.embed.pipeline.extract_pdf_text", return_value=[{"page": 1, "text": "Sample text"}]):
                 with patch("carta.embed.pipeline.chunk_text", return_value=[{"text": "Chunk 1", "page": 1}]):
                     with patch("carta.vision.router.extract_image_descriptions_intelligent") as mock_vision:
-                        with patch("carta.embed.pipeline.upsert_chunks"):
+                        with patch("carta.embed.pipeline.upsert_chunks", return_value=0):
                             with patch("carta.embed.pipeline.write_sidecar"):
                                 # Vision returns 2 image chunks with Phase 999.4 metadata
                                 mock_vision.return_value = [
@@ -541,7 +541,7 @@ class TestVisionIntegration:
             with patch("carta.embed.pipeline.extract_pdf_text", return_value=[{"page": 1, "text": "Text content"}]):
                 with patch("carta.embed.pipeline.chunk_text", return_value=[{"text": "Chunk", "page": 1}]):
                     with patch("carta.vision.router.extract_image_descriptions_intelligent") as mock_vision:
-                        with patch("carta.embed.pipeline.upsert_chunks"):
+                        with patch("carta.embed.pipeline.upsert_chunks", return_value=0):
                             with patch("carta.embed.pipeline.write_sidecar"):
                                 # Vision model unavailable: returns empty (fail-open)
                                 mock_vision.return_value = []

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -157,8 +157,8 @@ class TestRunEmbedFileMinimalPath:
                             # status should remain "embedded"
                             assert updated["status"] == "embedded"
 
-    def test_hash_mismatch_increments_generation_marks_stale(self, temp_repo, mock_qdrant):
-        """Hash mismatch -> generation incremented, status='stale', stale_as_of set."""
+    def test_hash_mismatch_increments_generation_embeds(self, temp_repo, mock_qdrant):
+        """Hash mismatch -> generation incremented, re-embed runs, status='embedded', stale_as_of=None."""
         repo_root, cfg = temp_repo
 
         # Create test file
@@ -217,10 +217,10 @@ class TestRunEmbedFileMinimalPath:
 
                                     # Generation should increment
                                     assert updated["generation"] == 3
-                                    # Status should be stale
-                                    assert updated["status"] == "stale"
-                                    # stale_as_of should be set
-                                    assert "stale_as_of" in updated
+                                    # Status should be embedded (not stale — Bug A fix)
+                                    assert updated["status"] == "embedded"
+                                    # stale_as_of should be None after successful re-embed
+                                    assert updated.get("stale_as_of") is None
                                     # file_hash should be updated
                                     assert updated["file_hash"] == new_hash
                                     # version_history should have new entry

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1140,3 +1140,41 @@ class TestRunSearchDocType:
             results = run_search("q", cfg)
 
         assert results and results[0]["doc_type"] == "quirk"
+
+
+class TestRunEmbedExtractionFailedSummary:
+    """Files flagged extraction_failed must not count as embedded in the summary."""
+
+    def test_extraction_failed_counted_separately(self, tmp_path):
+        repo_root = tmp_path
+        (repo_root / ".carta").mkdir()
+        doc = repo_root / "docs" / "scan.pdf"
+        doc.parent.mkdir(parents=True)
+        doc.write_bytes(b"%PDF-1.4 fake")
+        sc_path = repo_root / ".carta" / "sidecars" / "docs" / "scan.embed-meta.yaml"
+        sc_path.parent.mkdir(parents=True)
+        sc_path.write_text("status: pending\n")
+
+        cfg = {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                      "status_file": False},
+        }
+        file_info = {"slug": "scan", "doc_type": "unknown",
+                     "file_path": doc, "sidecar_path": sc_path}
+
+        with patch("carta.embed.pipeline.find_config") as mock_find_cfg, \
+             patch("carta.embed.pipeline.QdrantClient"), \
+             patch("carta.embed.pipeline.ensure_collection"), \
+             patch("carta.embed.pipeline.discover_pending_files", return_value=[file_info]), \
+             patch("carta.embed.pipeline.discover_stale_files", return_value=[]), \
+             patch("carta.embed.pipeline._embed_one_file") as mock_embed, \
+             patch("carta.embed.pipeline._update_sidecar"), \
+             patch("builtins.print"):
+            mock_find_cfg.return_value = repo_root / ".carta" / "config.yaml"
+            mock_embed.return_value = (0, {"status": "extraction_failed",
+                                           "chunk_count": 0, "_vision_events": []})
+            summary = run_embed(repo_root, cfg, verbose=False)
+
+        assert summary["extraction_failed"] == 1
+        assert summary["embedded"] == 0

--- a/docs/superpowers/plans/2026-06-12-data-integrity.md
+++ b/docs/superpowers/plans/2026-06-12-data-integrity.md
@@ -10,7 +10,7 @@
 
 **Worktree:** Execute in an isolated worktree (branch `data-integrity`) created via superpowers:using-git-worktrees, matching prior release cycles.
 
-**Verification baseline:** Before Task 1, run `python3 -m pytest carta/tests/ -q` and record the pass count (expected: 798 passed, 2 skipped).
+**Verification baseline:** Before Task 1, run `python3 -m pytest carta/ -q` and record the pass count (expected: 798 passed, 2 skipped).
 
 ---
 
@@ -166,7 +166,7 @@ differ (or delete it — the new class covers it).
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS (798+4 new, 2 skipped). If other tests pinned `_point_id`,
 update them deliberately — the scheme change is the point of this task.
 
@@ -340,7 +340,7 @@ an inline `from carta.embed.lifecycle import delete_other_generations`).
 
 - [ ] **Step 6: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS.
 
 - [ ] **Step 7: Commit**
@@ -494,7 +494,7 @@ before editing; if threading the status through is invasive, count files whose
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -611,7 +611,7 @@ flow.)
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS. Some existing lifecycle tests may assert the old
 `status: stale` end-state — update them deliberately (the old behavior is the
 bug).
@@ -933,7 +933,7 @@ stdout is one JSON document, merge instead: parse `result.to_json()`, add the
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -1142,7 +1142,7 @@ In `cmd_embed`, immediately after the module-enabled check (before the
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python3 -m pytest carta/tests/ -q`
+Run: `python3 -m pytest carta/ -q`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -1202,7 +1202,7 @@ match surrounding tone). Run `grep -n "doctor" README.md` to find the spot.
 
 - [ ] **Step 4: Run the full suite, commit**
 
-Run: `python3 -m pytest carta/tests/ -q` → PASS.
+Run: `python3 -m pytest carta/ -q` → PASS.
 
 ```bash
 git add carta/__init__.py pyproject.toml CHANGELOG.md README.md
@@ -1216,7 +1216,7 @@ git commit -m "chore: bump to 0.11.0, changelog + README for data-integrity rele
 - [ ] **Step 1: Integration review** — use superpowers:requesting-code-review against the spec (`docs/superpowers/specs/2026-06-12-data-integrity-design.md`); fix valid findings, rebut invalid ones with evidence.
 - [ ] **Step 2: Full suite + version sanity**
 
-Run: `python3 -m pytest carta/tests/ -q` → all pass.
+Run: `python3 -m pytest carta/ -q` → all pass.
 Run: `python3 -c "import carta; print(carta.__version__)"` → `0.11.0`.
 
 - [ ] **Step 3: PR** — push branch, `gh pr create` titled "Data integrity: path-based point IDs, empty-chunk guard, doctor/repair (v0.11.0)", body summarizing the four fixes + two features, linking issue #19 and the spec. Watch CI.

--- a/docs/superpowers/plans/2026-06-12-data-integrity.md
+++ b/docs/superpowers/plans/2026-06-12-data-integrity.md
@@ -1,0 +1,1266 @@
+# Carta v0.11.0 Data Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the point-ID collision and empty-chunk fail-open data-loss bugs, add corpus-integrity detection to `carta doctor` and repair via `carta embed --repair`, per the approved spec at `docs/superpowers/specs/2026-06-12-data-integrity-design.md`.
+
+**Architecture:** Point IDs become path-based (md5 of repo-relative file_path + chunk_index + generation) so same-stem files can no longer overwrite each other. Re-embeds stamp a `doc_generation` on every chunk and finish by deleting that file's points from other generations (organic migration of legacy IDs). Empty-text chunks are dropped at the `upsert_chunks` choke point; files yielding zero usable chunks are flagged `extraction_failed` instead of silently embedding garbage. A new `carta/embed/integrity.py` scanner powers both a read-only doctor section and the `embed --repair` flow.
+
+**Tech Stack:** Python 3.10+, qdrant-client, pytest with `unittest.mock.MagicMock` for Qdrant and `patch("carta.embed.embed.requests.post")` for Ollama (existing convention in `carta/tests/test_embed.py`).
+
+**Worktree:** Execute in an isolated worktree (branch `data-integrity`) created via superpowers:using-git-worktrees, matching prior release cycles.
+
+**Verification baseline:** Before Task 1, run `python3 -m pytest carta/tests/ -q` and record the pass count (expected: 798 passed, 2 skipped).
+
+---
+
+## Background for the implementer (read first)
+
+Today `carta/embed/embed.py` derives Qdrant point IDs from the filename-stem slug:
+
+```python
+def _point_id(slug: str, chunk_index: int) -> str:
+    raw = f"{slug}:{chunk_index}"           # "readme:0" — same for EVERY README.md!
+
+def _point_id_versioned(slug: str, chunk_index: int, generation: int) -> str:
+    raw = f"{slug}:{chunk_index}:g{generation}"
+
+def _visual_point_id(slug: str, page_num: int) -> str:
+    raw = f"{slug}:visual:{page_num}"
+```
+
+Four `README.md` files in the ET-embed corpus share slug `readme`; each embed
+overwrites the previous file's points. Chunks already carry a repo-relative
+`file_path` key (set in `_embed_one_file`, `pipeline.py:343`), which is the
+correct collision-free ID basis.
+
+Separately, `upsert_chunks` happily embeds chunks whose `text` is empty
+(43 fully-empty files / ~1,400 identical garbage vectors in ET-embed), and
+`run_embed_file` (`pipeline.py:1146`) merges `lifecycle_updates` containing
+`status: "stale"` OVER the success updates, leaving every re-embedded sidecar
+permanently `stale`.
+
+Chunk dicts currently do NOT carry `doc_generation` (so `build_point` falls
+into the legacy `_point_id` branch; the payload default `doc_generation: 1`
+comes from `build_point` itself). Task 2 starts stamping it.
+
+---
+
+### Task 1: Path-based point IDs
+
+**Files:**
+- Modify: `carta/embed/embed.py` (`_point_id_versioned` ~line 160, `_visual_point_id` ~line 312, `build_point` ~line 203, visual `point_id` ~line 379; delete `_point_id` ~line 154)
+- Test: `carta/tests/test_embed.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `carta/tests/test_embed.py` (and update the import line to drop `_point_id`, which this task removes — see Step 3):
+
+```python
+from carta.embed.embed import _point_id_versioned, _visual_point_id, upsert_chunks
+
+
+class TestPathBasedPointIds:
+    """Same-stem files must never share point IDs (the README-collision bug)."""
+
+    def test_same_stem_different_paths_get_distinct_ids(self):
+        id_a = _point_id_versioned("docs/ci/README.md", 0, 1)
+        id_b = _point_id_versioned("docs/diagrams/README.md", 0, 1)
+        assert id_a != id_b
+
+    def test_id_is_deterministic(self):
+        assert (_point_id_versioned("docs/ci/README.md", 3, 2)
+                == _point_id_versioned("docs/ci/README.md", 3, 2))
+
+    def test_visual_same_stem_different_paths_distinct(self):
+        id_a = _visual_point_id("docs/a/spec.pdf", 1)
+        id_b = _visual_point_id("docs/b/spec.pdf", 1)
+        assert id_a != id_b
+
+    @patch("carta.embed.embed.requests.post")
+    def test_upsert_uses_file_path_for_point_id(self, mock_post):
+        """build_point derives the ID from chunk['file_path'], not slug."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"embedding": [0.1] * 768}
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = True
+        # Force legacy (non-hybrid) schema so no fastembed import is needed
+        info = MagicMock()
+        info.config.params.vectors = None
+        info.config.params.sparse_vectors = None
+        mock_client.get_collection.return_value = info
+
+        cfg = {
+            "project_name": "test",
+            "qdrant_url": "http://localhost:6333",
+            "embed": {
+                "ollama_url": "http://localhost:11434",
+                "ollama_model": "nomic-embed-text:latest",
+                "embedding_workers": 1,
+            },
+        }
+        chunk = {"slug": "readme", "file_path": "docs/ci/README.md",
+                 "chunk_index": 0, "text": "hello world", "doc_type": "unknown"}
+        upsert_chunks([chunk], cfg, client=mock_client)
+
+        points = mock_client.upsert.call_args.kwargs["points"]
+        expected = _point_id_versioned("docs/ci/README.md", 0, 1)
+        assert points[0].id == expected
+```
+
+Note: `collection_is_hybrid` inspects `info.config.params.vectors` /
+`.sparse_vectors`; check how existing tests in this file fake non-hybrid
+collections and reuse that exact pattern if it differs from the above.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_embed.py -q`
+Expected: the new tests FAIL (`upsert_uses_file_path_for_point_id` asserts a
+path-based ID that the current slug-based code does not produce). Existing
+`TestPointIdVersioned` tests still pass (signature unchanged, semantics of the
+first argument change from slug to key).
+
+- [ ] **Step 3: Implement**
+
+In `carta/embed/embed.py`:
+
+```python
+def _point_id_versioned(key: str, chunk_index: int, generation: int) -> str:
+    """Deterministic UUID from key + chunk_index + generation.
+
+    `key` is the repo-relative file_path (collision-free); legacy points used
+    the filename-stem slug, which collided across same-stem files. Different
+    generations produce different UUIDs, enabling retries without collisions.
+    """
+    raw = f"{key}:{chunk_index}:g{generation}"
+    return str(uuid.UUID(hashlib.md5(raw.encode()).hexdigest()))
+
+
+def _visual_point_id(key: str, page_num: int) -> str:
+    """Deterministic UUID for visual page embeddings, keyed by file path."""
+    raw = f"{key}:visual:{page_num}"
+    return str(uuid.UUID(hashlib.md5(raw.encode()).hexdigest()))
+```
+
+Delete `_point_id` entirely. In `build_point` (inside `upsert_chunks`), replace the ID branch:
+
+```python
+        id_key = chunk.get("file_path") or chunk["slug"]
+        point_id = _point_id_versioned(
+            id_key, chunk["chunk_index"], chunk.get("doc_generation", 1)
+        )
+```
+
+In `upsert_visual_pages`, replace the ID line:
+
+```python
+            id_key = page.get("file_path") or page["slug"]
+            point_id = _visual_point_id(id_key, page["page_num"])
+```
+
+Then `grep -rn "_point_id\b" carta/` — update any remaining caller/import
+(tests included) to `_point_id_versioned`. Update the old
+`TestPointIdVersioned.test_point_id_versioned_differs_from_point_id` test:
+it imported `_point_id`; replace it with a check that two different keys
+differ (or delete it — the new class covers it).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS (798+4 new, 2 skipped). If other tests pinned `_point_id`,
+update them deliberately — the scheme change is the point of this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/embed.py carta/tests/test_embed.py
+git commit -m "fix(embed): derive point IDs from file path, not filename-stem slug
+
+Same-stem files (README.md x4 in a real corpus) overwrote each other's
+Qdrant points because IDs hashed only slug:chunk_index. IDs now hash the
+repo-relative file_path. Visual page IDs fixed identically."
+```
+
+---
+
+### Task 2: Stamp doc_generation on chunks + delete other generations after upsert
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (`_embed_one_file` metadata ~line 341 and both `image_chunks` literals ~lines 467, 501; `run_embed_file` ~line 1128)
+- Modify: `carta/embed/lifecycle.py` (new function)
+- Test: `carta/tests/test_lifecycle.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `carta/tests/test_lifecycle.py`:
+
+```python
+from unittest.mock import MagicMock
+from carta.embed.lifecycle import delete_other_generations
+
+
+class TestDeleteOtherGenerations:
+    def test_deletes_by_file_path_excluding_current_generation(self):
+        client = MagicMock()
+        delete_other_generations(client, "proj_doc", "docs/ci/README.md", keep_generation=3)
+
+        client.delete.assert_called_once()
+        kwargs = client.delete.call_args.kwargs
+        assert kwargs["collection_name"] == "proj_doc"
+        sel = kwargs["points_selector"]
+        # must: file_path == docs/ci/README.md ; must_not: doc_generation == 3
+        assert sel.must[0].key == "file_path"
+        assert sel.must[0].match.value == "docs/ci/README.md"
+        assert sel.must_not[0].key == "doc_generation"
+        assert sel.must_not[0].match.value == 3
+
+    def test_swallows_qdrant_errors(self):
+        """Cleanup is best-effort: a delete failure must not fail the embed."""
+        client = MagicMock()
+        client.delete.side_effect = RuntimeError("boom")
+        delete_other_generations(client, "proj_doc", "x.md", keep_generation=1)  # no raise
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_lifecycle.py -q`
+Expected: FAIL with `ImportError: cannot import name 'delete_other_generations'`.
+
+- [ ] **Step 3: Implement the lifecycle helper**
+
+In `carta/embed/lifecycle.py` (it already imports `Filter`, `FieldCondition`, `MatchValue` — verify and extend the import if needed):
+
+```python
+def delete_other_generations(
+    client, collection_name: str, rel_path: str, keep_generation: int
+) -> None:
+    """Delete a file's points from every generation except keep_generation.
+
+    Runs after a successful upsert so stale-generation chunks (and any
+    legacy slug-keyed points for this file) stop appearing in search.
+    Best-effort: errors are reported but never fail the embed that
+    just succeeded.
+    """
+    selector = Filter(
+        must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))],
+        must_not=[FieldCondition(key="doc_generation", match=MatchValue(value=keep_generation))],
+    )
+    try:
+        client.delete(collection_name=collection_name, points_selector=selector)
+    except Exception as e:
+        print(f"Warning: stale-generation cleanup failed for {rel_path} — {e}", flush=True)
+```
+
+- [ ] **Step 4: Stamp doc_generation and wire the cleanup**
+
+In `_embed_one_file` (`pipeline.py` ~line 341), add generation to the shared metadata:
+
+```python
+    generation = int(file_info.get("generation") or 1)
+    metadata = {
+        "slug": slug,
+        "file_path": str(file_path.relative_to(repo_root)),
+        "doc_type": file_info.get("doc_type", "unknown"),
+        "doc_generation": generation,
+    }
+```
+
+Add `"doc_generation": generation,` to BOTH `image_chunks.append({...})`
+literals (~lines 467 and 501) — image-description chunks share the file's
+file_path, so if they carried a different generation the cleanup below would
+delete them.
+
+At the END of `_embed_one_file`, just before the `return`, after all upserts
+(text + image chunks) have happened:
+
+```python
+    from carta.embed.lifecycle import delete_other_generations
+    from carta.config import collection_for_doc_type
+    if count + image_chunk_count > 0:
+        coll = collection_for_doc_type(cfg, file_info.get("doc_type", "unknown"))
+        delete_other_generations(
+            client, coll, str(file_path.relative_to(repo_root)), generation
+        )
+```
+
+(Image chunks land in `_doc` via `collection_for_doc_type(cfg, "image_description")`
+— same collection as non-note text chunks, so one cleanup call covers both. Note
+files route to `_notes`; their doc_type comes from `file_info`, so the same line
+picks the right collection.)
+
+In `run_embed_file` (~line 1128), pass the new generation through:
+
+```python
+    file_info = {
+        "slug": sidecar_data.get("slug", file_path.stem),
+        "doc_type": sidecar_data.get("doc_type", "unknown"),
+        "sidecar_path": sc_path,
+        "file_path": file_path,
+        "generation": new_generation,
+    }
+```
+
+The bulk `run_embed` path embeds files discovered as pending (first embed) —
+its `file_info` has no `generation` key, so chunks default to generation 1 and
+the cleanup is a harmless no-op delete. Verify `run_embed`'s `file_info`
+construction (around `pipeline.py:1152-1370`) and leave it unchanged.
+
+- [ ] **Step 5: Add a pipeline-level test**
+
+Add to `carta/tests/test_embed_targeted.py` (check its existing fixtures for
+how `run_embed_file`/`_embed_one_file` are exercised; follow that pattern). If
+no convenient harness exists, test at the unit seam instead — assert that
+`_embed_one_file` calls `delete_other_generations` with the file's relative
+path and generation, with `upsert_chunks` patched:
+
+```python
+@patch("carta.embed.pipeline.upsert_chunks", return_value=2)
+@patch("carta.embed.lifecycle.delete_other_generations")
+def test_embed_one_file_cleans_other_generations(self, mock_del, mock_upsert, tmp_path):
+    from carta.embed.pipeline import _embed_one_file
+    repo = tmp_path
+    doc = repo / "docs" / "a.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Title\n\nsome content here\n")
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    file_info = {"slug": "a", "doc_type": "unknown", "generation": 2}
+    count, updates = _embed_one_file(doc, file_info, cfg, MagicMock(), repo, 800, 0.15)
+    mock_del.assert_called_once()
+    args = mock_del.call_args.args
+    assert args[2] == "docs/a.md"
+    assert args[3] == 2
+```
+
+Adjust the patch target if `_embed_one_file` imports the helper inside the
+function body (`carta.embed.lifecycle.delete_other_generations` is correct for
+an inline `from carta.embed.lifecycle import delete_other_generations`).
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/embed/lifecycle.py carta/tests/
+git commit -m "feat(embed): stamp doc_generation on chunks and delete stale generations after upsert
+
+Old-generation points were only payload-stamped stale and stayed searchable
+forever. Re-embeds now end with a filtered delete of the file's other
+generations, which also organically migrates legacy slug-keyed points."
+```
+
+---
+
+### Task 3: Empty-chunk guard
+
+**Files:**
+- Modify: `carta/embed/embed.py` (`upsert_chunks` top)
+- Modify: `carta/embed/pipeline.py` (`_embed_one_file` after `enriched` is built)
+- Test: `carta/tests/test_embed.py`, `carta/tests/test_embed_targeted.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `carta/tests/test_embed.py`:
+
+```python
+class TestEmptyChunkGuard:
+    @patch("carta.embed.embed.requests.post")
+    def test_empty_chunks_are_not_upserted(self, mock_post):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"embedding": [0.1] * 768}
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = True
+        info = MagicMock()
+        info.config.params.vectors = None
+        info.config.params.sparse_vectors = None
+        mock_client.get_collection.return_value = info
+        cfg = {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                      "embedding_workers": 1},
+        }
+        chunks = [
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 0, "text": ""},
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 1, "text": "   \n"},
+            {"slug": "d", "file_path": "d.pdf", "chunk_index": 2, "text": "real content"},
+        ]
+        count = upsert_chunks(chunks, cfg, client=mock_client)
+        assert count == 1
+        points = mock_client.upsert.call_args.kwargs["points"]
+        assert len(points) == 1
+        assert points[0].payload["text"] == "real content"
+
+    def test_all_empty_returns_zero_without_upsert(self):
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = True
+        cfg = {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+        }
+        chunks = [{"slug": "d", "file_path": "d.pdf", "chunk_index": 0, "text": ""}]
+        count = upsert_chunks(chunks, cfg, client=mock_client)
+        assert count == 0
+        mock_client.upsert.assert_not_called()
+```
+
+In `carta/tests/test_embed_targeted.py` (same harness style as Task 2 Step 5):
+
+```python
+@patch("carta.embed.pipeline.upsert_chunks", return_value=0)
+def test_zero_usable_chunks_marks_extraction_failed(self, mock_upsert, tmp_path, capsys):
+    from carta.embed.pipeline import _embed_one_file
+    repo = tmp_path
+    doc = repo / "docs" / "scan.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("")  # extraction yields nothing
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    count, updates = _embed_one_file(doc, {"slug": "scan", "doc_type": "unknown"},
+                                     cfg, MagicMock(), repo, 800, 0.15)
+    assert count == 0
+    assert updates["status"] == "extraction_failed"
+    assert "0 extractable characters" in capsys.readouterr().out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_embed.py carta/tests/test_embed_targeted.py -q`
+Expected: FAIL — empty chunks are currently embedded; no `extraction_failed` status exists.
+
+- [ ] **Step 3: Implement**
+
+Top of `upsert_chunks` in `embed.py`, before `batch_doc_type` is computed:
+
+```python
+    n_total = len(chunks)
+    chunks = [c for c in chunks if (c.get("text") or "").strip()]
+    n_dropped = n_total - len(chunks)
+    if n_dropped:
+        src = chunks[0].get("file_path") if chunks else "(all chunks)"
+        print(f"Warning: dropped {n_dropped} empty chunk(s) for {src} — "
+              f"extraction produced no text for them", flush=True)
+    if not chunks:
+        return 0
+```
+
+In `_embed_one_file` (`pipeline.py`), right after `enriched` is built and
+before `upsert_chunks` is called, detect the nothing-usable case for markdown
+and PDFs alike:
+
+```python
+    usable = [c for c in enriched if (c.get("text") or "").strip()]
+    if not usable and file_path.suffix != ".pdf":
+        print(f"Warning: {file_path.name}: 0 extractable characters — skipped "
+              f"(empty or unreadable file)", flush=True)
+        return 0, {"status": "extraction_failed", "chunk_count": 0,
+                   "image_count": 0, "image_chunks": 0}
+    count = upsert_chunks(enriched, cfg, client=client)
+```
+
+For PDFs, image-description chunks may still rescue the file, so the check
+happens at the END of `_embed_one_file` instead — in the existing
+`sidecar_updates` construction (~line 523), set status when nothing usable was
+upserted:
+
+```python
+    sidecar_updates = {
+        "chunk_count": count + image_chunk_count,
+        ...existing keys...
+    }
+    if count + image_chunk_count == 0:
+        sidecar_updates["status"] = "extraction_failed"
+        print(f"Warning: {file_path.name}: 0 extractable characters — skipped "
+              f"(scanned PDF? OCR may be required)", flush=True)
+```
+
+Read the actual `sidecar_updates` construction at `pipeline.py:520-557` first
+and integrate (don't duplicate keys; the markdown early-return above must
+return the same key shape).
+
+Also make `run_embed` count these: in its per-file result handling
+(find where `summary` totals embedded/skipped/errors, ~`pipeline.py:1152+`),
+treat `status == "extraction_failed"` from the sidecar updates as its own
+counter `extraction_failed` and include it in the returned summary dict and
+the printed summary line. Follow the existing summary-shape exactly — read it
+before editing; if threading the status through is invasive, count files whose
+`_embed_one_file` returned `(0, {"status": "extraction_failed", ...})`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/embed.py carta/embed/pipeline.py carta/tests/
+git commit -m "fix(embed): never upsert empty chunks; flag zero-text files extraction_failed
+
+Silent extraction failures previously produced unfindable points with
+identical embedding-of-empty-string vectors (1,400+ in a real corpus)."
+```
+
+---
+
+### Task 4: Sidecar status bookkeeping + true force re-embed
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (`run_embed_file` ~lines 1074-1148)
+- Test: `carta/tests/test_embed_targeted.py` (or wherever `run_embed_file` is currently tested — `grep -rn "run_embed_file" carta/tests/`)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRunEmbedFileLifecycle:
+    def _cfg(self):
+        return {
+            "project_name": "test", "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+        }
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline._embed_one_file", return_value=(3, {"chunk_count": 3}))
+    @patch("carta.embed.pipeline.find_config")
+    def test_successful_embed_ends_current_not_stale(
+            self, mock_fc, mock_embed, mock_ensure, mock_qc, tmp_path):
+        from carta.embed.pipeline import run_embed_file
+        from carta.embed.induct import sidecar_path, read_sidecar
+        repo = tmp_path
+        (repo / ".carta").mkdir()
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+        doc = repo / "docs" / "a.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# hi\n\ncontent\n")
+
+        result = run_embed_file(doc, self._cfg(), force=True)
+        assert result["status"] == "ok"
+        sc = read_sidecar(sidecar_path(doc, repo))
+        assert sc["status"] == "current"
+        assert sc["stale_as_of"] is None
+
+    @patch("carta.embed.pipeline.QdrantClient")
+    @patch("carta.embed.pipeline.ensure_collection")
+    @patch("carta.embed.pipeline._embed_one_file", return_value=(2, {"chunk_count": 2}))
+    @patch("carta.embed.pipeline.find_config")
+    def test_force_reembeds_even_when_hash_unchanged(
+            self, mock_fc, mock_embed, mock_ensure, mock_qc, tmp_path):
+        from carta.embed.pipeline import run_embed_file
+        repo = tmp_path
+        (repo / ".carta").mkdir()
+        mock_fc.return_value = repo / ".carta" / "config.yaml"
+        doc = repo / "docs" / "a.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# hi\n\ncontent\n")
+
+        first = run_embed_file(doc, self._cfg(), force=True)
+        assert first["status"] == "ok"
+        second = run_embed_file(doc, self._cfg(), force=True)  # hash unchanged
+        assert second["status"] == "ok"          # currently returns "skipped"
+        assert mock_embed.call_count == 2
+```
+
+Check the sidecar helper signatures (`sidecar_path(file_path, repo_root)`,
+`read_sidecar(path)`) in `carta/embed/induct.py` before writing; adapt if they
+differ. `run_embed_file` also calls `mark_sidecar_stale` and creates a
+`QdrantClient` — both patched above.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_embed_targeted.py -q`
+Expected: FAIL — first test sees `status: "stale"`; second sees `"skipped"` on the second call.
+
+- [ ] **Step 3: Implement**
+
+In `run_embed_file`:
+
+1. Hash short-circuit (~line 1082): only when not forced —
+
+```python
+    if not force and current_hash == old_hash and old_hash is not None:
+```
+
+2. Lifecycle updates (~line 1112): remove `"status": "stale"` and
+   `"stale_as_of": ...` from `lifecycle_updates` (the in-Qdrant stale stamp via
+   `mark_sidecar_stale` stays — it marks the OLD generation's points during the
+   re-embed window).
+
+3. Final merge (~line 1146): after `_embed_one_file` returns, set the closing
+   state — `_embed_one_file` may have set `status: extraction_failed` (Task 3),
+   which must win:
+
+```python
+    sidecar_updates.update(lifecycle_updates)
+    sidecar_updates.setdefault("status", "current")
+    sidecar_updates["stale_as_of"] = None
+    sidecar_updates.pop("_vision_events", None)
+    _update_sidecar(sc_path, sidecar_updates)
+```
+
+(`setdefault` keeps `extraction_failed` when present; otherwise `current`.
+With the order above, also remove `status`/`stale_as_of` from
+`lifecycle_updates` so they can't clobber — verify by reading the final dict
+flow.)
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS. Some existing lifecycle tests may assert the old
+`status: stale` end-state — update them deliberately (the old behavior is the
+bug).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/
+git commit -m "fix(embed): successful re-embed ends status=current; force bypasses hash short-circuit
+
+lifecycle_updates previously clobbered the success state, leaving every
+re-embedded sidecar permanently 'stale' (169/971 in a real corpus)."
+```
+
+---
+
+### Task 5: Corpus-integrity scanner module
+
+**Files:**
+- Create: `carta/embed/integrity.py`
+- Test: `carta/tests/test_integrity.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `carta/tests/test_integrity.py`:
+
+```python
+"""Tests for corpus-integrity scanning (doctor + embed --repair)."""
+from unittest.mock import MagicMock
+
+from carta.embed.integrity import scan_corpus_integrity
+
+
+def _point(file_path, slug, chunk_index, text):
+    p = MagicMock()
+    p.payload = {"file_path": file_path, "slug": slug,
+                 "chunk_index": chunk_index, "text": text}
+    return p
+
+
+def _client_with_points(points):
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    client.scroll.return_value = (points, None)  # single page
+    return client
+
+
+CFG = {"project_name": "test", "qdrant_url": "http://localhost:6333",
+       "embed": {"ollama_url": "http://x", "ollama_model": "m"}}
+
+
+class TestScanCorpusIntegrity:
+    def test_detects_slug_collisions(self, tmp_path):
+        pts = [
+            _point("docs/ci/README.md", "readme", 8, "a"),
+            _point("docs/diagrams/README.md", "readme", 0, "b"),
+            _point("docs/unique.md", "unique", 0, "c"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["slug_collisions"] == {
+            "readme": sorted(["docs/ci/README.md", "docs/diagrams/README.md"])}
+
+    def test_detects_empty_text_files(self, tmp_path):
+        pts = [
+            _point("docs/scan.pdf", "scan", 0, ""),
+            _point("docs/scan.pdf", "scan", 1, ""),
+            _point("docs/partial.pdf", "partial", 0, ""),
+            _point("docs/partial.pdf", "partial", 1, "real"),
+            _point("docs/ok.md", "ok", 0, "fine"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["empty_files"] == ["docs/scan.pdf"]
+        assert report["partial_empty_files"] == {"docs/partial.pdf": 1}
+
+    def test_clean_corpus_reports_nothing(self, tmp_path):
+        pts = [_point("docs/ok.md", "ok", 0, "fine")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["slug_collisions"] == {}
+        assert report["empty_files"] == []
+        assert report["partial_empty_files"] == {}
+        assert report["affected_files"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_integrity.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'carta.embed.integrity'`.
+
+- [ ] **Step 3: Implement**
+
+Create `carta/embed/integrity.py`:
+
+```python
+"""Corpus-integrity scanning: detect point-ID collisions, empty-text points,
+sidecar/Qdrant count mismatches, and stuck-stale sidecars.
+
+Read-only — used by `carta doctor` (report) and `carta embed --repair`
+(which re-embeds/purges what this module finds).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from qdrant_client import QdrantClient
+
+from carta.config import collection_name
+from carta.embed.lifecycle import compute_file_hash
+from carta.embed.induct import read_sidecar
+
+
+def _scroll_all(client, coll: str):
+    """Yield every point's payload in a collection (no vectors)."""
+    offset = None
+    while True:
+        points, offset = client.scroll(
+            coll, limit=1000, offset=offset, with_payload=True, with_vectors=False
+        )
+        for p in points:
+            yield p.payload or {}
+        if offset is None:
+            return
+
+
+def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
+    """Scan the project's _doc collection and sidecars for integrity issues.
+
+    Returns a dict:
+        slug_collisions:      {slug: [file_path, ...]} for slugs with >1 file
+        empty_files:          [file_path] — every point has empty text
+        partial_empty_files:  {file_path: n_empty} — some points empty
+        count_mismatches:     {file_path: {"sidecar": n, "qdrant": n}}
+        stuck_stale:          [rel sidecar source path] — status stale, hash matches disk
+        affected_files:       sorted union of files needing re-embed/purge
+    """
+    if client is None:
+        client = QdrantClient(url=cfg["qdrant_url"], timeout=30)
+    coll = collection_name(cfg, "doc")
+
+    slug_files: dict[str, set] = defaultdict(set)
+    per_file_counts: dict[str, int] = defaultdict(int)
+    per_file_empty: dict[str, int] = defaultdict(int)
+
+    if client.collection_exists(coll):
+        for payload in _scroll_all(client, coll):
+            fp = payload.get("file_path", "")
+            slug_files[payload.get("slug", "")].add(fp)
+            per_file_counts[fp] += 1
+            if not (payload.get("text") or "").strip():
+                per_file_empty[fp] += 1
+
+    slug_collisions = {
+        slug: sorted(files) for slug, files in slug_files.items() if len(files) > 1
+    }
+    empty_files = sorted(
+        fp for fp, n in per_file_empty.items() if n == per_file_counts[fp]
+    )
+    partial_empty_files = {
+        fp: n for fp, n in sorted(per_file_empty.items())
+        if 0 < n < per_file_counts[fp]
+    }
+
+    # Sidecar-side checks
+    count_mismatches: dict[str, dict] = {}
+    stuck_stale: list[str] = []
+    sidecars_root = repo_root / ".carta" / "sidecars"
+    if sidecars_root.exists():
+        for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
+            sc = read_sidecar(sc_path) or {}
+            rel = sc.get("current_path")
+            if not rel:
+                continue
+            src = repo_root / rel
+            if rel in per_file_counts and sc.get("chunk_count") not in (None, per_file_counts[rel]):
+                count_mismatches[rel] = {
+                    "sidecar": sc.get("chunk_count"), "qdrant": per_file_counts[rel]
+                }
+            if sc.get("status") == "stale" and src.exists():
+                try:
+                    if compute_file_hash(src) == sc.get("file_hash"):
+                        stuck_stale.append(rel)
+                except OSError:
+                    pass
+
+    affected = set(empty_files) | set(partial_empty_files) | set(count_mismatches)
+    for files in slug_collisions.values():
+        affected.update(files)
+
+    return {
+        "slug_collisions": slug_collisions,
+        "empty_files": empty_files,
+        "partial_empty_files": partial_empty_files,
+        "count_mismatches": count_mismatches,
+        "stuck_stale": sorted(stuck_stale),
+        "affected_files": sorted(affected),
+    }
+```
+
+Verify the sidecar key for the relative source path: the inspected ET-embed
+sidecars use `current_path: docs/ci/README.md`. Confirm via
+`grep -n "current_path" carta/embed/induct.py` and adapt if the canonical key
+differs. Likewise confirm `compute_file_hash`'s import location
+(`carta/embed/lifecycle.py:` per `pipeline.py`'s import).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest carta/tests/test_integrity.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/integrity.py carta/tests/test_integrity.py
+git commit -m "feat(integrity): corpus-integrity scanner (collisions, empty points, mismatches, stuck-stale)"
+```
+
+---
+
+### Task 6: Doctor integration (read-only report)
+
+**Files:**
+- Modify: `carta/cli.py` (`cmd_doctor`, ~line 441)
+- Test: `carta/tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `carta/tests/test_cli.py` (match its existing patching style — read the
+top of the file first; it sets PYTHONPATH/uses runner helpers):
+
+```python
+class TestDoctorCorpusIntegrity:
+    @patch("carta.embed.integrity.scan_corpus_integrity")
+    @patch("carta.cli.find_config")
+    def test_doctor_prints_integrity_section_inside_project(
+            self, mock_fc, mock_scan, tmp_path, capsys, monkeypatch):
+        from carta import cli
+        (tmp_path / ".carta").mkdir()
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.write_text("project_name: test\nqdrant_url: http://localhost:6333\n")
+        mock_fc.return_value = cfg_file
+        mock_scan.return_value = {
+            "slug_collisions": {"readme": ["docs/a/README.md", "docs/b/README.md"]},
+            "empty_files": ["docs/scan.pdf"],
+            "partial_empty_files": {},
+            "count_mismatches": {},
+            "stuck_stale": [],
+            "affected_files": ["docs/a/README.md", "docs/b/README.md", "docs/scan.pdf"],
+        }
+        # Bypass the preflight machinery: patch PreflightChecker to a no-op
+        with patch("carta.install.preflight.PreflightChecker") as mock_chk:
+            result = MagicMock()
+            result.fixable_failures = []
+            result.to_json.return_value = "{}"
+            mock_chk.return_value.run.return_value = result
+            args = MagicMock(json=False, fix=False, yes=True, verbose=False)
+            cli.cmd_doctor(args)
+        out = capsys.readouterr().out
+        assert "Corpus integrity" in out
+        assert "readme" in out
+        assert "docs/scan.pdf" in out
+        assert "carta embed --repair" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest carta/tests/test_cli.py -q -k integrity`
+Expected: FAIL — no integrity section printed.
+
+- [ ] **Step 3: Implement**
+
+At the end of `cmd_doctor` in `carta/cli.py` (after the existing preflight
+report/fix flow), append a project-scoped integrity section. Doctor must keep
+working outside a carta project, so everything is guarded:
+
+```python
+    # Corpus integrity (project-scoped, read-only). Never break doctor itself.
+    try:
+        cfg_path = find_config()
+    except Exception:
+        cfg_path = None
+    if cfg_path is not None:
+        try:
+            from carta.config import load_config
+            from carta.embed.integrity import scan_corpus_integrity
+            cfg = load_config(cfg_path)
+            repo_root = cfg_path.parent.parent
+            report = scan_corpus_integrity(cfg, repo_root)
+            if args.json:
+                import json as _json
+                print(_json.dumps({"corpus_integrity": report}))
+            else:
+                print("\n📦 Corpus integrity")
+                if not report["affected_files"] and not report["stuck_stale"]:
+                    print("  ✅ no issues found")
+                else:
+                    for slug, files in report["slug_collisions"].items():
+                        print(f"  ⚠️  slug collision '{slug}': {', '.join(files)}")
+                    for fp in report["empty_files"]:
+                        print(f"  ⚠️  all chunks empty: {fp}")
+                    for fp, n in report["partial_empty_files"].items():
+                        print(f"  ⚠️  {n} empty chunk(s): {fp}")
+                    for fp, c in report["count_mismatches"].items():
+                        print(f"  ⚠️  count mismatch: {fp} (sidecar {c['sidecar']} vs qdrant {c['qdrant']})")
+                    if report["stuck_stale"]:
+                        print(f"  ⚠️  {len(report['stuck_stale'])} sidecar(s) stuck 'stale' with unchanged files")
+                    print(f"  → run `carta embed --repair` to fix "
+                          f"({len(report['affected_files'])} file(s) affected)")
+        except Exception as e:
+            if not args.json:
+                print(f"\n📦 Corpus integrity: check skipped ({e})")
+```
+
+Note on `--json`: the existing flow prints `result.to_json()` separately;
+keeping integrity as its own JSON object on a separate line is acceptable for
+this release (doctor's JSON consumers are tests only — verify with
+`grep -rn "doctor" carta/tests/ | grep -i json`). If a test asserts the whole
+stdout is one JSON document, merge instead: parse `result.to_json()`, add the
+`corpus_integrity` key, print once.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/cli.py carta/tests/test_cli.py
+git commit -m "feat(doctor): read-only corpus-integrity section (collisions, empty points, mismatches)"
+```
+
+---
+
+### Task 7: `carta embed --repair`
+
+**Files:**
+- Create: `carta/embed/repair.py`
+- Modify: `carta/cli.py` (embed parser ~line 661; `cmd_embed` ~line 179)
+- Test: `carta/tests/test_integrity.py` (repair tests live with integrity tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `carta/tests/test_integrity.py`:
+
+```python
+from carta.embed.repair import run_repair
+
+
+class TestRunRepair:
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_repair_deletes_points_then_reembeds_each_affected_file(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {"readme": ["docs/a/README.md", "docs/b/README.md"]},
+            "empty_files": [], "partial_empty_files": {}, "count_mismatches": {},
+            "stuck_stale": [],
+            "affected_files": ["docs/a/README.md", "docs/b/README.md"],
+        }
+        mock_reembed.return_value = {"status": "ok", "chunks": 5}
+        for rel in ("docs/a/README.md", "docs/b/README.md"):
+            f = tmp_path / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("# x\ncontent\n")
+
+        summary = run_repair(tmp_path, CFG)
+
+        client = mock_qc.return_value
+        assert client.delete.call_count == 2          # one purge per file
+        assert mock_reembed.call_count == 2
+        assert summary["repaired"] == 2
+        assert summary["purged_only"] == 0
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_missing_file_is_purged_not_reembedded(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": ["docs/gone.pdf"],
+            "partial_empty_files": {}, "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/gone.pdf"],
+        }
+        summary = run_repair(tmp_path, CFG)
+        assert mock_qc.return_value.delete.call_count == 1
+        mock_reembed.assert_not_called()
+        assert summary["purged_only"] == 1
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_extraction_failed_counts_as_flagged(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": ["docs/scan.pdf"],
+            "partial_empty_files": {}, "count_mismatches": {}, "stuck_stale": [],
+            "affected_files": ["docs/scan.pdf"],
+        }
+        f = tmp_path / "docs" / "scan.pdf"
+        f.parent.mkdir(parents=True)
+        f.write_bytes(b"%PDF-1.4 fake")
+        mock_reembed.return_value = {"status": "ok", "chunks": 0}
+        summary = run_repair(tmp_path, CFG)
+        assert summary["flagged"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest carta/tests/test_integrity.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'carta.embed.repair'`.
+
+- [ ] **Step 3: Implement**
+
+Create `carta/embed/repair.py`:
+
+```python
+"""carta embed --repair: fix corpus-integrity issues found by integrity.scan.
+
+Per affected file: delete ALL of its points (any generation, any legacy ID),
+then force re-embed through the fixed pipeline. Files that no longer exist on
+disk, or whose extraction yields nothing, end up purged + flagged rather than
+re-upserted. Stuck-stale sidecars get their status corrected in place.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+from carta.config import collection_name
+from carta.embed.integrity import scan_corpus_integrity
+from carta.embed.pipeline import run_embed_file
+
+
+def _delete_file_points(client, coll: str, rel_path: str) -> None:
+    selector = Filter(
+        must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))]
+    )
+    client.delete(collection_name=coll, points_selector=selector)
+
+
+def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
+    """Detect and repair corpus-integrity issues. Returns a summary dict."""
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=30)
+    report = scan_corpus_integrity(cfg, repo_root, client=client)
+    coll = collection_name(cfg, "doc")
+
+    repaired = purged_only = flagged = failed = 0
+    for rel in report["affected_files"]:
+        src = repo_root / rel
+        if verbose:
+            print(f"  repairing {rel}...", flush=True)
+        try:
+            _delete_file_points(client, coll, rel)
+        except Exception as e:
+            print(f"  Warning: could not purge points for {rel} — {e}", flush=True)
+        if not src.exists():
+            purged_only += 1
+            if verbose:
+                print(f"    purged (file no longer on disk)", flush=True)
+            continue
+        try:
+            result = run_embed_file(src, cfg, force=True)
+            if result.get("chunks", 0) > 0:
+                repaired += 1
+            else:
+                flagged += 1   # extraction_failed: purged + sidecar flagged
+        except Exception as e:
+            failed += 1
+            print(f"  Error: re-embed failed for {rel} — {e}", flush=True)
+
+    # Stuck-stale sidecars that aren't otherwise affected: fix status in place.
+    stale_fixed = 0
+    affected = set(report["affected_files"])
+    if report["stuck_stale"]:
+        from carta.embed.induct import sidecar_path
+        from carta.embed.pipeline import _update_sidecar
+        for rel in report["stuck_stale"]:
+            if rel in affected:
+                continue  # re-embed above already rewrote it
+            sc = sidecar_path(repo_root / rel, repo_root)
+            if sc.exists():
+                _update_sidecar(sc, {"status": "current", "stale_as_of": None})
+                stale_fixed += 1
+
+    summary = {
+        "affected": len(report["affected_files"]),
+        "repaired": repaired,
+        "purged_only": purged_only,
+        "flagged": flagged,
+        "failed": failed,
+        "stale_fixed": stale_fixed,
+    }
+    if verbose:
+        print(
+            f"Repair complete: {repaired} re-embedded, {purged_only} purged, "
+            f"{flagged} flagged extraction_failed, {failed} failed, "
+            f"{stale_fixed} stale sidecar(s) corrected.",
+            flush=True,
+        )
+    return summary
+```
+
+In `carta/cli.py`, add the flag to the embed parser (~line 661 block):
+
+```python
+    embed_p.add_argument(
+        "--repair",
+        action="store_true",
+        help="Detect and repair corpus-integrity issues (point-ID collisions, "
+             "empty chunks, count mismatches), then exit.",
+    )
+```
+
+In `cmd_embed`, immediately after the module-enabled check (before the
+`--visual` branch), add:
+
+```python
+    if getattr(args, "repair", False) is True:
+        from carta.embed.repair import run_repair
+        repo_root = cfg_path.parent.parent
+        summary = run_repair(repo_root, cfg, verbose=True)
+        _notify_if_update(cfg_path, cfg)
+        sys.exit(1 if summary["failed"] else 0)
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest carta/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/repair.py carta/cli.py carta/tests/test_integrity.py
+git commit -m "feat(embed): carta embed --repair — purge + force re-embed integrity-affected files"
+```
+
+---
+
+### Task 8: Docs, version bump, changelog
+
+**Files:**
+- Modify: `carta/__init__.py` (version), `pyproject.toml` (if version duplicated there — check), `CHANGELOG.md`, `README.md`
+
+- [ ] **Step 1: Bump version**
+
+`carta/__init__.py`: `__version__ = "0.11.0"`. Run
+`grep -rn "0\.10\.0" pyproject.toml carta/__init__.py` and update every
+version source (prior releases synced both).
+
+- [ ] **Step 2: CHANGELOG entry**
+
+Add at the top of `CHANGELOG.md`, matching its existing format:
+
+```markdown
+## 0.11.0 — data integrity
+
+### Fixed
+- **Point-ID collision (data loss):** point IDs hashed only the filename-stem
+  slug, so same-stem files (e.g. multiple `README.md`) silently overwrote each
+  other's Qdrant points. IDs now hash the repo-relative file path. Visual page
+  IDs fixed identically.
+- **Empty-chunk fail-open:** PDF extraction failures produced points with empty
+  text and identical garbage vectors (unfindable, dense-space noise). Empty
+  chunks are now dropped at upsert; files yielding zero text are flagged
+  `extraction_failed` with a loud warning instead of embedding nothing.
+- **Stale-generation leak:** re-embeds now delete the file's points from prior
+  generations after a successful upsert (previously they stayed searchable
+  forever). This also organically migrates legacy slug-keyed points.
+- **Sidecar status bookkeeping:** a successful re-embed now ends with
+  `status: current` instead of permanently `stale`; `carta embed FILE` with
+  force now truly re-embeds even when the file hash is unchanged.
+
+### Added
+- `carta doctor` corpus-integrity section: detects slug collisions, empty-text
+  points, sidecar/Qdrant chunk-count mismatches, and stuck-stale sidecars.
+- `carta embed --repair`: purges and force re-embeds affected files.
+```
+
+- [ ] **Step 3: README**
+
+Add a short "Corpus integrity" subsection to README.md near the doctor/embed
+docs describing `carta doctor` detection + `carta embed --repair` (3-6 lines,
+match surrounding tone). Run `grep -n "doctor" README.md` to find the spot.
+
+- [ ] **Step 4: Run the full suite, commit**
+
+Run: `python3 -m pytest carta/tests/ -q` → PASS.
+
+```bash
+git add carta/__init__.py pyproject.toml CHANGELOG.md README.md
+git commit -m "chore: bump to 0.11.0, changelog + README for data-integrity release"
+```
+
+---
+
+### Task 9: Branch finish — review, PR, merge, release
+
+- [ ] **Step 1: Integration review** — use superpowers:requesting-code-review against the spec (`docs/superpowers/specs/2026-06-12-data-integrity-design.md`); fix valid findings, rebut invalid ones with evidence.
+- [ ] **Step 2: Full suite + version sanity**
+
+Run: `python3 -m pytest carta/tests/ -q` → all pass.
+Run: `python3 -c "import carta; print(carta.__version__)"` → `0.11.0`.
+
+- [ ] **Step 3: PR** — push branch, `gh pr create` titled "Data integrity: path-based point IDs, empty-chunk guard, doctor/repair (v0.11.0)", body summarizing the four fixes + two features, linking issue #19 and the spec. Watch CI.
+- [ ] **Step 4: Merge + release** — squash-merge, tag `v0.11.0`, confirm release workflow publishes to PyPI (expect the known ~15-min simple-index lag; use `pipx install --force carta-cc` per the recorded quirk).
+
+---
+
+### Task 10: ET-embed corpus repair + eval validation (post-release)
+
+All commands run from `~/School/Elementrailer/ET-embed` with carta-cc 0.11.0
+installed (or `PYTHONPATH=<checkout> ~/.local/pipx/venvs/carta-cc/bin/python -m carta ...`
+to validate pre-release).
+
+- [ ] **Step 1: Detection sanity** — `carta doctor`: expect the integrity section to report 1 slug collision (`readme`, 4 files), 43 fully-empty files, ~24 partial-empty, count mismatches incl. `docs/ci/README.md` (sidecar 10 vs qdrant 2), and ~169 stuck-stale sidecars. Numbers should match the 2026-06-12 investigation.
+- [ ] **Step 2: Repair** — `carta embed --repair`. Expect: READMEs re-embedded with distinct points; ~1,400+ garbage points purged; scanned patents flagged `extraction_failed`; stuck-stale sidecars corrected. Re-run `carta doctor` → integrity clean except `extraction_failed` files (still listed as empty until OCR work — acceptable; they have no points now, so they should drop out of the empty-files list and appear only via their sidecar status).
+- [ ] **Step 3: Eval expect fix** — in `.carta/eval/et-embed.yaml`, change the
+  termination query's expectation:
+
+```yaml
+  # grounded: vcu/pcb-design-checklist.md — CAN_A/CAN_B termination table, PESD2CAN TVS
+  - q: "what are the CAN bus termination rules for CAN_A and CAN_B on the VCU PCB and where does each 120 ohm resistor go"
+    expect: ["vcu/pcb-design-checklist"]
+```
+
+- [ ] **Step 4: Re-run the 62-query eval** — hybrid-only and reranked
+  (`OMP_NUM_THREADS=1`, rerank block per the config comment). Expect at
+  minimum: ci/README and the pcb query flip to hits (reranked ≥ 56/62,
+  recall@5 ≥ 0.90). US-11965795 remains a miss (honest, flagged). Record both
+  runs in `.carta/eval/RESULTS.md` with a dated section attributing deltas to
+  the v0.11.0 repair.
+- [ ] **Step 5: Issue bookkeeping** — comment on #19 with the investigation
+  findings table + new numbers; file v0.12.0 issues: visual pool dilution
+  (Bug C), reranker demotion (Bug D), OCR recovery for extraction_failed PDFs.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §1-§7 each map to Tasks 1-7+10; Bug E is Task 4; release mechanics Task 8-9.
+- Type/name consistency: `_point_id_versioned(key, chunk_index, generation)`,
+  `delete_other_generations(client, collection_name, rel_path, keep_generation)`,
+  `scan_corpus_integrity(cfg, repo_root, client=None)`,
+  `run_repair(repo_root, cfg, verbose=True)` — used identically across tasks.
+- Known soft spots called out inline rather than hidden: exact
+  `sidecar_updates` shape in `_embed_one_file` (Task 3 Step 3), doctor JSON
+  merging (Task 6 Step 3), sidecar `current_path` key name (Task 5 Step 3) —
+  each step says what to verify and how.

--- a/docs/superpowers/specs/2026-06-12-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-06-12-data-integrity-design.md
@@ -1,0 +1,179 @@
+# Carta v0.11.0 — Data Integrity: point-ID collisions, empty-chunk fail-open, corpus repair
+
+**Date:** 2026-06-12
+**Status:** Approved (design review with Ian, 2026-06-12)
+**Origin:** Issue #19 depth-check investigation on the ET-embed 62-query eval (8 misses).
+
+## Background: what the investigation found
+
+The 8 remaining eval misses were assumed to be chunking-bound. A per-query depth
+check (dense leg, BM25 leg, fused pool at standard and 300-deep settings, plus
+the real cross-collection merged pool) showed none of them is primarily a
+chunk-size problem. Root causes, with evidence:
+
+| Miss | Evidence | Root cause |
+|---|---|---|
+| ci/README | Only chunks 8–9 of 10 survive in Qdrant; chunks 0–7 overwritten | **A: point-ID collision** |
+| US-11965795 patent | 32 points, all `text: ""`, byte-identical vectors | **B: empty-chunk fail-open** |
+| SAFETY-MCU-MESSAGES | Text-only fused #34; merged pool absent | C: visual pool dilution (v0.12.0) |
+| TIMING_ARCHITECTURE | Deep fused #34, outside 40-pool | C + weak first-stage rank (v0.12.0) |
+| connector-map | Merged pool #35/40; reranker doesn't promote | C + D (v0.12.0) |
+| US10245972 | First-stage #2–3; reranker demotes out of top-5 | D: reranker demotion (v0.12.0) |
+| cts-control | Pool #4–7, not promoted | D (v0.12.0) |
+| pcb/DESIGN_CHECKLIST | Retrieval ranks `vcu/pcb-design-checklist.md` #1 — the file that actually contains the 120Ω/PESD2CAN content | **Eval expect points at wrong file** |
+
+**Bug A (data loss).** `_point_id()` / `_point_id_versioned()`
+(`carta/embed/embed.py:154-167`) hash only `slug:chunk_index[:generation]`, and
+slug is the filename stem (`carta/embed/induct.py:31-36`). Same-stem files
+(README.md ×4 in ET-embed) overwrite each other's points: 10 points survive
+where ~25+ should exist. `_visual_point_id(slug, page_num)`
+(`embed.py:312-323`) has the identical bug for the visual collection.
+
+**Bug B (silent fail-open).** PDF extraction that yields no text still flows
+into embed+upsert. ET-embed has 43 fully-empty files (~1,400 points, all with
+identical embedding-of-empty-string vectors — confirmed cos=1.0) and 24
+partially-empty files, including the project's own PCT filing (67/135 chunks
+empty). These points are unfindable by dense or BM25 and pollute dense space.
+
+**Bug E (bookkeeping).** `run_embed_file` (`carta/embed/pipeline.py:1146`)
+merges `lifecycle_updates` (containing `status: stale`, `stale_as_of`) OVER the
+success updates from `_embed_one_file`, so every successfully re-embedded
+file's sidecar permanently reads `stale` (169 of 971 ET-embed sidecars).
+
+**Generation leak (related to A).** Old-generation points are stamped stale via
+`mark_sidecar_stale` (guarded on `sidecar_id`, which is empty for most legacy
+points) but never deleted; search does not filter them. Re-embedded files leave
+their previous generation's chunks searchable indefinitely.
+
+## Scope
+
+v0.11.0 fixes A, B, E, the generation leak, adds detection (`carta doctor`) and
+repair (`carta embed --repair`), and repairs the ET-embed corpus + eval set.
+
+Out of scope (deferred, tracked as v0.12.0 candidates):
+- OCR recovery for scanned PDFs whose extraction yields nothing (Bug B files
+  become honestly *flagged*, not findable).
+- Visual pool dilution (Bug C) and reranker demotion (Bug D).
+- Excluding ET-embed's `_dropped/`/`_marginal/` patent directories.
+
+## Design
+
+### 1. Path-based point IDs (Bug A)
+
+- `_point_id_versioned(rel_path, chunk_index, generation)` →
+  `md5("{rel_path}:{chunk_index}:g{generation}")`. Same change to `_point_id`
+  (legacy path) and `_visual_point_id` (`md5("{rel_path}:p{page_num}")`).
+- ID basis is the repo-relative `file_path` already present in every chunk
+  payload. `upsert_chunks` and the visual upsert derive the ID from
+  `chunk["file_path"]`, falling back to slug only if file_path is absent
+  (defensive; all current callers set it).
+- Point IDs are opaque — nothing reads them back — so no consumer changes.
+  `carta export`/`import` (`share.py`) must be verified early in implementation
+  to confirm it round-trips IDs without assuming the scheme.
+
+### 2. Generation cleanup on re-embed
+
+After a successful upsert of generation *g* for a file, delete points where
+`file_path == <file>` AND `doc_generation != g` (Qdrant filtered delete).
+Consequences:
+- Stale-generation chunks no longer linger in search results.
+- Legacy-scheme points are organically migrated: any file that is re-embedded
+  has all its old points (whatever their IDs) removed by the file_path filter.
+  Unchanged files keep their old-scheme points harmlessly. **No forced
+  migration**; existing healthy corpora are not regressed.
+- Add a keyword payload index on `file_path` at `ensure_collection` time (new
+  collections) to keep filtered deletes fast; absence of the index on existing
+  collections is acceptable (full-scan delete at local corpus sizes).
+
+### 3. Empty-chunk guard (Bug B)
+
+In `_embed_one_file` (text path) and the visual path:
+- Drop chunks whose text is empty/whitespace before embedding; count drops.
+- File yields **zero** non-empty chunks → upsert nothing, set sidecar
+  `status: extraction_failed`, print a warning naming the file:
+  `"0 extractable characters — skipped (scanned PDF? OCR may be required)"`.
+- File yields **some** empty chunks → embed the rest; report
+  `"N empty chunks dropped"` (verbose per-file; aggregate in the embed summary).
+- `run_embed` summary gains an `extraction_failed` count alongside
+  embedded/skipped.
+
+### 4. Sidecar status bookkeeping (Bug E)
+
+`run_embed_file`: on successful embed, the final sidecar state is
+`status: current`, `stale_as_of: null` (lifecycle updates must not clobber the
+success state). `status: stale` persists only when the embed itself failed.
+The stale marker remains correct for the window between hash-change detection
+and re-embed completion.
+
+### 5. `carta doctor` corpus-integrity checks (read-only)
+
+New doctor section scanning the project's `_doc` (and `_visual` if present)
+collections plus sidecars:
+
+1. **Slug collisions:** >1 embedded file sharing a slug (these overwrite each
+   other under the legacy ID scheme).
+2. **Empty-text points:** files with ≥1 empty-text point; report fully-empty
+   vs partial counts.
+3. **Count mismatches:** sidecar `chunk_count` vs actual point count per
+   `file_path`.
+4. **Stuck-stale sidecars:** `status: stale` while `file_hash` matches the file
+   on disk.
+
+Human-readable summary + `--json`, consistent with existing doctor output.
+Doctor only reports; it directs the user to `carta embed --repair`.
+
+### 6. `carta embed --repair`
+
+Runs the same detection, then per affected file:
+- Delete all points for that `file_path` (filtered delete, both collections as
+  applicable).
+- Force re-embed via `run_embed_file(force=True)` through the fixed pipeline
+  (new IDs, empty guard, correct status bookkeeping). Note: `force=True` today
+  only bypasses the mtime fast-path; the hash short-circuit at
+  `pipeline.py:1082` would still skip files whose sidecar hash matches disk
+  (true for all 43 empty files). Repair must bypass the hash short-circuit as
+  well — `force` is extended to mean "re-embed unconditionally".
+- Empty-extraction files therefore end up purged + `extraction_failed`, not
+  re-upserted. Stuck-stale sidecars get their status corrected even when no
+  re-embed is needed.
+- Prints per-file actions and a final summary (repaired / purged / flagged).
+
+### 7. ET-embed corpus repair + eval fix (post-release, not Carta code)
+
+- Run `carta doctor` (verify detection matches the investigation's numbers),
+  then `carta embed --repair`: re-embeds the 4 collided READMEs, purges ~1,400
+  fully-empty points + ~150 partial-empty chunks, fixes 169 stuck-stale
+  sidecars.
+- Eval set: change the termination query's `expect` to
+  `["vcu/pcb-design-checklist"]`.
+- Re-run the 62-query eval (hybrid-only and reranked), update `RESULTS.md`.
+  Expected: ci/README and the pcb query recover (+2 hits); US-11965795 remains
+  an honest, flagged miss pending OCR work; possible incidental gains from
+  removing ~1,500 garbage vectors from dense space.
+
+## Testing
+
+Strict TDD per task. Key cases:
+- **Collision regression:** embed two same-stem files; assert distinct point
+  IDs and both files fully retrievable by file_path; assert visual page IDs
+  likewise distinct.
+- **Generation cleanup:** re-embed a changed file; assert old-generation points
+  gone, new generation intact; assert a *different* file's points untouched.
+- **Empty guard:** all-empty extraction → no upsert, sidecar
+  `extraction_failed`, warning printed; partial-empty → only empty chunks
+  dropped, drop count reported.
+- **Status bookkeeping:** successful re-embed ends `status: current`,
+  `stale_as_of: null`; failed embed leaves `stale`.
+- **Doctor checks:** each of the four detections against fixture corpora
+  (mocked Qdrant or ephemeral collections, matching existing test patterns).
+- **Repair:** integration test covering delete→re-embed and purge+flag paths.
+- All 798 existing tests stay green; tests pinning the old ID derivation are
+  updated deliberately (the change is the point).
+
+## Release
+
+- Version 0.11.0; CHANGELOG; README docs for doctor integrity checks and
+  `embed --repair`.
+- Update issue #19 with the investigation findings (chunking hypothesis
+  largely disproven); file v0.12.0 issues for Bug C (pool dilution), Bug D
+  (reranker demotion), and OCR recovery.

--- a/docs/superpowers/specs/2026-06-12-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-06-12-data-integrity-design.md
@@ -94,9 +94,10 @@ generation-arithmetic strategy and closes holes it could not cover:
 `_embed_one_file` also persists `generation` to `sidecar_updates` so that bulk
 sidecars correctly record the generation after their first embed.
 
-- Add a keyword payload index on `file_path` at `ensure_collection` time (new
-  collections) to keep filtered deletes fast; absence of the index on existing
-  collections is acceptable (full-scan delete at local corpus sizes).
+- The keyword payload index on `file_path` originally planned for
+  `ensure_collection` is **deferred** (recorded at final review): filtered
+  deletes full-scan, which is acceptable at local corpus sizes; revisit if
+  collections grow past ~10⁵ points.
 
 ### 3. Empty-chunk guard (Bug B)
 

--- a/docs/superpowers/specs/2026-06-12-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-06-12-data-integrity-design.md
@@ -100,15 +100,20 @@ In `_embed_one_file` (text path) and the visual path:
 ### 4. Sidecar status bookkeeping (Bug E)
 
 `run_embed_file`: on successful embed, the final sidecar state is
-`status: current`, `stale_as_of: null` (lifecycle updates must not clobber the
-success state). `status: stale` persists only when the embed itself failed.
-The stale marker remains correct for the window between hash-change detection
-and re-embed completion.
+`status: embedded` (the codebase's existing canonical healthy value — not
+`current` as originally drafted), `stale_as_of: null`; `extraction_failed`
+from the embed itself survives the merge. On an embed exception nothing is
+written, so the sidecar keeps its prior state and the file stays
+re-discoverable. Sidecar-level `stale` is no longer persisted at all — the
+stale marker during the re-embed window lives on the old generation's Qdrant
+points (`mark_sidecar_stale`), which generation cleanup then removes.
 
 ### 5. `carta doctor` corpus-integrity checks (read-only)
 
-New doctor section scanning the project's `_doc` (and `_visual` if present)
-collections plus sidecars:
+New doctor section scanning the project's `_doc` collection plus sidecars.
+(`_visual` scanning is deliberately deferred to the visual/OCR follow-up:
+repair cannot re-create visual points it purges until a visual re-embed path
+exists, so detecting damage there without a fix path would only mislead.)
 
 1. **Slug collisions:** >1 embedded file sharing a slug (these overwrite each
    other under the legacy ID scheme).
@@ -162,8 +167,8 @@ Strict TDD per task. Key cases:
 - **Empty guard:** all-empty extraction → no upsert, sidecar
   `extraction_failed`, warning printed; partial-empty → only empty chunks
   dropped, drop count reported.
-- **Status bookkeeping:** successful re-embed ends `status: current`,
-  `stale_as_of: null`; failed embed leaves `stale`.
+- **Status bookkeeping:** successful re-embed ends `status: embedded`,
+  `stale_as_of: null`; an embed exception writes nothing (prior state kept).
 - **Doctor checks:** each of the four detections against fixture corpora
   (mocked Qdrant or ephemeral collections, matching existing test patterns).
 - **Repair:** integration test covering delete→re-embed and purge+flag paths.

--- a/docs/superpowers/specs/2026-06-12-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-06-12-data-integrity-design.md
@@ -73,14 +73,27 @@ Out of scope (deferred, tracked as v0.12.0 candidates):
 
 ### 2. Generation cleanup on re-embed
 
-After a successful upsert of generation *g* for a file, delete points where
-`file_path == <file>` AND `doc_generation != g` (Qdrant filtered delete).
-Consequences:
-- Stale-generation chunks no longer linger in search results.
-- Legacy-scheme points are organically migrated: any file that is re-embedded
-  has all its old points (whatever their IDs) removed by the file_path filter.
-  Unchanged files keep their old-scheme points harmlessly. **No forced
-  migration**; existing healthy corpora are not regressed.
+After a successful, complete upsert for a file, delete every point where
+`file_path == <file>` EXCEPT the point IDs just written (`HasIdCondition`
+exclusion — Qdrant filtered delete). Generation remains as a payload field
+(`doc_generation`) for observability but is no longer the cleanup key.
+
+This ID-set-based approach (`delete_other_points`) subsumes the earlier
+generation-arithmetic strategy and closes holes it could not cover:
+- **Tail chunks of shrunken files**: a file that loses chunks on re-embed at
+  the *same* generation still has its orphaned tail removed, because those
+  points are not in the just-written ID set.
+- **Legacy slug-keyed duplicates**: old points with different IDs (keyed by
+  filename stem instead of file path) are caught by the file_path filter and
+  excluded from the keep set, so they are deleted on first re-embed.
+- **Bulk-path generation reuse (C1)**: bulk sidecars initialised at
+  `generation: 0` caused the first re-embed to reuse generation 1; the old
+  `doc_generation != g` filter then spared all prior gen-1 points. The ID-set
+  approach is independent of generation arithmetic and is unaffected by this.
+
+`_embed_one_file` also persists `generation` to `sidecar_updates` so that bulk
+sidecars correctly record the generation after their first embed.
+
 - Add a keyword payload index on `file_path` at `ensure_collection` time (new
   collections) to keep filtered deletes fast; absence of the index on existing
   collections is acceptable (full-scan delete at local corpus sizes).


### PR DESCRIPTION
## Summary

Fixes two data-loss bugs and two bookkeeping bugs found by the issue #19 depth-check investigation, and adds detection + repair tooling for corpora damaged by them.

### Fixed
- **Point-ID collision (data loss):** point IDs hashed only the filename-stem slug, so same-stem files (4× `README.md` in the ET-embed corpus) silently overwrote each other's Qdrant points. IDs now hash the repo-relative file path; visual page IDs fixed identically.
- **Stale-point leak:** re-embedded files left their previous points searchable forever. Cleanup is now **ID-set-based** — after a complete upsert, every point for the file except the just-written IDs is deleted (`HasIdCondition`), which also organically migrates legacy slug-keyed points on first re-embed and handles shrinking files. Partial upserts keep the previous generation and warn.
- **Empty-chunk fail-open:** PDF extraction failures produced unfindable points with identical embedding-of-empty-string vectors (1,400+ in ET-embed, including its own PCT filing). Empty chunks are dropped at upsert; zero-text files are flagged `extraction_failed` and counted separately.
- **Sidecar status bookkeeping:** successful re-embeds ended permanently `stale` (169/971 ET-embed sidecars); they now end `embedded`. `force` now truly re-embeds even when the hash is unchanged (required by `--repair`).

### Added
- **`carta doctor` corpus-integrity section** (read-only): slug collisions, empty-text points, sidecar/Qdrant count mismatches, stuck-stale sidecars; merged into doctor's JSON output.
- **`carta embed --repair`:** purges and force re-embeds affected files; fixes stuck-stale sidecars in place; summary distinguishes repaired / purged / flagged `extraction_failed` / queued-for-visual / failed.

## Notes & recorded deferrals
- `_visual` collection integrity scanning is deferred until a visual re-embed path exists (repair can't restore what it purges there). Recorded in the spec.
- The `file_path` payload index is deferred — filtered deletes full-scan, fine at local corpus sizes.
- Heads-up: pass-1 visual queueing is unscoped, so repairing a large scanned-PDF corpus can queue many pages into `visual_pending`; draining (`carta embed --visual`) remains opt-in.
- Pre-existing (not a regression): sidecar-level `status: stale` is no longer produced anywhere, so MCP `carta_embed scope='stale'` (which keys on it) effectively returns empty; its prior population was an artifact of the bug fixed here. Follow-up issue to be filed.

## Test plan
- 851 passed, 2 skipped (baseline 798 + 53 new tests), strict TDD per task, per-task spec + quality reviews, final integration review with a Critical (generation-reuse cleanup hole) found and fixed pre-PR.
- Post-release validation on the ET-embed corpus (doctor → repair → 62-query eval re-run) tracked as the next step; expected to recover the ci/README and pcb-checklist eval misses.

Spec: `docs/superpowers/specs/2026-06-12-data-integrity-design.md` · Plan: `docs/superpowers/plans/2026-06-12-data-integrity.md` · Investigation: #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)