### PR TITLE
Visual-cap fusion: bound the _visual lane's share of the RRF pool (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable changes to **carta-cc** are documented here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.11.0] — 2026-06-12
+## [Unreleased]
+
+### Fixed
+- **Visual pool dilution (#36).** Cross-collection RRF fusion interleaved text and visual
+  hits ~1:1 by rank, so once a `_visual` collection had content ~half of every query's
+  candidate pool was visual — including pure-text questions — halving effective text depth.
+  A new `search.fusion.visual_max_ratio` knob caps the visual lane's share of the fused pool
+  (default `0.2`; cap = round(ratio × pool size); freed slots backfill with deeper text).
+  `1.0` restores the old behaviour, and pure-text corpora are unaffected. The cap lives in
+  the cross-collection merge, so it lifts both the hybrid-alone results and the rerank pool.
+  Measured on the 62-query ET-embed eval: hybrid-alone recall@5 **0.839 → 0.887** (3 misses
+  recovered, none regressed), the 14-query visual eval held flat at 0.857, and the reranked
+  path unchanged at 0.935.
 
 ### Fixed
 - **Point-ID collision (data loss).** Point IDs were hashed from the filename stem only, so

--- a/carta/config.py
+++ b/carta/config.py
@@ -52,6 +52,15 @@ DEFAULTS = {
             "seed_count": 10,       # how many top fused hits seed the walk
             "candidate_depth": 50,  # deep-fetch size when graph expansion is enabled
         },
+        "fusion": {
+            # Ceiling on the visual (_visual/ColPali) collection's share of the fused
+            # candidate pool, as a fraction of pool size (cap = round(ratio * pool)).
+            # RRF interleaves text and visual ~1:1 by rank, which halves text depth on
+            # every query once a _visual collection exists; this bounds visual so text
+            # questions keep their depth. 1.0 disables the cap (legacy behaviour). No
+            # effect on pure-text corpora. Eval-swept optimum — see RESULTS.md 2026-06-12.
+            "visual_max_ratio": 0.34,
+        },
     },
     "embed": {
         "reference_docs_path": "docs/reference/",

--- a/carta/config.py
+++ b/carta/config.py
@@ -58,8 +58,10 @@ DEFAULTS = {
             # RRF interleaves text and visual ~1:1 by rank, which halves text depth on
             # every query once a _visual collection exists; this bounds visual so text
             # questions keep their depth. 1.0 disables the cap (legacy behaviour). No
-            # effect on pure-text corpora. Eval-swept optimum — see RESULTS.md 2026-06-12.
-            "visual_max_ratio": 0.34,
+            # effect on pure-text corpora. Eval-swept optimum (ET-embed 62q hybrid
+            # 0.839->0.887, visual 14q held at 0.857, reranked neutral at 0.935) —
+            # see RESULTS.md 2026-06-13.
+            "visual_max_ratio": 0.2,
         },
     },
     "embed": {

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1506,7 +1506,12 @@ def _visual_collection_ready(client, coll_name: str) -> bool:
     return bool(count and count > 0)
 
 
-def _rrf_merge_collections(per_collection: list[list[dict]], top_n: int, k: int = 60) -> list[dict]:
+def _rrf_merge_collections(
+    per_collection: list[list[dict]],
+    top_n: int,
+    k: int = 60,
+    visual_max_ratio: float = 1.0,
+) -> list[dict]:
     """Fuse ranked hit lists from multiple collections with Reciprocal Rank Fusion.
 
     Each collection's native scores live on incomparable scales — text uses cosine
@@ -1515,10 +1520,20 @@ def _rrf_merge_collections(per_collection: list[list[dict]], top_n: int, k: int 
     hit.  RRF discards score magnitude and fuses by rank instead, so a rank-0 text
     hit and a rank-0 visual hit compete fairly regardless of scale.
 
+    RRF alone, however, interleaves text and visual ~1:1 by rank, so once a `_visual`
+    collection has hits ~half of every fused pool is visual — even for pure-text
+    questions — halving effective text depth.  `visual_max_ratio` caps the visual
+    lane's share of the returned pool: visual hits beyond the cap are dropped and the
+    freed slots are backfilled with deeper text (or, if text is exhausted, restored
+    from the diverted visual).  RRF order is preserved among everything admitted.
+
     Args:
         per_collection: one list per collection, each already ordered best-first.
         top_n: number of fused results to return.
         k: RRF damping constant (Qdrant's fusion default is 60).
+        visual_max_ratio: ceiling on the visual lane's share of the pool, as a
+            fraction of `top_n` (cap = round(visual_max_ratio * top_n)). 1.0 (default)
+            disables the cap; a corpus with no visual hits is unaffected either way.
 
     Returns:
         Flat list of the original hit dicts, best-first by RRF, length <= top_n.
@@ -1532,7 +1547,29 @@ def _rrf_merge_collections(per_collection: list[list[dict]], top_n: int, k: int 
             scored.append((rrf, coll_index, rank, hit))
     # -rrf: higher fused score first. coll_index/rank: deterministic, text-first ties.
     scored.sort(key=lambda t: (-t[0], t[1], t[2]))
-    return [hit for _, _, _, hit in scored[:top_n]]
+
+    # Cap the visual lane's share of the pool. No-op when no hit is visual or when
+    # visual_cap >= top_n (i.e. visual_max_ratio >= 1.0): the visual branch never
+    # diverts, so the walk reproduces scored[:top_n] exactly.
+    visual_cap = round(visual_max_ratio * top_n)
+    result: list[dict] = []
+    overflow: list[dict] = []
+    visual_admitted = 0
+    for _, _, _, hit in scored:
+        if len(result) >= top_n:
+            break
+        if hit.get("type") == "visual":
+            if visual_admitted < visual_cap:
+                result.append(hit)
+                visual_admitted += 1
+            else:
+                overflow.append(hit)
+        else:
+            result.append(hit)
+    # Text too shallow to fill the pool: restore diverted visual, still RRF order.
+    if len(result) < top_n and overflow:
+        result.extend(overflow[: top_n - len(result)])
+    return result
 
 
 def _apply_graph_expansion(results: list[dict], cfg: dict, repo_root) -> list[dict]:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1772,7 +1772,12 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     
     # Fuse across collections by rank (RRF) — scale-free, so visual MaxSim scores
     # can't swamp text cosine/RRF scores. fetch_limit keeps the rerank pool wide.
-    all_results = _rrf_merge_collections(per_collection, fetch_limit)
+    # visual_max_ratio caps the visual lane's share so text questions keep their depth.
+    fusion_cfg = cfg.get("search", {}).get("fusion", {})
+    visual_max_ratio = fusion_cfg.get("visual_max_ratio", 1.0)
+    all_results = _rrf_merge_collections(
+        per_collection, fetch_limit, visual_max_ratio=visual_max_ratio
+    )
 
     # Graph-aware expansion: promote related:-adjacent docs into the pool the reranker
     # sees. Fail-open. Off by default (opt in via search.graph.enabled); when enabled,

--- a/carta/embed/tests/test_visual_search_merge.py
+++ b/carta/embed/tests/test_visual_search_merge.py
@@ -4,6 +4,8 @@ Bug: text (cosine/RRF, ~0-1) and visual (ColPali MaxSim, ~10-40) hits were merge
 by raw score, so visual always won every slot — enabling colpali_enabled dropped
 recall to 0. The fix fuses by rank (RRF across collections), which is scale-free.
 """
+from unittest.mock import MagicMock
+
 from carta.embed.pipeline import _rrf_merge_collections
 
 
@@ -106,3 +108,29 @@ def test_ratio_zero_excludes_visual_when_text_fills_pool():
     merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.0)
     assert all(m["type"] == "text" for m in merged)
     assert [m["source"] for m in merged] == ["t0", "t1", "t2", "t3", "t4"]
+
+
+def test_run_search_forwards_configured_visual_max_ratio(monkeypatch, tmp_path):
+    # The configured search.fusion.visual_max_ratio must reach _rrf_merge_collections.
+    import carta.embed.pipeline as pipeline
+
+    captured = {}
+
+    def fake_merge(per_collection, top_n, k=60, visual_max_ratio=1.0):
+        captured["ratio"] = visual_max_ratio
+        return []
+
+    monkeypatch.setattr(pipeline, "_rrf_merge_collections", fake_merge)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(pipeline, "find_config", lambda: str(tmp_path / ".carta" / "config.yaml"))
+    # No collections -> the per-collection loop is skipped and the merge is still called.
+    monkeypatch.setattr("carta.search.scoped.get_search_collections", lambda cfg, scope: [])
+
+    cfg = {
+        "project_name": "proj",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://localhost:11434", "ollama_model": "nomic-embed-text"},
+        "search": {"top_n": 5, "fusion": {"visual_max_ratio": 0.34}},
+    }
+    pipeline.run_search("query", cfg)
+    assert captured["ratio"] == 0.34

--- a/carta/embed/tests/test_visual_search_merge.py
+++ b/carta/embed/tests/test_visual_search_merge.py
@@ -50,3 +50,59 @@ def test_single_collection_preserves_order():
     visual = [_visual("v0", 30), _visual("v1", 20), _visual("v2", 10)]
     merged = _rrf_merge_collections([visual], top_n=5)
     assert [m["source"] for m in merged] == ["v0", "v1", "v2"]
+
+
+def test_cap_is_noop_without_visual_lane():
+    # A capping ratio must not change output when there are no visual hits.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(6)]
+    capped = _rrf_merge_collections([text], top_n=5, visual_max_ratio=0.2)
+    uncapped = _rrf_merge_collections([text], top_n=5, visual_max_ratio=1.0)
+    assert [m["source"] for m in capped] == [m["source"] for m in uncapped]
+    assert [m["source"] for m in capped] == ["t0", "t1", "t2", "t3", "t4"]
+
+
+def test_visual_cap_limits_visual_share():
+    # cap = round(0.2 * 5) = 1 -> exactly one visual survives, text keeps the rest.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(5)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(5)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.2)
+    types = [m["type"] for m in merged]
+    assert types.count("visual") == 1
+    assert types.count("text") == 4
+    # RRF order preserved among admitted hits (text-first tie at rank 0).
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "t2", "t3"]
+
+
+def test_overflow_backfills_when_text_exhausted():
+    # Few text hits, many visual, cap = 1: pool must still fill to top_n from the
+    # diverted (overflow) visual hits, in RRF order.
+    text = [_text("t0", 0.5), _text("t1", 0.49)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(6)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.2)
+    assert len(merged) == 5
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "v2"]
+
+
+def test_admitted_hits_keep_rrf_order():
+    # cap = round(0.25 * 6) = 2: two visual admitted, interleave order preserved, no backfill.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(4)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(4)]
+    merged = _rrf_merge_collections([text, visual], top_n=6, visual_max_ratio=0.25)
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "t2", "t3"]
+
+
+def test_ratio_one_disables_cap():
+    # visual_max_ratio = 1.0 (the function default) -> full RRF interleave, unchanged.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(3)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(3)]
+    merged = _rrf_merge_collections([text, visual], top_n=6, visual_max_ratio=1.0)
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "t2", "v2"]
+
+
+def test_ratio_zero_excludes_visual_when_text_fills_pool():
+    # cap = round(0.0 * 5) = 0 -> no visual admitted while text can fill the pool.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(5)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(3)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.0)
+    assert all(m["type"] == "text" for m in merged)
+    assert [m["source"] for m in merged] == ["t0", "t1", "t2", "t3", "t4"]

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -136,3 +136,10 @@ def test_graph_defaults_present():
     assert graph["hops"] == 1
     assert graph["seed_count"] == 10
     assert graph["candidate_depth"] == 50
+
+
+def test_fusion_defaults_present():
+    from carta.config import DEFAULTS
+    fusion = DEFAULTS["search"]["fusion"]
+    # Provisional cap; finalized by the ratio sweep (see RESULTS.md 2026-06-12).
+    assert fusion["visual_max_ratio"] == 0.34

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -141,5 +141,6 @@ def test_graph_defaults_present():
 def test_fusion_defaults_present():
     from carta.config import DEFAULTS
     fusion = DEFAULTS["search"]["fusion"]
-    # Provisional cap; finalized by the ratio sweep (see RESULTS.md 2026-06-12).
-    assert fusion["visual_max_ratio"] == 0.34
+    # Eval-swept optimum: maximizes ET-embed 62q text recall (0.839->0.887) while
+    # holding the 14q visual eval flat at 0.857 (see RESULTS.md 2026-06-13).
+    assert fusion["visual_max_ratio"] == 0.2

--- a/docs/superpowers/plans/2026-06-12-visual-pool-dilution.md
+++ b/docs/superpowers/plans/2026-06-12-visual-pool-dilution.md
@@ -1,0 +1,435 @@
+# Visual-cap Fusion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the `_visual` collection from claiming ~half of every query's fused candidate pool, so text questions keep their retrieval depth — recovering the three dilution misses on the ET-embed eval without regressing the visual eval.
+
+**Architecture:** One localized change in `_rrf_merge_collections` (`carta/embed/pipeline.py`): after the existing RRF sort, cap how many fused-pool slots may be visual (`type == "visual"`), preserving RRF order among admitted hits and backfilling vacated slots with deeper text. A new config knob `search.fusion.visual_max_ratio` controls the cap; `run_search` reads it and passes it through. The merge feeds both the hybrid-alone return and the rerank pool, so this fixes both paths at once. No-op for pure-text corpora and when the ratio is `>= 1.0`.
+
+**Tech Stack:** Python 3.10+, pytest, qdrant-client. No new dependencies.
+
+**Spec:** [docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md](../specs/2026-06-12-visual-pool-dilution-design.md) · **Issue:** [#36](https://github.com/Ian-q/Carta/issues/36)
+
+**Before starting:** This is feature work; an isolated worktree/branch (e.g. `visual-pool-dilution`) should exist via the `superpowers:using-git-worktrees` skill. Per repo convention, version bump / tag / PyPI release are a **separate post-merge chore** and are NOT part of this plan (see Closeout).
+
+---
+
+## File Structure
+
+- **Modify** `carta/embed/pipeline.py`
+  - `_rrf_merge_collections` (currently lines 1509–1535): add `visual_max_ratio` param + cap logic.
+  - `run_search` (the merge call, currently line 1738): read `search.fusion.visual_max_ratio` and pass it.
+- **Modify** `carta/config.py`
+  - `DEFAULTS["search"]`: add a `"fusion": {"visual_max_ratio": 0.34}` block (provisional default; finalized by the sweep in Task 4).
+- **Test** `carta/embed/tests/test_visual_search_merge.py` — new cap unit tests (extends the existing file).
+- **Test** `carta/tests/test_config.py` — new `fusion` default test.
+- **Docs** `CHANGELOG.md`, project memory `MEMORY.md`/`et-embed-eval-workflow`, and the ET-embed `RESULTS.md` (sweep table).
+
+---
+
+## Task 1: Cap the visual lane in `_rrf_merge_collections`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py:1509-1535`
+- Test: `carta/embed/tests/test_visual_search_merge.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `carta/embed/tests/test_visual_search_merge.py` (the `_text`/`_visual` helpers already exist at the top of the file):
+
+```python
+def test_cap_is_noop_without_visual_lane():
+    # A capping ratio must not change output when there are no visual hits.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(6)]
+    capped = _rrf_merge_collections([text], top_n=5, visual_max_ratio=0.2)
+    uncapped = _rrf_merge_collections([text], top_n=5, visual_max_ratio=1.0)
+    assert [m["source"] for m in capped] == [m["source"] for m in uncapped]
+    assert [m["source"] for m in capped] == ["t0", "t1", "t2", "t3", "t4"]
+
+
+def test_visual_cap_limits_visual_share():
+    # cap = round(0.2 * 5) = 1 -> exactly one visual survives, text keeps the rest.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(5)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(5)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.2)
+    types = [m["type"] for m in merged]
+    assert types.count("visual") == 1
+    assert types.count("text") == 4
+    # RRF order preserved among admitted hits (text-first tie at rank 0).
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "t2", "t3"]
+
+
+def test_overflow_backfills_when_text_exhausted():
+    # Few text hits, many visual, cap = 1: pool must still fill to top_n from the
+    # diverted (overflow) visual hits, in RRF order.
+    text = [_text("t0", 0.5), _text("t1", 0.49)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(6)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.2)
+    assert len(merged) == 5
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "v2"]
+
+
+def test_admitted_hits_keep_rrf_order():
+    # cap = round(0.25 * 6) = 2: two visual admitted, interleave order preserved, no backfill.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(4)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(4)]
+    merged = _rrf_merge_collections([text, visual], top_n=6, visual_max_ratio=0.25)
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "t2", "t3"]
+
+
+def test_ratio_one_disables_cap():
+    # visual_max_ratio = 1.0 (the function default) -> full RRF interleave, unchanged.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(3)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(3)]
+    merged = _rrf_merge_collections([text, visual], top_n=6, visual_max_ratio=1.0)
+    assert [m["source"] for m in merged] == ["t0", "v0", "t1", "v1", "t2", "v2"]
+
+
+def test_ratio_zero_excludes_visual_when_text_fills_pool():
+    # cap = round(0.0 * 5) = 0 -> no visual admitted while text can fill the pool.
+    text = [_text(f"t{i}", 0.5 - i * 0.01) for i in range(5)]
+    visual = [_visual(f"v{i}", 30 - i) for i in range(3)]
+    merged = _rrf_merge_collections([text, visual], top_n=5, visual_max_ratio=0.0)
+    assert all(m["type"] == "text" for m in merged)
+    assert [m["source"] for m in merged] == ["t0", "t1", "t2", "t3", "t4"]
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `python -m pytest carta/embed/tests/test_visual_search_merge.py -v`
+Expected: the 6 new tests FAIL with `TypeError: _rrf_merge_collections() got an unexpected keyword argument 'visual_max_ratio'`. The 4 existing tests still PASS.
+
+- [ ] **Step 3: Implement the cap**
+
+Replace the whole function body at `carta/embed/pipeline.py:1509-1535` with:
+
+```python
+def _rrf_merge_collections(
+    per_collection: list[list[dict]],
+    top_n: int,
+    k: int = 60,
+    visual_max_ratio: float = 1.0,
+) -> list[dict]:
+    """Fuse ranked hit lists from multiple collections with Reciprocal Rank Fusion.
+
+    Each collection's native scores live on incomparable scales — text uses cosine
+    or RRF (~0-1) while the visual collection uses ColPali MaxSim (a sum over query
+    tokens, ~10-40).  Merging by raw score lets visual hits crowd out every text
+    hit.  RRF discards score magnitude and fuses by rank instead, so a rank-0 text
+    hit and a rank-0 visual hit compete fairly regardless of scale.
+
+    RRF alone, however, interleaves text and visual ~1:1 by rank, so once a `_visual`
+    collection has hits ~half of every fused pool is visual — even for pure-text
+    questions — halving effective text depth.  `visual_max_ratio` caps the visual
+    lane's share of the returned pool: visual hits beyond the cap are dropped and the
+    freed slots are backfilled with deeper text (or, if text is exhausted, restored
+    from the diverted visual).  RRF order is preserved among everything admitted.
+
+    Args:
+        per_collection: one list per collection, each already ordered best-first.
+        top_n: number of fused results to return.
+        k: RRF damping constant (Qdrant's fusion default is 60).
+        visual_max_ratio: ceiling on the visual lane's share of the pool, as a
+            fraction of `top_n` (cap = round(visual_max_ratio * top_n)). 1.0 (default)
+            disables the cap; a corpus with no visual hits is unaffected either way.
+
+    Returns:
+        Flat list of the original hit dicts, best-first by RRF, length <= top_n.
+        Ties (same rank across collections) break toward earlier collections, so
+        callers should pass the text collection before the visual one.
+    """
+    scored = []
+    for coll_index, hits in enumerate(per_collection):
+        for rank, hit in enumerate(hits):
+            rrf = 1.0 / (k + rank + 1)
+            scored.append((rrf, coll_index, rank, hit))
+    # -rrf: higher fused score first. coll_index/rank: deterministic, text-first ties.
+    scored.sort(key=lambda t: (-t[0], t[1], t[2]))
+
+    # Cap the visual lane's share of the pool. No-op when no hit is visual or when
+    # visual_cap >= top_n (i.e. visual_max_ratio >= 1.0): the visual branch never
+    # diverts, so the walk reproduces scored[:top_n] exactly.
+    visual_cap = round(visual_max_ratio * top_n)
+    result: list[dict] = []
+    overflow: list[dict] = []
+    visual_admitted = 0
+    for _, _, _, hit in scored:
+        if len(result) >= top_n:
+            break
+        if hit.get("type") == "visual":
+            if visual_admitted < visual_cap:
+                result.append(hit)
+                visual_admitted += 1
+            else:
+                overflow.append(hit)
+        else:
+            result.append(hit)
+    # Text too shallow to fill the pool: restore diverted visual, still RRF order.
+    if len(result) < top_n and overflow:
+        result.extend(overflow[: top_n - len(result)])
+    return result
+```
+
+- [ ] **Step 4: Run the merge tests to verify they pass**
+
+Run: `python -m pytest carta/embed/tests/test_visual_search_merge.py -v`
+Expected: all 10 tests PASS (4 original + 6 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/embed/tests/test_visual_search_merge.py
+git commit -m "feat(search): cap visual lane's share of the fused pool (#36)"
+```
+
+---
+
+## Task 2: Add the `search.fusion.visual_max_ratio` config default
+
+**Files:**
+- Modify: `carta/config.py:45-55` (inside `DEFAULTS["search"]`, after the `graph` block)
+- Test: `carta/tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `carta/tests/test_config.py`:
+
+```python
+def test_fusion_defaults_present():
+    from carta.config import DEFAULTS
+    fusion = DEFAULTS["search"]["fusion"]
+    # Provisional cap; finalized by the ratio sweep (see RESULTS.md 2026-06-12).
+    assert fusion["visual_max_ratio"] == 0.34
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m pytest carta/tests/test_config.py::test_fusion_defaults_present -v`
+Expected: FAIL with `KeyError: 'fusion'`.
+
+- [ ] **Step 3: Add the default block**
+
+In `carta/config.py`, inside `DEFAULTS["search"]`, immediately after the closing `}` of the `"graph": { ... }` block (currently line 54) and before the closing `}` of `"search"`, add:
+
+```python
+        "fusion": {
+            # Ceiling on the visual (_visual/ColPali) collection's share of the fused
+            # candidate pool, as a fraction of pool size (cap = round(ratio * pool)).
+            # RRF interleaves text and visual ~1:1 by rank, which halves text depth on
+            # every query once a _visual collection exists; this bounds visual so text
+            # questions keep their depth. 1.0 disables the cap (legacy behaviour). No
+            # effect on pure-text corpora. Eval-swept optimum — see RESULTS.md 2026-06-12.
+            "visual_max_ratio": 0.34,
+        },
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `python -m pytest carta/tests/test_config.py::test_fusion_defaults_present -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/config.py carta/tests/test_config.py
+git commit -m "feat(config): add search.fusion.visual_max_ratio default (#36)"
+```
+
+---
+
+## Task 3: Wire `run_search` to read and pass the ratio
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (the `_rrf_merge_collections` call, currently line 1738)
+- Test: `carta/embed/tests/test_visual_search_merge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `carta/embed/tests/test_visual_search_merge.py`. Add `from unittest.mock import MagicMock` to the imports at the top of the file if not already present:
+
+```python
+def test_run_search_forwards_configured_visual_max_ratio(monkeypatch, tmp_path):
+    # The configured search.fusion.visual_max_ratio must reach _rrf_merge_collections.
+    import carta.embed.pipeline as pipeline
+
+    captured = {}
+
+    def fake_merge(per_collection, top_n, k=60, visual_max_ratio=1.0):
+        captured["ratio"] = visual_max_ratio
+        return []
+
+    monkeypatch.setattr(pipeline, "_rrf_merge_collections", fake_merge)
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(pipeline, "find_config", lambda: str(tmp_path / ".carta" / "config.yaml"))
+    # No collections -> the per-collection loop is skipped and the merge is still called.
+    monkeypatch.setattr("carta.search.scoped.get_search_collections", lambda cfg, scope: [])
+
+    cfg = {
+        "project_name": "proj",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://localhost:11434", "ollama_model": "nomic-embed-text"},
+        "search": {"top_n": 5, "fusion": {"visual_max_ratio": 0.34}},
+    }
+    pipeline.run_search("query", cfg)
+    assert captured["ratio"] == 0.34
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m pytest carta/embed/tests/test_visual_search_merge.py::test_run_search_forwards_configured_visual_max_ratio -v`
+Expected: FAIL — `captured["ratio"]` is `1.0` (the function default), not `0.34`, because `run_search` does not yet pass the config value. Assertion error `assert 1.0 == 0.34`.
+
+- [ ] **Step 3: Read the config value and pass it**
+
+In `carta/embed/pipeline.py`, find the merge call (currently line 1738):
+
+```python
+    all_results = _rrf_merge_collections(per_collection, fetch_limit)
+```
+
+Replace it with:
+
+```python
+    fusion_cfg = cfg.get("search", {}).get("fusion", {})
+    visual_max_ratio = fusion_cfg.get("visual_max_ratio", 1.0)
+    all_results = _rrf_merge_collections(
+        per_collection, fetch_limit, visual_max_ratio=visual_max_ratio
+    )
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `python -m pytest carta/embed/tests/test_visual_search_merge.py -v`
+Expected: all tests PASS (including the new wiring test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/embed/tests/test_visual_search_merge.py
+git commit -m "feat(search): run_search passes visual_max_ratio to fusion (#36)"
+```
+
+---
+
+## Task 4: Full suite + ratio sweep (finalize the default)
+
+**Files:**
+- Possibly modify: `carta/config.py` (set the swept-best ratio if it differs from 0.34)
+- Modify: `~/School/Elementrailer/ET-embed/RESULTS.md` (append a dated sweep table)
+
+- [ ] **Step 1: Run the full carta test suite**
+
+Run: `python -m pytest -q`
+Expected: all tests PASS (851 prior + 7 new = 858), no failures. If anything else broke, stop and fix before sweeping.
+
+- [ ] **Step 2: Sweep the ratio on both eval sets**
+
+The sweep uses the unreleased checkout against the live ET-embed corpus. From the ET-embed root
+(`~/School/Elementrailer/ET-embed`), for each `R` in `1.0, 0.5, 0.34, 0.2`, temporarily set
+`search.fusion.visual_max_ratio: R` in `.carta/config.yaml`, then run:
+
+```bash
+# 62-query text eval, hybrid-alone (default config = rerank off)
+PYTHONPATH=/Users/ian/dev/doc-audit-cc ~/.local/pipx/venvs/carta-cc/bin/python \
+  -m carta eval .carta/eval/et-embed.yaml -k 5
+
+# 62-query text eval, reranked (temporarily enable the rerank block documented in config.yaml)
+OMP_NUM_THREADS=1 PYTHONPATH=/Users/ian/dev/doc-audit-cc ~/.local/pipx/venvs/carta-cc/bin/python \
+  -m carta eval .carta/eval/et-embed.yaml -k 5
+
+# 14-query visual eval, auto (rerank off) — the regression guard
+PYTHONPATH=/Users/ian/dev/doc-audit-cc ~/.local/pipx/venvs/carta-cc/bin/python \
+  -m carta eval .carta/eval/et-embed-datasheets.yaml -k 5
+```
+
+Record recall@5 / MRR for each (ratio × eval-set × mode) cell. Baselines to beat / hold:
+hybrid-alone 0.839/0.674, reranked 0.903/0.819 (these are the `R=1.0` rows by construction),
+and the visual eval's current recall@5 (capture the `R=1.0` value first as the no-regression bar).
+
+- [ ] **Step 3: Pick the default and set it**
+
+Choose the lowest-dilution ratio that **maximizes 62-query text recall@5/MRR (hybrid-alone and
+reranked) while holding the 14-query visual eval flat**. If that ratio is not `0.34`, update
+`carta/config.py` `DEFAULTS["search"]["fusion"]["visual_max_ratio"]` to the chosen value and
+update `carta/tests/test_config.py::test_fusion_defaults_present` to match. Confirm the three
+dilution misses (SAFETY-MCU-MESSAGES, TIMING_ARCHITECTURE, connector-map) now land in top-5.
+
+- [ ] **Step 4: Restore the ET-embed config**
+
+Set `~/School/Elementrailer/ET-embed/.carta/config.yaml` back to its normal state (rerank off,
+no temporary `visual_max_ratio` override — the new default is inherited from carta). Verify with
+`git -C ~/School/Elementrailer/ET-embed diff .carta/config.yaml` (should show no leftover sweep edits).
+
+- [ ] **Step 5: Re-run the suite if the default changed, then commit**
+
+If Step 3 changed the default:
+
+```bash
+python -m pytest carta/tests/test_config.py::test_fusion_defaults_present -v   # PASS
+git add carta/config.py carta/tests/test_config.py
+git commit -m "perf(search): set visual_max_ratio default to swept optimum (#36)"
+```
+
+Append the sweep table to the ET-embed `RESULTS.md` under a `## 2026-06-12 — visual-cap fusion (#36)`
+heading (this file lives in the ET-embed repo, committed there separately, not in carta).
+
+---
+
+## Task 5: Closeout — CHANGELOG + memory
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `MEMORY.md` index + `et-embed-eval-workflow` memory (carta-cc session memory dir)
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, add a new section above the `## [0.11.0]` heading. Use the chosen ratio
+from Task 4 in the prose:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+- **Visual pool dilution (#36).** Cross-collection RRF fusion interleaved text and visual
+  hits ~1:1 by rank, so once a `_visual` collection had content ~half of every query's
+  candidate pool was visual — including pure-text questions — halving effective text depth.
+  A new `search.fusion.visual_max_ratio` knob caps the visual lane's share of the fused pool
+  (default `<chosen>`; `1.0` restores the old behaviour); freed slots backfill with deeper
+  text. No effect on pure-text corpora. Recovers the SAFETY-MCU-MESSAGES, TIMING_ARCHITECTURE,
+  and connector-map misses on the ET-embed eval.
+```
+
+- [ ] **Step 2: Commit the CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for visual-cap fusion (#36)"
+```
+
+- [ ] **Step 3: Update project memory**
+
+Update the `et-embed-eval-workflow` memory (in the carta-cc session memory dir,
+`/Users/ian/.claude/projects/-Users-ian-dev-doc-audit-cc/memory/project_et-embed-eval-workflow.md`)
+with the new post-#36 baseline numbers and the chosen `visual_max_ratio`. This is session memory,
+not a repo file — no git commit.
+
+- [ ] **Step 4: Final verification before PR**
+
+Run: `python -m pytest -q`
+Expected: all PASS. The branch is ready for `requesting-code-review` → PR. Version bump
+(`carta/__init__.py` → `0.12.0`), tag, and PyPI release are a **separate post-merge chore**
+per repo convention; decide at PR time whether to ship #36 alone as 0.12.0 or bundle it with
+#37 (reranker demotion, phase 2 of this cycle).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** mechanism → Task 1; config knob → Task 2; `run_search` wiring → Task 3;
+  no-op/ratio-1.0/backfill/order/cap-0 test cases → Task 1 (all six from the spec's testing
+  section); ratio sweep on both eval sets + swept default → Task 4; CHANGELOG + memory → Task 5.
+- **Non-goals respected:** no score-gating, no fetch-widening, no visual drain, no #37 work.
+- **Type/name consistency:** `visual_max_ratio` (float), `search.fusion.visual_max_ratio`, and
+  `_rrf_merge_collections(..., visual_max_ratio=...)` are spelled identically in every task.
+- **Provisional value:** `0.34` appears in Tasks 2 and the Task 4 sweep grid; Task 4 Step 3 is
+  the single place it is finalized, with the test updated in lockstep.

--- a/docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md
+++ b/docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md
@@ -1,0 +1,187 @@
+# Design — Visual-cap fusion (bound the `_visual` lane's share of the fused pool)
+
+**Date:** 2026-06-12 · **Status:** approved (brainstorm) · **Target:** carta-cc (next minor, 0.12.0) · **Phase:** 1 of 2 — the v0.12.0 retrieval-quality cycle (follows v0.11.0 data integrity [2026-06-12-data-integrity-design.md](2026-06-12-data-integrity-design.md); precedes #37 reranker demotion). Closes [#36](https://github.com/Ian-q/Carta/issues/36).
+
+## Problem
+
+`_rrf_merge_collections` (`carta/embed/pipeline.py:1509`) fuses the per-collection hit
+lists with Reciprocal Rank Fusion: every hit's fused score depends **only on its rank
+within its own collection** (`rrf = 1/(k + rank + 1)`). A text rank-0 hit and a visual
+rank-0 hit therefore score identically and tie; text and visual interleave ~1:1 all the
+way down, and the merged list is truncated to `fetch_limit`.
+
+The consequence: **whenever a `_visual` collection holds content, ~half of every query's
+fused pool is visual — including pure-text questions.** Effective text depth is silently
+halved. Text docs at text-fused rank `pool/2 .. pool` can never reach the second stage
+(or, with rerank off, the returned `top_n`).
+
+Measured on the 62-query ET-embed eval (2026-06-12, post v0.11.0 repair, hybrid-alone):
+three misses are wholly or partly dilution —
+
+| Query | expected doc | note |
+|---|---|---|
+| SAFETY-MCU-MESSAGES | `docs/CAN/SAFETY-MCU-MESSAGES.md` | text-fused ~#34 → absent from the merged pool |
+| TIMING_ARCHITECTURE | telemetry timing doc | text rank survives single-collection, lost after merge |
+| connector-map | `docs/hardware/vcu/connector-map.md` | text #18 → merged #35 |
+
+Two structural facts shape the fix:
+
+- **The merge feeds both retrieval paths.** `run_search` calls `_rrf_merge_collections`
+  once (`pipeline.py:1738`); its output is *both* the hybrid-alone `top_n` return *and*
+  the `candidate_pool` slice handed to the reranker (`:1750`). A fix here lifts text depth
+  in **both** the 0.839 hybrid number and the 0.903 reranked number, in one place.
+- **Only `_visual` is scale-incompatible.** `per_collection` can hold several *text*
+  collections (`doc`, `session`, `quirk`, `note`) plus one `_visual`. The text collections
+  share a comparable cosine/RRF scale; RRF among them is fine. The intruder is specifically
+  the visual lane (ColPali MaxSim, ~10–40). The fix must treat **"all text lanes" vs "the
+  one visual lane"**, not collection-by-collection. Hits already carry the discriminator:
+  text hits are stamped `"type": "text"` (`:1717`), visual `"type": "visual"` (`:1668`).
+
+## Goals / Non-goals
+
+**Goals**
+- **Cap the visual lane's share of the fused pool** at a configurable fraction, preserving
+  RRF ordering among everything admitted. Excess visual hits are dropped (not interleaved),
+  and the slots they vacated are backfilled with deeper text.
+- **No-op for pure-text corpora.** When no hit has `type == "visual"`, output is byte-identical
+  to today. Pure-text projects (the common case) see zero behaviour change.
+- **One config knob:** `search.fusion.visual_max_ratio`, defaulted in `config.py` DEFAULTS.
+  Because the cap is a fraction of pool size, it auto-scales across regimes (hybrid-alone
+  pool=5, reranked pool=30/40, graph pool=50).
+- **Fix both paths at once** by living in `_rrf_merge_collections` — helps hybrid-alone
+  (the ET-embed default, rerank off) and reranked alike.
+- **Measurable, eval-swept default:** choose the shipped `visual_max_ratio` by sweeping it
+  on *both* eval sets (below). Success = the three dilution misses reach top-5 on the
+  62-query eval (hybrid-alone and reranked) **with no regression on the 14-query visual eval**.
+
+**Non-goals**
+- #37 (reranker demoting correct first-stage hits) — the next phase of this cycle.
+- Score-gated / relevance-thresholded visual inclusion — reintroduces the cross-scale
+  comparison RRF exists to avoid; fragile thresholds across corpora. Rejected during brainstorm.
+- Widening `fetch_limit` / the rerank pool to fit both lanes — raises rerank latency
+  (already ~10–15 s/query) and papers over, rather than fixes, the 50/50 split. Rejected.
+- A per-query "is this a visual question?" classifier — out of scope; the cap is a static dial.
+- Draining the 55 `--visual`-queued ET-embed patents — separate work (#38); intentionally
+  **after** this fix, since draining more visual before capping would amplify dilution.
+
+## Design
+
+### Mechanism — capped RRF merge
+
+A single change inside `_rrf_merge_collections`. After the existing RRF sort produces the
+fused, best-first list, walk it once with a visual budget:
+
+```
+visual_cap = round(visual_max_ratio * top_n)      # top_n == the pool size being composed
+result, overflow, visual_admitted = [], [], 0
+for hit in rrf_sorted:
+    if len(result) == top_n:
+        break
+    if hit is visual (hit.get("type") == "visual"):
+        if visual_admitted < visual_cap:
+            result.append(hit); visual_admitted += 1
+        else:
+            overflow.append(hit)            # divert, preserve order
+    else:
+        result.append(hit)                  # text admitted freely
+# text ran out before filling the pool → backfill from diverted visual, still RRF order
+if len(result) < top_n:
+    result.extend(overflow[: top_n - len(result)])
+return result
+```
+
+Properties:
+- **RRF order is preserved** among admitted hits — the cap only removes excess visual and
+  pulls up whatever text/visual sat behind it. No re-scoring, no scale comparison.
+- **No-op when no visual lane:** with zero visual hits the visual branch never fires and the
+  walk reproduces the current `scored[:top_n]`. (Also a no-op when `visual_cap >= top_n`,
+  i.e. `visual_max_ratio >= 1.0` — the explicit "disable the cap" setting.)
+- **Backfill guarantees length:** when text is too shallow to fill the pool, diverted visual
+  is restored, so the merge never returns fewer hits than it does today.
+- **Latency-neutral:** pool size is unchanged; the reranker sees the same number of candidates.
+
+The signature stays `_rrf_merge_collections(per_collection, top_n, k=60)` with one new
+keyword arg `visual_max_ratio: float = 1.0` (default = no cap, so existing callers/tests are
+unaffected until `run_search` passes the configured value). `run_search` reads
+`cfg["search"]["fusion"]["visual_max_ratio"]` and passes it at the `:1738` call site.
+
+### Config surface
+
+New `fusion` block in `config.py` DEFAULTS under `search`, beside `hybrid`/`rerank`/`graph`:
+
+```yaml
+search:
+  fusion:
+    # Ceiling on the visual (_visual/ColPali) collection's share of the fused candidate
+    # pool, as a fraction of pool size. RRF interleaves text and visual ~1:1 by rank, which
+    # halves text depth on every query once a _visual collection exists; this bounds visual
+    # so text questions keep their depth. 1.0 disables the cap (legacy behaviour). No effect
+    # on pure-text corpora. Default is the eval-swept optimum (see RESULTS.md 2026-06-12).
+    visual_max_ratio: <swept-best>   # provisional 0.34 pending the sweep
+```
+
+The shipped default is the value chosen by the sweep below — set during implementation, not
+guessed here. `_deep_merge` of DEFAULTS + user YAML (existing mechanism, `config.py:147`
+already deep-merges the `search` subtree) means existing project configs inherit the new
+key without edits.
+
+### Data flow (unchanged except the merge)
+
+```
+run_search
+  → per-collection query (text lanes + _visual), each to fetch_limit          (unchanged)
+  → _rrf_merge_collections(per_collection, fetch_limit, visual_max_ratio=…)    (← capped here)
+  → [graph expansion if enabled]                                              (unchanged)
+  → [rerank top candidate_pool if enabled]                                    (unchanged)
+  → return top_n                                                              (unchanged)
+```
+
+## Testing (TDD, unit-level on the merge)
+
+New cases in the merge's test module (`carta/embed/tests/test_visual_search_merge.py`):
+
+1. **No-op without visual:** all-text `per_collection` → output identical to the un-capped
+   `scored[:top_n]` (regression guard for pure-text corpora).
+2. **Cap binds:** text-heavy fused list, `visual_max_ratio` giving `cap=1` on a pool of 5 →
+   exactly 1 visual in output, ≥4 text, RRF order preserved among admitted.
+3. **Text exhausted → overflow backfill:** few text hits, many visual, small cap →
+   result length == `top_n`, filled from diverted visual in RRF order.
+4. **Order preservation:** admitted hits appear in the same relative order RRF gave them.
+5. **`visual_max_ratio = 1.0` disables the cap:** output == current behaviour (cap ≥ pool).
+6. **Rounding edge:** `cap == 0` (ratio rounds to 0) drops all visual when text fills the
+   pool; documents/asserts the chosen rounding (`round`).
+
+Full suite (851 + new) green on 3.10–3.12 before PR, per house practice.
+
+## Validation — the ratio sweep (deliverable: the shipped default)
+
+The cap is a Pareto dial, not a constant: too loose and text stays diluted; too tight and
+the visual eval's class-2 queries (the `(page N)` suffix appears **only** on `_visual`
+results — text chunks can never satisfy them, and the visual eval runs **rerank-off**) lose
+their visual hits. So the default is chosen empirically against *both* sets.
+
+Run from the ET-embed root with the unreleased checkout
+(`PYTHONPATH=<carta-checkout> ~/.local/pipx/venvs/carta-cc/bin/python -m carta eval …`,
+`OMP_NUM_THREADS=1` when reranking), sweeping `visual_max_ratio ∈ {1.0, 0.5, 0.34, 0.2}`:
+
+| Eval set | config | metric watched | direction |
+|---|---|---|---|
+| `et-embed.yaml` (62q) | hybrid-alone | recall@5 / MRR | maximize (recover the 3 misses) |
+| `et-embed.yaml` (62q) | + qwen3.5:9b rerank, pool 40 | recall@5 / MRR | maximize / hold ≥ 0.903 |
+| `et-embed-datasheets.yaml` (14q) | auto (rerank off) | recall@5 (esp. class-2) | **must not regress** |
+
+Pick the lowest-dilution ratio that maximizes 62-query text recall while holding the visual
+eval flat; ship it as the `config.py` default. Record the full table in `RESULTS.md`
+(dated section) and update `MEMORY.md` project memory (`et-embed-eval-workflow`) with the
+new baseline and the chosen ratio.
+
+## Rollout / risk
+
+- **Behaviour change for visual-enabled projects only.** Approved to ship the swept-best
+  ratio as the new default; pure-text projects are unaffected, and any project can restore
+  legacy fusion with `search.fusion.visual_max_ratio: 1.0`.
+- **Fail-safe shape:** the merge cannot raise on the new path (pure list walk); worst case a
+  mis-set ratio changes pool composition, never breaks search. No fail-open wrapper needed.
+- **Interaction with graph expansion (#graph):** graph runs *after* the capped merge on the
+  already-composed pool — no special handling; the cap simply shapes what graph sees. Off by
+  default on ET-embed, so the sweep measures the cap in isolation.


### PR DESCRIPTION
## Summary

Fixes **#36**. Cross-collection RRF fusion (`_rrf_merge_collections`) interleaved text and visual hits ~1:1 by rank, so whenever a `_visual` collection had content **~half of every query's candidate pool was visual — including pure-text questions**, halving effective text depth.

New `search.fusion.visual_max_ratio` knob caps the visual lane's share of the fused pool (`cap = round(ratio × pool size)`); excess visual hits are dropped and the freed slots backfill with deeper text, preserving RRF order among everything admitted. The cap lives in the cross-collection merge, so it shapes **both** the hybrid-alone result and the rerank pool. Default **`0.2`** (eval-swept); `1.0` restores the old behaviour; pure-text corpora are unaffected.

## Results (62-query ET-embed eval, ratio sweep)

| path | before (no cap) | after (0.2) |
|---|---|---|
| **hybrid-alone** recall@5 | 0.839 | **0.887** (+3 recovered, 0 regressed) |
| **14q visual** eval recall@5 | 0.857 | **0.857** (held — guard) |
| **reranked** recall@5 | 0.935 | **0.935** (neutral, identical miss set) |

`0.2` = 1 visual slot at the default pool of 5 — the Pareto sweet spot: cap≥2 leaves text diluted, cap=0 (ratio 0.1) collapses the visual eval to 0.571. Full sweep table in the ET-embed `RESULTS.md`.

**Honest scope note:** the cap's win is on the hybrid-alone (rerank-off, ET-embed default) path. The 3 deep misses #36 *predicted* (SAFETY-MCU / telemetry-timing / connector-map) are **not** recovered by pool composition — connector-map already hits when reranking, and SAFETY-MCU + telemetry still miss even reranked. Those are a deeper first-stage/reranker problem (feeds **#37**). Bonus #37 signal: RJ45-CTS hits hybrid-alone at 0.2 but the reranker demotes it back out of top-5.

## Test plan

- [x] 7 new unit tests on the cap (no-op without visual, cap binds, overflow backfill, RRF-order preservation, ratio=1.0 disables, ratio=0 excludes) + `run_search` wiring test + config-default test
- [x] Full suite green locally: **859 passed, 2 skipped** (Python 3.14 / Homebrew)
- [ ] CI green on 3.10 / 3.11 / 3.12

Spec: `docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md` · Plan: `docs/superpowers/plans/2026-06-12-visual-pool-dilution.md`

Version bump / release deferred (post-merge chore); decide at merge whether to ship as 0.12.0 alone or bundle with #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)