### PR TITLE
fix(scanner): exclude worktree/build/temp noise & whitelist skills (#49, #52)

### DIFF
--- a/carta/config.py
+++ b/carta/config.py
@@ -15,7 +15,8 @@ DEFAULTS = {
     "anchor_doc": "CLAUDE.md",
     "excluded_paths": [
         "node_modules/", ".venv/", "*.tmp",
-        ".planning/", ".worktrees/", ".carta/", ".pio/",
+        ".planning/", ".worktrees/", ".claude/worktrees/", ".carta/", ".pio/",
+        "build/", "temp/",
     ],
     "contradiction_types": [
         "version numbers",

--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -40,14 +40,23 @@ def parse_frontmatter(doc_path: Path) -> Optional[dict]:
 # Exclusion helpers
 # ---------------------------------------------------------------------------
 
+# Machine/tooling dirs that are never valid scan targets — excluded regardless
+# of user config, like .git (skipped in _iter_md_files). Existing repos carry a
+# config.yaml whose excluded_paths replaces DEFAULTS wholesale (_deep_merge does
+# not merge lists), so DEFAULTS alone would never reach them. `.claude/worktrees/`
+# holds full-repo worktree copies; `build/` holds packaging mirrors; `temp/` is scratch.
+_ALWAYS_EXCLUDED_DIRS = (".claude/worktrees/", "build/", "temp/")
+
+
 def is_excluded(file_path: Path, cfg: dict, repo_root: Path) -> bool:
-    """Return True if file_path matches any excluded_paths pattern in cfg."""
+    """Return True if file_path matches any excluded_paths pattern in cfg, or
+    falls under an always-excluded machine/tooling dir."""
     try:
         rel = str(file_path.relative_to(repo_root))
     except ValueError:
         rel = str(file_path)
 
-    for pattern in cfg.get("excluded_paths", []):
+    for pattern in (*_ALWAYS_EXCLUDED_DIRS, *cfg.get("excluded_paths", [])):
         if pattern.endswith("/"):
             if rel.startswith(pattern) or ("/" + pattern.rstrip("/") + "/" in "/" + rel):
                 return True
@@ -81,9 +90,15 @@ DEFAULT_HOMELESS_ROOT_WHITELIST = frozenset({
     "CLAUDE.md",
     "AGENTS.md",
     "GEMINI.md",
+    "BUGS.md",
     ".cursorrules",
     "CODEOWNERS",
 })
+
+# Directory prefixes whose markdown is an intentional home, not homeless_doc.
+# Skills live as `skills/<name>/SKILL.md` (and the bundled `carta/skills/` mirror)
+# by convention — outside docs/ on purpose.
+DEFAULT_HOMELESS_DIR_WHITELIST = ("skills/", "carta/skills/")
 
 
 def _anchor_basenames(cfg: dict) -> set[str]:
@@ -111,12 +126,14 @@ def check_homeless_docs(repo_root: Path, cfg: dict) -> list:
             continue
         if is_excluded(p, cfg, repo_root):
             continue
+        rel = str(p.relative_to(repo_root))
+        if any(rel.startswith(prefix) for prefix in DEFAULT_HOMELESS_DIR_WHITELIST):
+            continue  # intentional skill home — not homeless
         try:
             p.relative_to(docs_root)
             continue  # inside docs/ — fine
         except ValueError:
             pass
-        rel = str(p.relative_to(repo_root))
         issues.append({
             "type": "homeless_doc",
             "severity": "warning",

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -189,6 +189,79 @@ def test_default_root_whitelist_skips_common_root_docs(tmp_path):
     assert "LICENSE.md" not in doc_paths
 
 
+# ---------------------------------------------------------------------------
+# Scanner-noise exclusions — doc-audit #1 (#49 worktrees/build/temp, #52 skills/BUGS.md)
+# ---------------------------------------------------------------------------
+
+from carta.config import DEFAULTS as _DEFAULTS
+
+
+def _default_excluded_cfg():
+    return {"excluded_paths": list(_DEFAULTS["excluded_paths"])}
+
+
+def test_default_excludes_claude_worktrees(tmp_path):
+    """`.claude/worktrees/` copies of the whole repo must not be scanned (#49)."""
+    cfg = _default_excluded_cfg()
+    p = tmp_path / ".claude" / "worktrees" / "feat-x" / "NOTES.md"
+    assert is_excluded(p, cfg, tmp_path) is True
+
+
+def test_default_excludes_build_artifacts(tmp_path):
+    """`build/` packaging artifacts (build/lib mirrors) must not be scanned (#49)."""
+    cfg = _default_excluded_cfg()
+    p = tmp_path / "build" / "lib" / "carta" / "skills" / "doc-embed" / "SKILL.md"
+    assert is_excluded(p, cfg, tmp_path) is True
+
+
+def test_default_excludes_temp(tmp_path):
+    """`temp/` scratch dir must not be scanned (#49)."""
+    cfg = _default_excluded_cfg()
+    p = tmp_path / "temp" / "scratch.md"
+    assert is_excluded(p, cfg, tmp_path) is True
+
+
+def test_structural_dirs_excluded_regardless_of_config(tmp_path):
+    """Worktree/build/temp dirs are machine artifacts — excluded even when a
+    pre-existing config.yaml lists an older excluded_paths that omits them (#49).
+
+    `_deep_merge` replaces the list wholesale, so existing installs would never
+    pick up new DEFAULTS otherwise. Treat these like `.git`: always skipped.
+    """
+    cfg = {"excluded_paths": []}  # simulates a stale/empty user config
+    assert is_excluded(tmp_path / ".claude" / "worktrees" / "wt" / "X.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / "build" / "lib" / "X.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / "temp" / "X.md", cfg, tmp_path) is True
+    # A normal doc is still not excluded.
+    assert is_excluded(tmp_path / "docs" / "X.md", cfg, tmp_path) is False
+
+
+def test_homeless_skips_skills_dirs(tmp_path):
+    """SKILL.md files under skills/ and carta/skills/ are intentional homes (#52)."""
+    _make_tree(tmp_path, [
+        "docs/x.md",
+        "skills/doc-embed/SKILL.md",
+        "carta/skills/doc-embed/SKILL.md",
+    ])
+    cfg = _minimal_cfg(tmp_path)
+    issues = check_homeless_docs(tmp_path, cfg)
+    doc_paths = [i["doc"] for i in issues]
+    assert "skills/doc-embed/SKILL.md" not in doc_paths
+    assert "carta/skills/doc-embed/SKILL.md" not in doc_paths
+
+
+def test_homeless_skips_bugs_md(tmp_path):
+    """BUGS.md at repo root is an intentional location, not homeless (#52)."""
+    _make_tree(tmp_path, [
+        "docs/x.md",
+        "BUGS.md",
+    ])
+    cfg = _minimal_cfg(tmp_path)
+    issues = check_homeless_docs(tmp_path, cfg)
+    doc_paths = [i["doc"] for i in issues]
+    assert "BUGS.md" not in doc_paths
+
+
 def test_nested_docs_folder_detected(tmp_path):
     _make_tree(tmp_path, [
         "docs/ARCHITECTURE.md",


### PR DESCRIPTION
Closes #49. Closes #52.

## Problem
`carta scan` reported **160 issues** on this repo; ~113 were false positives from `.claude/worktrees/` full-repo copies and `build/lib` packaging mirrors, plus `homeless_doc` warnings for intentional `skills/*/SKILL.md` files and `BUGS.md`. The noise drowned the ~47 real findings.

## Fix
- **`is_excluded()` always skips `.claude/worktrees/`, `build/`, `temp/`** regardless of config — same precedent as `.git` in `_iter_md_files`. This is the key bit: `_deep_merge` replaces the `excluded_paths` list wholesale, so a DEFAULTS-only change would never reach existing repos whose `config.yaml` predates it. The hardcoded layer fixes existing installs with **no config edit required**.
- Mirrored the same dirs into `DEFAULTS.excluded_paths` for fresh-`init` discoverability.
- Whitelisted **`BUGS.md`** (root) and **`skills/` + `carta/skills/`** (dir prefixes) from `homeless_doc` detection — intentional homes outside `docs/`.

## Result
| | before | after |
|---|---|---|
| total scan issues (this repo) | 160 | **47** |
| worktree/build/temp noise | 113 | **0** |
| skills/BUGS false homeless | 26 | **0** |

Remaining 47 = 45 genuine `missing_frontmatter` (tracked separately in #48) + 1 homeless + 1 orphan.

Side benefit: `is_excluded` is shared by `carta/audit/audit.py`, so the integrity scan also stops descending into worktrees/build (helps #40).

## Tests (TDD)
6 new tests in `carta/scanner/tests/test_scanner.py`, written failing first — including `test_structural_dirs_excluded_regardless_of_config` which proves the existing-repo case (empty config still excludes). Full suite: **889 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)