### PR TITLE
fix(docs): skill CLI invocation, sidecar paths & install/config defaults (#44, #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ docker run -d -p 6333:6333 -v ~/.carta/qdrant_storage:/qdrant/storage --name qdr
 # 2. Ollama — install from ollama.ai, then pull required models
 ollama pull nomic-embed-text   # text embeddings
 ollama pull qwen3.5:0.8b       # hook judge (swap for larger model if preferred)
-ollama pull qwen2.5vl:7b       # vision describer for PDFs with figures/diagrams
+ollama pull qwen3-vl:8b        # vision describer for PDFs with figures/diagrams (needs Ollama >= 0.12.7)
+ollama pull glm-ocr            # OCR for text/tables on image-heavy PDF pages
 ```
 
 Both services are optional if you only want structural audit without embedding or search. See **[docs/install.md](docs/install.md)** for the full setup walkthrough and `carta doctor` to verify your environment.
@@ -228,7 +229,7 @@ search:
     model: BAAI/bge-reranker-base   # backend=cross-encoder (fastembed, local ONNX)
     llm_model: qwen3.5:0.8b         # backend=llm: one listwise Ollama call per search
     llm_timeout_s: 20
-    candidate_pool: 40      # docs fetched before reranking (use ~40 for the llm backend)
+    candidate_pool: 40      # docs fetched before reranking (default 30; ~40 suits the llm backend)
 ```
 
 - **`cross-encoder`** — fastembed `bge-reranker-base`, no Ollama, fast.
@@ -311,8 +312,8 @@ Then set in `.carta/config.yaml`:
 
 ```yaml
 embed:
-  colpali_enabled: true              # opt-in flag (default: false)
-  colpali_model: "vidore/colqwen2-v1.0"  # or colpali-v1.3 for lower VRAM
+  colpali_enabled: true              # force on; default is null (auto: search _visual when it exists)
+  colpali_model: "vidore/colqwen2-v1.0-hf"  # HF-native variant; or vidore/colpali-v1.3-hf for lower VRAM
   colpali_device: "cpu"              # "cpu", "cuda", or "mps"
   colpali_batch_size: 1              # pages per batch (1 for CPU)
   colpali_sidecar_path: ".carta/visual_cache/"
@@ -322,8 +323,8 @@ embed:
 
 | Model | VRAM | Speed | Quality | Best For |
 |-------|------|-------|---------|----------|
-| `vidore/colqwen2-v1.0` | ~8GB | Slow | Highest | GPU servers |
-| `vidore/colpali-v1.3` | ~6GB | Medium | High | Balanced GPU |
+| `vidore/colqwen2-v1.0-hf` | ~8GB | Slow | Highest | GPU servers |
+| `vidore/colpali-v1.3-hf` | ~6GB | Medium | High | Balanced GPU |
 | `vidore/colSmol-500M` | ~3GB | Medium | Good | CPU workstations |
 | `vidore/colSmol-256M` | ~2GB | Fast | Fair | CPU-only/laptops |
 

--- a/carta/install/auto_fix.py
+++ b/carta/install/auto_fix.py
@@ -350,7 +350,7 @@ class AutoInstaller:
         """Get suggested commands to pull required Ollama models."""
         return {
             "nomic-embed-text": "ollama pull nomic-embed-text",
-            "qwen2.5vl:7b": "ollama pull qwen2.5vl:7b",
+            "qwen3-vl:8b": "ollama pull qwen3-vl:8b",
             "qwen2.5:0.5b": "ollama pull qwen2.5:0.5b",
         }
 

--- a/carta/install/config.yaml.example
+++ b/carta/install/config.yaml.example
@@ -1,6 +1,10 @@
-# Carta Configuration Template
-# This template is used by `carta init` to generate .carta/config.yaml.
-# All fields are documented below; defaults are shown as YAML values.
+# Carta Configuration Reference
+#
+# REFERENCE ONLY — `carta init` does NOT read this file. Bootstrap generates
+# .carta/config.yaml from the built-in DEFAULTS in carta/config.py and deep-merges
+# any keys you set over those defaults. Use this file to discover available settings
+# and their default values, then copy only the keys you want to override into
+# .carta/config.yaml. Values below match the code DEFAULTS.
 
 # REQUIRED: Unique project identifier used for Qdrant collection namespacing
 # Example: my_project, product_docs, engineering_kb
@@ -12,88 +16,91 @@ qdrant_url: http://localhost:6333
 
 # Module toggles: enable/disable specific Carta features
 modules:
-  doc_audit: true          # Enable documentation consistency auditing
-  doc_embed: true          # Enable document embedding and vectorization
-  doc_search: true         # Enable semantic search over documents
-  session_memory: true     # Enable session-level memory persistence
-  proactive_recall: true   # Enable similarity-based doc suggestions during sessions
+  doc_audit: true          # Documentation consistency auditing
+  doc_embed: true          # Document embedding and vectorization
+  doc_search: true         # Semantic search over documents
+  session_memory: true     # Session-level memory persistence
+  proactive_recall: true   # Similarity-based doc suggestions during sessions
 
-# Root directory to scan for markdown documents (relative or absolute path)
-# Carta will recursively index all .md files under this directory
+# Root directory to scan for markdown documents
 docs_root: docs/
 
-# Glob patterns for directories/files to exclude from scanning
-# Useful for skipping build artifacts, vendor code, temporary files, etc.
+# Directories / globs to skip during scanning
 excluded_paths:
   - node_modules/
   - .venv/
   - "*.tmp"
+  - .planning/
+  - .worktrees/
+  - .carta/
+  - .pio/
 
-# Days before a document is marked as stale (no recent modifications)
-# Used by doc_audit to flag outdated or untouched documentation
+# Days before a document with a last_reviewed date is flagged stale
 stale_threshold_days: 30
 
-# Number of stale docs that triggers interactive human review
-# When audit finds this many stale docs, Carta prompts for input before continuing
+# Number of needs-input audits before interactive human review is requested
 needs_input_at_audit_count: 3
 
 # Document consistency checks: types of contradictions to detect
-# Examples are shown below; customize to your domain (e.g., pricing, endpoints, versions)
 contradiction_types:
-  - version numbers          # Check for inconsistent software/API versions
-  - API endpoints            # Check for mismatched URLs or service endpoints
-  - configuration values     # Check for conflicting settings or parameters
-  - environment variable names  # Check for variable name inconsistencies
+  - version numbers
+  - API endpoints
+  - configuration values
+  - environment variable names
 
-# Root document for consistency baseline
-# All other docs are checked against this anchor for contradictions
-# Usually CLAUDE.md or a root README containing canonical values
+# Root document used as the consistency baseline
 anchor_doc: CLAUDE.md
 
 # Search settings
 search:
-  top_n: 5  # Number of results returned by semantic search queries
+  top_n: 5                    # results returned by semantic search
+  hybrid:
+    enabled: true             # BM25 + dense fusion (RRF)
+    bm25_model: Qdrant/bm25
+    prefetch_limit: 40
+  rerank:
+    enabled: false            # off by default; opt in per project
+    backend: cross-encoder    # cross-encoder | llm
+    model: BAAI/bge-reranker-base
+    llm_model: qwen3.5:0.8b   # used when backend=llm
+    llm_timeout_s: 20
+    candidate_pool: 30        # docs fetched before reranking (~40 suits the llm backend)
 
 # Document embedding and vectorization settings
 embed:
-  # Path to reference documents used for embedding context
-  # Helps Carta understand domain-specific terminology and structure
   reference_docs_path: docs/reference/
-
-  # Path to audio transcripts or multimedia docs (for future multimodal support)
   audio_path: docs/audio/
-
-  # URL of Ollama instance for local LLM embedding and inference
-  # Required for doc_embed and proactive_recall features
   ollama_url: http://localhost:11434
-
-  # Ollama model for embedding vectors (typically a small, fast model)
-  # Examples: nomic-embed-text:latest, mxbai-embed-large:latest
-  ollama_model: nomic-embed-text:latest
-
-  # Text chunking configuration for embedding long documents
+  ollama_model: nomic-embed-text:latest    # text embeddings (768-dim)
+  ollama_vision_model: qwen3-vl:8b         # PDF page describer (requires Ollama >= 0.12.7)
+  ocr_model: glm-ocr:latest                # OCR for text/tables on image-heavy pages
+  vision_routing: auto                     # auto | ocr | vision | both
   chunking:
-    max_tokens: 800        # Maximum tokens per chunk before splitting
-    overlap_fraction: 0.15 # Fraction of overlap between consecutive chunks (0.0-1.0)
+    max_tokens: 800
+    overlap_fraction: 0.15
+    preserve_tables: true
 
-# Proactive recall settings: suggest related docs during active sessions
+# Proactive recall (carta-hook): three-zone relevance gate
+#   score > high_threshold  -> inject immediately (no judge call)
+#   score < low_threshold   -> silent (no injection)
+#   in between (gray zone)  -> small Ollama judge decides
 proactive_recall:
-  similarity_threshold: 0.78  # Minimum cosine similarity (0.0-1.0) for suggestions
-  max_results: 3              # Maximum number of related docs to suggest per query
-  ollama_judge: false         # Use LLM to re-rank results (requires Ollama; slower)
-  ollama_model: phi3.5-mini   # LLM model for ranking (if ollama_judge=true)
+  high_threshold: 0.85
+  low_threshold: 0.60
+  max_results: 5
+  judge_timeout_s: 3
+  ollama_model: qwen3.5:0.8b
 
-# Cross-project recall: suggest docs from other projects (Plan 1 stub)
+# Cross-project recall: suggest docs from other projects
 cross_project_recall:
-  enabled: false  # Enable cross-project semantic search
+  enabled: false
   scope:
-    - quirk       # Project types to include in cross-project search (see Carta docs)
-  require_ollama_judge: true  # Require LLM re-ranking for cross-project results
-  # Filter which projects to include in cross-project recall
+    - quirk
+  require_ollama_judge: true
   project_filter:
-    mode: all                # Mode: "all" (include all), "whitelist" (projects list)
-    projects: []             # Project names to include (if mode=whitelist)
+    mode: all                # all | whitelist
+    projects: []
 
-# Deep scan settings: intensive multi-pass analysis (V3 feature — not implemented in Plan 1)
-deep_scan:
-  enabled: false  # Stub for future implementation
+# Many more advanced settings exist (visual/ColPali embedding, vision-routing
+# thresholds, graph/fusion search tuning). See carta/config.py (DEFAULTS) for the
+# complete, authoritative list.

--- a/carta/install/preflight.py
+++ b/carta/install/preflight.py
@@ -322,7 +322,7 @@ class PreflightChecker:
         )
         if ollama_check and ollama_check.status == "pass":
             self.checks.append(self._check_ollama_model("nomic-embed-text"))
-            self.checks.append(self._check_ollama_model("qwen2.5vl:7b"))
+            self.checks.append(self._check_ollama_model("qwen3-vl:8b"))
             self.checks.append(self._check_ollama_model("qwen3.5:0.8b"))
         else:
             self.checks.append(

--- a/carta/install/tests/test_auto_fix.py
+++ b/carta/install/tests/test_auto_fix.py
@@ -1,0 +1,10 @@
+from carta.install.auto_fix import AutoInstaller
+
+
+def test_suggest_model_pulls_uses_current_vision_default():
+    """The `carta doctor --fix` pull map must offer the current vision default
+    (qwen3-vl:8b) so it matches what preflight checks — not the retired
+    qwen2.5vl:7b (#45)."""
+    pulls = AutoInstaller(interactive=False).suggest_model_pulls()
+    assert pulls.get("qwen3-vl:8b") == "ollama pull qwen3-vl:8b"
+    assert "qwen2.5vl:7b" not in pulls

--- a/carta/install/tests/test_preflight.py
+++ b/carta/install/tests/test_preflight.py
@@ -124,6 +124,30 @@ class TestJudgeModelCheck:
         check_names = [c.name for c in checker.checks]
         assert "ollama_model_qwen3.5:0.8b" in check_names
 
+    def test_vision_model_checked_uses_current_default(self):
+        """Preflight checks the current vision default (qwen3-vl:8b), not the
+        retired qwen2.5vl:7b (#45)."""
+        checker = PreflightChecker(interactive=False)
+        checker.checks = [
+            PreflightCheck(
+                name="ollama_running",
+                status="pass",
+                message="Ollama server running",
+                category="infrastructure",
+            )
+        ]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("R", (), {
+                "returncode": 0,
+                "stdout": "nomic-embed-text:latest\n",
+                "stderr": "",
+            })()
+            checker._phase3_models()
+
+        check_names = [c.name for c in checker.checks]
+        assert "ollama_model_qwen3-vl:8b" in check_names
+        assert "ollama_model_qwen2.5vl:7b" not in check_names
+
     def test_judge_model_warn_when_not_pulled(self):
         checker = PreflightChecker(interactive=False)
         checker.checks = [

--- a/carta/skills/doc-audit/SKILL.md
+++ b/carta/skills/doc-audit/SKILL.md
@@ -17,8 +17,10 @@ Check if `.carta/scan-results.json` exists and was written less than 1 hour ago 
 - If stale or missing: run the scanner first:
 
 ```bash
-python .carta/carta/cli.py scan
+carta scan
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta scan` instead (from the repo root).
 
 Read `scan-results.json` and extract:
 - `issues` list (structural findings)
@@ -56,7 +58,7 @@ For each doc in `changed_since_last_audit`:
 
 ### Qdrant Agent (optional)
 
-If Qdrant is reachable (run `python .carta/carta/cli.py search "test" 2>&1 | head -1` — no error means reachable):
+If Qdrant is reachable (run `carta search "test" 2>&1 | head -1` — no error means reachable):
 1. For each changed doc, run a semantic similarity search to find potentially conflicting or duplicate content in the knowledge graph.
 2. Surface any high-similarity (>0.92) matches that are not the same document as additional findings.
 

--- a/carta/skills/doc-embed/SKILL.md
+++ b/carta/skills/doc-embed/SKILL.md
@@ -17,8 +17,10 @@ Check if `.carta/scan-results.json` exists and was written less than 1 hour ago 
 - If stale or missing: run the scanner first:
 
 ```bash
-python .carta/carta/cli.py scan
+carta scan
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta scan` instead (from the repo root).
 
 Identify any files flagged `embed_induction_needed` in the scan results — these require a sidecar `.embed-meta.yaml` before embedding.
 
@@ -28,7 +30,7 @@ Identify any files flagged `embed_induction_needed` in the scan results — thes
 
 For each file flagged `embed_induction_needed`:
 
-1. Check if a `.embed-meta.yaml` sidecar already exists alongside the file.
+1. Check if a `.embed-meta.yaml` sidecar already exists for the file. Sidecars live under `.carta/sidecars/`, mirroring the source file's repo-relative path (e.g. `docs/reference/foo.pdf` → `.carta/sidecars/docs/reference/foo.embed-meta.yaml`) — they are **not** colocated beside the file.
    - If yes: read it and confirm it has at minimum `slug`, `doc_type`, and `status` fields.
    - If no: create a minimal sidecar with:
      ```yaml
@@ -50,7 +52,7 @@ For each file flagged `embed_induction_needed`:
 Run the embed command:
 
 ```bash
-python .carta/carta/cli.py embed
+carta embed
 ```
 
 Wait for the command to complete. Capture stdout/stderr. The command will report which files were newly embedded and which were skipped (already up to date).

--- a/carta/skills/doc-search/SKILL.md
+++ b/carta/skills/doc-search/SKILL.md
@@ -26,8 +26,10 @@ Extract the query string. If the user invoked the skill with no query text, ask:
 Run:
 
 ```bash
-python .carta/carta/cli.py search "<query>"
+carta search "<query>"
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta search "<query>"` instead (from the repo root).
 
 Replace `<query>` with the user's query string, properly quoted.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,8 +40,11 @@ ollama pull nomic-embed-text
 ollama pull qwen3.5:0.8b
 
 # Vision describer — used by carta embed for PDF pages with figures, tables, or images.
-# Default is qwen2.5vl:7b (~5GB). Override via embed.ollama_vision_model in .carta/config.yaml.
-ollama pull qwen2.5vl:7b
+# Default is qwen3-vl:8b (requires Ollama >= 0.12.7). Override via embed.ollama_vision_model in .carta/config.yaml.
+ollama pull qwen3-vl:8b
+
+# OCR — text/table extraction from image-heavy PDF pages (default ocr_model: glm-ocr:latest).
+ollama pull glm-ocr
 ```
 
 ### Verify

--- a/skills/doc-audit/SKILL.md
+++ b/skills/doc-audit/SKILL.md
@@ -17,8 +17,10 @@ Check if `.carta/scan-results.json` exists and was written less than 1 hour ago 
 - If stale or missing: run the scanner first:
 
 ```bash
-python .carta/carta/cli.py scan
+carta scan
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta scan` instead (from the repo root).
 
 Read `scan-results.json` and extract:
 - `issues` list (structural findings)
@@ -56,7 +58,7 @@ For each doc in `changed_since_last_audit`:
 
 ### Qdrant Agent (optional)
 
-If Qdrant is reachable (run `python .carta/carta/cli.py search "test" 2>&1 | head -1` — no error means reachable):
+If Qdrant is reachable (run `carta search "test" 2>&1 | head -1` — no error means reachable):
 1. For each changed doc, run a semantic similarity search to find potentially conflicting or duplicate content in the knowledge graph.
 2. Surface any high-similarity (>0.92) matches that are not the same document as additional findings.
 

--- a/skills/doc-embed/SKILL.md
+++ b/skills/doc-embed/SKILL.md
@@ -17,8 +17,10 @@ Check if `.carta/scan-results.json` exists and was written less than 1 hour ago 
 - If stale or missing: run the scanner first:
 
 ```bash
-python .carta/carta/cli.py scan
+carta scan
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta scan` instead (from the repo root).
 
 Identify any files flagged `embed_induction_needed` in the scan results — these require a sidecar `.embed-meta.yaml` before embedding.
 
@@ -28,7 +30,7 @@ Identify any files flagged `embed_induction_needed` in the scan results — thes
 
 For each file flagged `embed_induction_needed`:
 
-1. Check if a `.embed-meta.yaml` sidecar already exists alongside the file.
+1. Check if a `.embed-meta.yaml` sidecar already exists for the file. Sidecars live under `.carta/sidecars/`, mirroring the source file's repo-relative path (e.g. `docs/reference/foo.pdf` → `.carta/sidecars/docs/reference/foo.embed-meta.yaml`) — they are **not** colocated beside the file.
    - If yes: read it and confirm it has at minimum `slug`, `doc_type`, and `status` fields.
    - If no: create a minimal sidecar with:
      ```yaml
@@ -50,7 +52,7 @@ For each file flagged `embed_induction_needed`:
 Run the embed command:
 
 ```bash
-python .carta/carta/cli.py embed
+carta embed
 ```
 
 Wait for the command to complete. Capture stdout/stderr. The command will report which files were newly embedded and which were skipped (already up to date).

--- a/skills/doc-search/SKILL.md
+++ b/skills/doc-search/SKILL.md
@@ -26,8 +26,10 @@ Extract the query string. If the user invoked the skill with no query text, ask:
 Run:
 
 ```bash
-python .carta/carta/cli.py search "<query>"
+carta search "<query>"
 ```
+
+> Uses the installed `carta` CLI. If it isn't on your PATH, run `python -m carta search "<query>"` instead (from the repo root).
 
 Replace `<query>` with the user's query string, properly quoted.
 


### PR DESCRIPTION
Closes #44. Closes #45.

These are the "actually broken" doc fixes — agents and new users hit failures following the current docs.

## #44 — Skill docs (skills/ + carta/skills/)
- **Broken CLI path:** all three skills invoked `python .carta/carta/cli.py <cmd>`, which bootstrap no longer creates after `carta init` → "file not found". Replaced with the installed `carta <cmd>` CLI plus a `python -m carta <cmd>` fallback note.
- **Sidecar location:** doc-embed Step 2 said sidecars sit "alongside the file." Corrected to `.carta/sidecars/<mirrored-repo-relative-path>.embed-meta.yaml` (per `induct.py::sidecar_path`).
- Both `skills/` and the bundled `carta/skills/` mirror updated in lockstep.

## #45 — Install / config docs vs `carta/config.py` DEFAULTS
- **`config.yaml.example`** rewritten as a *reference-only* template (it is **not** read by `carta init` — bootstrap merges DEFAULTS). Dropped the phantom `deep_scan` stub and the stale `proactive_recall` schema (`similarity_threshold`/`ollama_judge`/`phi3.5-mini`/`max_results: 3`) in favour of the real three-zone gate.
- **Vision model** `qwen2.5vl:7b` → `qwen3-vl:8b` in README, `docs/install.md`, `preflight.py`, and the `carta doctor --fix` pull map (`auto_fix.py`) — so doctor checks and offers the same model.
- **glm-ocr** added to install prerequisites (README + install.md).
- **ColPali** config examples → `-hf` HF-native variants; corrected `colpali_enabled` default annotation (null/auto, not false); clarified rerank `candidate_pool` default is 30.

## Tests (TDD)
- New: preflight checks `qwen3-vl:8b` (not `qwen2.5vl:7b`); `auto_fix` pull map offers `qwen3-vl:8b`. Both written failing first.
- Full suite: **885 passed, 1 skipped**.

## Deliberately out of scope (follow-up)
Remaining `qwen2.5vl:7b` references not in #45's stated scope, left to avoid scope-creep — flagging for a follow-up:
- `carta/vision/router.py` fallback default (only used when config omits the key)
- a comment in `carta/cli.py`
- `auto_fix.py`'s *separately*-stale judge entry (`qwen2.5:0.5b`, should be `qwen3.5:0.8b`)
- test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)