### PR TITLE
fix(hook): skip injection on judge timeout — HOOK-05 (#51)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -86,7 +86,7 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. `carta-prompt-hook.sh` invokes `carta-hook` after the enabled check — the Python hook module is reachable
   2. `carta-hook` exists on PATH after `pip install` (registered in `pyproject.toml [project.scripts]`)
-  3. On `TimeoutError` in `_judge_with_timeout`, the hook returns `True` (inject / fail open)
+  3. On `TimeoutError` in `_judge_with_timeout`, the hook returns `False` (no injection on timeout; prompt still proceeds unblocked) — per HOOK-05
   4. Flow C works end-to-end: Claude Code hook triggers → shell stub → Python hook → inject/discard
 **Plans:** 1 plan (1 complete)
 

--- a/carta/hook/hook.py
+++ b/carta/hook/hook.py
@@ -5,9 +5,11 @@ run_search, and routes through three score zones:
 
   score > high_threshold  → fast-path inject (no Ollama)
   score < low_threshold   → noise gate (silent exit)
-  gray zone               → Ollama judge with timeout; inject on yes
+  gray zone               → Ollama judge with timeout; inject on yes,
+                            skip on no or timeout (HOOK-05: no injection on timeout)
 
-All paths exit 0 (fail-open). stdout is reserved for the JSON context block.
+All paths exit 0 (the prompt always proceeds unblocked). stdout is reserved for
+the JSON context block.
 All diagnostic output goes to stderr.
 """
 
@@ -199,17 +201,23 @@ def _call_ollama_judge(prompt: str, hits: list[dict], cfg: dict) -> bool:
 def _judge_with_timeout(
     prompt: str, hits: list[dict], cfg: dict, timeout_s: int
 ) -> bool:
-    """Run Ollama judge in a thread; return True on timeout (fail-open per HOOK-05), False on other errors."""
+    """Run Ollama judge in a thread; return False on timeout and on other errors.
+
+    HOOK-05: on timeout we do NOT inject. The gray-zone hits are exactly the
+    borderline ones the judge exists to vet, so injecting them unvetted would be
+    the context noise Carta tries to avoid. The hook still exits 0 — the prompt
+    proceeds unblocked — it just stays silent.
+    """
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(_call_ollama_judge, prompt, hits, cfg)
         try:
             return future.result(timeout=timeout_s)
         except concurrent.futures.TimeoutError:
             print(
-                f"carta-hook: judge timeout after {timeout_s}s (fail-open)",
+                f"carta-hook: judge timeout after {timeout_s}s (skipping injection)",
                 file=sys.stderr,
             )
-            return True
+            return False
         except Exception as e:
             print(f"carta-hook: judge exception (fail-open): {e}", file=sys.stderr)
             return False

--- a/carta/hook/tests/test_hook.py
+++ b/carta/hook/tests/test_hook.py
@@ -205,11 +205,12 @@ def test_gray_zone_judge_maybe_discards():
 
 
 # ---------------------------------------------------------------------------
-# Judge timeout: > judge_timeout_s fails open (HOOK-05)
+# Judge timeout: > judge_timeout_s skips injection (HOOK-05)
 # ---------------------------------------------------------------------------
 
-def test_judge_timeout_fails_open():
-    """Ollama judge sleeping 5s with 3s timeout: injects (fail-open per HOOK-05), completes within 6.5s."""
+def test_judge_timeout_skips_injection():
+    """Ollama judge sleeping 5s with 3s timeout: skips injection (HOOK-05: no
+    injection on timeout, prompt proceeds), completes within 6.5s."""
     hits = [_make_hit(0.75)]
     cfg = _make_cfg(judge_timeout_s=3)
 
@@ -228,10 +229,8 @@ def test_judge_timeout_fails_open():
         out = _capture_main()
     elapsed = time.time() - t_start
 
-    # HOOK-05: timeout is fail-open — inject context rather than discard
-    assert out.strip(), "Timeout should inject (fail-open per HOOK-05)"
-    data = json.loads(out.strip())
-    assert "context" in data
+    # HOOK-05: on timeout, do NOT inject the unvetted gray-zone hits — stay silent.
+    assert out.strip() == "", "Timeout should skip injection (HOOK-05: no injection on timeout)"
     # Hook logic completes at timeout (3s); thread pool shutdown waits for the
     # slow thread to finish (5s total). Allow up to 6.5s for full cleanup.
     assert elapsed < 6.5, f"Should complete within 6.5s, took {elapsed:.2f}s"
@@ -481,18 +480,18 @@ def test_call_ollama_judge_parses_no():
 
 
 # ---------------------------------------------------------------------------
-# _judge_with_timeout: HOOK-05 fail-open on timeout (returns True)
+# _judge_with_timeout: HOOK-05 no injection on timeout (returns False)
 # ---------------------------------------------------------------------------
 
-def test_judge_timeout_returns_true():
-    """TimeoutError in _judge_with_timeout returns True (fail-open per HOOK-05)."""
+def test_judge_timeout_returns_false():
+    """TimeoutError in _judge_with_timeout returns False (HOOK-05: no injection on timeout)."""
     import concurrent.futures
     from carta.hook.hook import _judge_with_timeout
     cfg = _make_cfg(judge_timeout_s=1)
     hits = [_make_hit(0.75)]
     with patch("carta.hook.hook._call_ollama_judge", side_effect=concurrent.futures.TimeoutError):
         result = _judge_with_timeout("prompt", hits, cfg, timeout_s=1)
-    assert result is True, "TimeoutError must return True (fail-open = inject)"
+    assert result is False, "TimeoutError must return False (no injection on timeout)"
 
 
 def test_judge_exception_returns_false():


### PR DESCRIPTION
Closes #51.

Implements the decision on #51: **Option B — skip injection on judge timeout.**

## Behavior change
On Ollama judge timeout, `_judge_with_timeout` now returns `False` (no injection) instead of `True` (inject). The gray-zone hits are precisely the borderline candidates the judge exists to vet — injecting them unvetted is the "context noise" Carta's core value promises to avoid. The hook still **exits 0**: the prompt proceeds unblocked, it just stays silent on timeout.

## Resolves the disagreement (AUDIT-009)
| Source | Before | After |
|--------|--------|-------|
| `REQUIREMENTS.md` HOOK-05 | no injection on timeout | ✅ unchanged (was already correct) |
| `hook.py` | injected | **skips** |
| `test_hook.py` | asserted injection | **asserts no injection** |
| `ROADMAP.md` criterion #3 | "returns True (inject)" | **"returns False (no injection)"** |

All four now agree.

## Changes
- `carta/hook/hook.py` — timeout branch returns `False`; docstring + module header comment updated.
- `carta/hook/tests/test_hook.py` — `test_judge_timeout_skips_injection` (asserts empty output) and `test_judge_timeout_returns_false`.
- `.planning/ROADMAP.md` — Phase 5 success criterion #3 corrected.

Note: non-timeout judge exceptions still return `False` (unchanged). Full suite: **919 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)