### PR TITLE
docs: add YAML frontmatter to the superpowers spec/plan corpus (#48)

### DIFF
--- a/docs/superpowers/plans/2026-03-25-cli-mcp-hybrid-and-bug-fixes-v2.md
+++ b/docs/superpowers/plans/2026-03-25-cli-mcp-hybrid-and-bug-fixes-v2.md
@@ -1,3 +1,11 @@
+---
+id: 2026-03-25-cli-mcp-hybrid-and-bug-fixes-v2
+title: "CLI + MCP Hybrid Migration and Stability Fixes Implementation Plan"
+status: shipped
+related: []
+date: 2026-03-25
+---
+
 # CLI + MCP Hybrid Migration and Stability Fixes Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-04-carta-marketplace-readiness.md
+++ b/docs/superpowers/plans/2026-04-04-carta-marketplace-readiness.md
@@ -1,3 +1,11 @@
+---
+id: 2026-04-04-carta-marketplace-readiness
+title: "Carta Marketplace Readiness Implementation Plan"
+status: shipped
+related: []
+date: 2026-04-04
+---
+
 # Carta Marketplace Readiness Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-05-carta-doctor-qdrant-start.md
+++ b/docs/superpowers/plans/2026-04-05-carta-doctor-qdrant-start.md
@@ -1,3 +1,11 @@
+---
+id: 2026-04-05-carta-doctor-qdrant-start
+title: "Carta Doctor Qdrant Start + Search Error Handling Implementation Plan"
+status: shipped
+related: []
+date: 2026-04-05
+---
+
 # Carta Doctor Qdrant Start + Search Error Handling Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-05-carta-update.md
+++ b/docs/superpowers/plans/2026-04-05-carta-update.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-05-carta-update
+title: "Carta Update Implementation Plan"
+status: shipped
+related:
+  - 2026-04-05-carta-update-design
+date: 2026-04-05
+---
+
 # Carta Update Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-05-progress-bar.md
+++ b/docs/superpowers/plans/2026-04-05-progress-bar.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-05-progress-bar
+title: "Interactive Progress Bar Implementation Plan"
+status: shipped
+related:
+  - 2026-04-05-progress-bar-design
+date: 2026-04-05
+---
+
 # Interactive Progress Bar Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-05-smart-vision-routing.md
+++ b/docs/superpowers/plans/2026-04-05-smart-vision-routing.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-05-smart-vision-routing
+title: "Smart Vision Routing Implementation Plan"
+status: shipped
+related:
+  - 2026-04-05-smart-vision-routing-design
+date: 2026-04-05
+---
+
 # Smart Vision Routing Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-06-embed-vision-progress.md
+++ b/docs/superpowers/plans/2026-04-06-embed-vision-progress.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-06-embed-vision-progress
+title: "Embed Vision Progress Implementation Plan"
+status: shipped
+related:
+  - 2026-04-06-embed-vision-progress-design
+date: 2026-04-06
+---
+
 # Embed Vision Progress Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-07-audit-command-implementation.md
+++ b/docs/superpowers/plans/2026-04-07-audit-command-implementation.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-07-audit-command-implementation
+title: "Audit Command Implementation Plan"
+status: shipped
+related:
+  - 2026-04-07-audit-command-design
+date: 2026-04-07
+---
+
 # Audit Command Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-07-skill-installation.md
+++ b/docs/superpowers/plans/2026-04-07-skill-installation.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-07-skill-installation
+title: "Skill Installation (`carta init`) Implementation Plan"
+status: shipped
+related:
+  - 2026-04-07-skill-installation-design
+date: 2026-04-07
+---
+
 # Skill Installation (`carta init`) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-08-qdrant-ollama-setup-ux.md
+++ b/docs/superpowers/plans/2026-04-08-qdrant-ollama-setup-ux.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-08-qdrant-ollama-setup-ux
+title: "Qdrant & Ollama Setup UX Implementation Plan"
+status: shipped
+related:
+  - 2026-04-08-qdrant-ollama-setup-ux-design
+date: 2026-04-08
+---
+
 # Qdrant & Ollama Setup UX Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-10-embed-progress-targeted.md
+++ b/docs/superpowers/plans/2026-04-10-embed-progress-targeted.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-10-embed-progress-targeted
+title: "Embed Progress Bar + Targeted File Embed Implementation Plan"
+status: shipped
+related:
+  - 2026-04-10-embed-progress-targeted-design
+date: 2026-04-10
+---
+
 # Embed Progress Bar + Targeted File Embed Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-04-21-sidecar-relocation.md
+++ b/docs/superpowers/plans/2026-04-21-sidecar-relocation.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-21-sidecar-relocation
+title: "Sidecar Relocation Implementation Plan"
+status: shipped
+related:
+  - 2026-04-21-sidecar-relocation-design
+date: 2026-04-21
+---
+
 # Sidecar Relocation Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-05-carta-hybrid-retrieval-rerank-eval.md
+++ b/docs/superpowers/plans/2026-06-05-carta-hybrid-retrieval-rerank-eval.md
@@ -1,3 +1,11 @@
+---
+id: 2026-06-05-carta-hybrid-retrieval-rerank-eval
+title: "Carta Hybrid Retrieval + Reranking + Eval Harness Implementation Plan"
+status: shipped
+related: []
+date: 2026-06-05
+---
+
 # Carta Hybrid Retrieval + Reranking + Eval Harness Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-06-statusline-progress-widget.md
+++ b/docs/superpowers/plans/2026-06-06-statusline-progress-widget.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-06-statusline-progress-widget
+title: "Carta status-line progress widget — Implementation Plan"
+status: shipped
+related:
+  - 2026-06-06-statusline-progress-widget-design
+date: 2026-06-06
+---
+
 # Carta status-line progress widget — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-07-two-pass-visual-embedding.md
+++ b/docs/superpowers/plans/2026-06-07-two-pass-visual-embedding.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-07-two-pass-visual-embedding
+title: "Two-Pass Visual Embedding — Implementation Plan"
+status: shipped
+related:
+  - 2026-06-07-two-pass-visual-embedding-design
+date: 2026-06-07
+---
+
 # Two-Pass Visual Embedding — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-09-llm-reranker.md
+++ b/docs/superpowers/plans/2026-06-09-llm-reranker.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-09-llm-reranker
+title: "LLM Reranker Backend — Implementation Plan"
+status: shipped
+related:
+  - 2026-06-09-llm-reranker-design
+date: 2026-06-09
+---
+
 # LLM Reranker Backend — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-10-eval-trust-hook-rerank.md
+++ b/docs/superpowers/plans/2026-06-10-eval-trust-hook-rerank.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-10-eval-trust-hook-rerank
+title: "Eval Trust + Hook Rerank Decoupling (v0.9.1) Implementation Plan"
+status: shipped
+related:
+  - 2026-06-10-eval-trust-hook-rerank-design
+date: 2026-06-10
+---
+
 # Eval Trust + Hook Rerank Decoupling (v0.9.1) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-10-graph-aware-retrieval.md
+++ b/docs/superpowers/plans/2026-06-10-graph-aware-retrieval.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-10-graph-aware-retrieval
+title: "Graph-aware Retrieval Implementation Plan"
+status: shipped
+related:
+  - 2026-06-10-graph-aware-retrieval-design
+date: 2026-06-10
+---
+
 # Graph-aware Retrieval Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-11-note-capture.md
+++ b/docs/superpowers/plans/2026-06-11-note-capture.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-11-note-capture
+title: "Note Capture (Quirks & Notes, v0.10.0) Implementation Plan"
+status: shipped
+related:
+  - 2026-06-10-note-capture-design
+date: 2026-06-11
+---
+
 # Note Capture (Quirks & Notes, v0.10.0) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-12-data-integrity.md
+++ b/docs/superpowers/plans/2026-06-12-data-integrity.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-12-data-integrity
+title: "Carta v0.11.0 Data Integrity Implementation Plan"
+status: shipped
+related:
+  - 2026-06-12-data-integrity-design
+date: 2026-06-12
+---
+
 # Carta v0.11.0 Data Integrity Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-12-visual-pool-dilution.md
+++ b/docs/superpowers/plans/2026-06-12-visual-pool-dilution.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-12-visual-pool-dilution
+title: "Visual-cap Fusion Implementation Plan"
+status: shipped
+related:
+  - 2026-06-12-visual-pool-dilution-design
+date: 2026-06-12
+---
+
 # Visual-cap Fusion Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-14-carta-status-command.md
+++ b/docs/superpowers/plans/2026-06-14-carta-status-command.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-14-carta-status-command
+title: "`carta status` Command Implementation Plan"
+status: shipped
+related:
+  - 2026-06-14-carta-status-command-design
+date: 2026-06-14
+---
+
 # `carta status` Command Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-06-14-contextual-chunk-headers.md
+++ b/docs/superpowers/plans/2026-06-14-contextual-chunk-headers.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-14-contextual-chunk-headers
+title: "Contextual Chunk Headers Implementation Plan"
+status: shipped
+related:
+  - 2026-06-14-contextual-chunk-headers-design
+date: 2026-06-14
+---
+
 # Contextual Chunk Headers Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/skills/audit-embed.md
+++ b/docs/superpowers/skills/audit-embed.md
@@ -1,6 +1,11 @@
 ---
-name: audit-embed
-description: Run and interpret Carta audit reports for embed pipeline consistency
+id: audit-embed
+title: "Carta audit and embed"
+status: shipped
+related: []
+date: 2026-04-07
+name: "audit-embed"
+description: "Run and interpret Carta audit reports for embed pipeline consistency"
 ---
 
 # Carta audit and embed

--- a/docs/superpowers/skills/carta-repair.md
+++ b/docs/superpowers/skills/carta-repair.md
@@ -1,6 +1,11 @@
 ---
-name: carta-repair
-description: Interactive repair of audit findings (reserved for future carta repair flows)
+id: carta-repair
+title: "Carta repair (stub)"
+status: draft
+related: []
+date: 2026-04-07
+name: "carta-repair"
+description: "Interactive repair of audit findings (reserved for future carta repair flows)"
 ---
 
 # Carta repair (stub)

--- a/docs/superpowers/skills/carta-workflow.md
+++ b/docs/superpowers/skills/carta-workflow.md
@@ -1,6 +1,11 @@
 ---
-name: carta-workflow
-description: General Carta workflow — scan, embed, search, and session memory
+id: carta-workflow
+title: "Carta workflow"
+status: shipped
+related: []
+date: 2026-04-07
+name: "carta-workflow"
+description: "General Carta workflow — scan, embed, search, and session memory"
 ---
 
 # Carta workflow

--- a/docs/superpowers/specs/2026-03-31-999.3-collection-scoping-design.md
+++ b/docs/superpowers/specs/2026-03-31-999.3-collection-scoping-design.md
@@ -1,3 +1,11 @@
+---
+id: 2026-03-31-999.3-collection-scoping-design
+title: "Phase 999.3 — Qdrant Collection Scoping (Repo Isolation + Shared + Global) — Design Spec"
+status: shipped
+related: []
+date: 2026-03-31
+---
+
 # Phase 999.3 — Qdrant Collection Scoping (Repo Isolation + Shared + Global) — Design Spec
 
 **Project:** Carta (`carta-cc`)  

--- a/docs/superpowers/specs/2026-04-02-999.4-glm-ocr-intelligent-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-02-999.4-glm-ocr-intelligent-extraction-design.md
@@ -1,3 +1,11 @@
+---
+id: 2026-04-02-999.4-glm-ocr-intelligent-extraction-design
+title: "Phase 999.4 — GLM-OCR Intelligent PDF Extraction — Design Spec"
+status: shipped
+related: []
+date: 2026-04-02
+---
+
 # Phase 999.4 — GLM-OCR Intelligent PDF Extraction — Design Spec
 
 **Project:** Carta (`carta-cc`)  

--- a/docs/superpowers/specs/2026-04-05-carta-update-design.md
+++ b/docs/superpowers/specs/2026-04-05-carta-update-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-05-carta-update-design
+title: "Carta Update — Design Spec"
+status: shipped
+related:
+  - 2026-04-05-carta-update
+date: 2026-04-05
+---
+
 # Carta Update — Design Spec
 
 **Date:** 2026-04-05  

--- a/docs/superpowers/specs/2026-04-05-progress-bar-design.md
+++ b/docs/superpowers/specs/2026-04-05-progress-bar-design.md
@@ -1,7 +1,10 @@
 ---
-title: Interactive Progress Bar for carta embed and carta scan
+id: 2026-04-05-progress-bar-design
+title: "Interactive Progress Bar for carta embed and carta scan"
+status: shipped
+related:
+  - 2026-04-05-progress-bar
 date: 2026-04-05
-status: approved
 ---
 
 # Interactive Progress Bar for `carta embed` and `carta scan`

--- a/docs/superpowers/specs/2026-04-05-smart-vision-routing-design.md
+++ b/docs/superpowers/specs/2026-04-05-smart-vision-routing-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-05-smart-vision-routing-design
+title: "Smart Vision Routing for PDF Embedding"
+status: shipped
+related:
+  - 2026-04-05-smart-vision-routing
+date: 2026-04-05
+---
+
 # Smart Vision Routing for PDF Embedding
 
 **Date:** 2026-04-05

--- a/docs/superpowers/specs/2026-04-06-embed-vision-progress-design.md
+++ b/docs/superpowers/specs/2026-04-06-embed-vision-progress-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-06-embed-vision-progress-design
+title: "Design: Embed Vision Progress — Per-Page Feedback & Post-File Summary"
+status: shipped
+related:
+  - 2026-04-06-embed-vision-progress
+date: 2026-04-06
+---
+
 # Design: Embed Vision Progress — Per-Page Feedback & Post-File Summary
 
 **Date:** 2026-04-06  

--- a/docs/superpowers/specs/2026-04-07-audit-command-design.md
+++ b/docs/superpowers/specs/2026-04-07-audit-command-design.md
@@ -1,7 +1,10 @@
 ---
-title: Audit Command & Skill Design
+id: 2026-04-07-audit-command-design
+title: "Audit Command & Skill Design"
+status: shipped
+related:
+  - 2026-04-07-audit-command-implementation
 date: 2026-04-07
-status: approved
 ---
 
 # Audit Command & Skill Design

--- a/docs/superpowers/specs/2026-04-07-skill-installation-design.md
+++ b/docs/superpowers/specs/2026-04-07-skill-installation-design.md
@@ -1,7 +1,10 @@
 ---
-title: Skill Installation for Carta Init
+id: 2026-04-07-skill-installation-design
+title: "Skill Installation for Carta Init"
+status: shipped
+related:
+  - 2026-04-07-skill-installation
 date: 2026-04-07
-status: implemented
 ---
 
 # Skill Installation Design

--- a/docs/superpowers/specs/2026-04-08-qdrant-ollama-setup-ux-design.md
+++ b/docs/superpowers/specs/2026-04-08-qdrant-ollama-setup-ux-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-08-qdrant-ollama-setup-ux-design
+title: "Qdrant & Ollama Setup UX — Design Spec"
+status: shipped
+related:
+  - 2026-04-08-qdrant-ollama-setup-ux
+date: 2026-04-08
+---
+
 # Qdrant & Ollama Setup UX — Design Spec
 
 **Date:** 2026-04-08

--- a/docs/superpowers/specs/2026-04-10-embed-progress-targeted-design.md
+++ b/docs/superpowers/specs/2026-04-10-embed-progress-targeted-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-10-embed-progress-targeted-design
+title: "Design: Embed Progress Bar + Targeted File Embed"
+status: shipped
+related:
+  - 2026-04-10-embed-progress-targeted
+date: 2026-04-10
+---
+
 # Design: Embed Progress Bar + Targeted File Embed
 
 **Date:** 2026-04-10  

--- a/docs/superpowers/specs/2026-04-21-sidecar-relocation-design.md
+++ b/docs/superpowers/specs/2026-04-21-sidecar-relocation-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-04-21-sidecar-relocation-design
+title: "Sidecar Relocation: Co-located → `.carta/sidecars/`"
+status: shipped
+related:
+  - 2026-04-21-sidecar-relocation
+date: 2026-04-21
+---
+
 # Sidecar Relocation: Co-located → `.carta/sidecars/`
 
 **Date:** 2026-04-21

--- a/docs/superpowers/specs/2026-05-05-stale-reference-detection-design.md
+++ b/docs/superpowers/specs/2026-05-05-stale-reference-detection-design.md
@@ -1,8 +1,10 @@
 ---
-title: Stale-reference detection (v1) — design spec
+id: 2026-05-05-stale-reference-detection-design
+title: "Stale-reference detection (v1) — design spec"
 status: draft
+related: []
 date: 2026-05-05
-related_issue: Ian-q/Carta#10
+related_issue: "Ian-q/Carta#10"
 ---
 
 # Stale-reference detection (v1) — design spec

--- a/docs/superpowers/specs/2026-06-06-statusline-progress-widget-design.md
+++ b/docs/superpowers/specs/2026-06-06-statusline-progress-widget-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-06-statusline-progress-widget-design
+title: "Carta status-line progress widget — design"
+status: shipped
+related:
+  - 2026-06-06-statusline-progress-widget
+date: 2026-06-06
+---
+
 # Carta status-line progress widget — design
 
 **Date:** 2026-06-06

--- a/docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md
+++ b/docs/superpowers/specs/2026-06-07-two-pass-visual-embedding-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-07-two-pass-visual-embedding-design
+title: "Two-Pass Visual Embedding — Design"
+status: shipped
+related:
+  - 2026-06-07-two-pass-visual-embedding
+date: 2026-06-07
+---
+
 # Two-Pass Visual Embedding — Design
 
 **Date:** 2026-06-07

--- a/docs/superpowers/specs/2026-06-08-carta-share-export-import-design.md
+++ b/docs/superpowers/specs/2026-06-08-carta-share-export-import-design.md
@@ -1,3 +1,11 @@
+---
+id: 2026-06-08-carta-share-export-import-design
+title: "Carta `share` — Export / Import of Embeddings"
+status: shipped
+related: []
+date: 2026-06-08
+---
+
 # Carta `share` — Export / Import of Embeddings
 
 **Date:** 2026-06-08

--- a/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
+++ b/docs/superpowers/specs/2026-06-09-llm-reranker-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-09-llm-reranker-design
+title: "Design — LLM reranker backend for `search.rerank`"
+status: shipped
+related:
+  - 2026-06-09-llm-reranker
+date: 2026-06-09
+---
+
 # Design — LLM reranker backend for `search.rerank`
 
 **Date:** 2026-06-09 · **Status:** approved (brainstorm) · **Target:** carta-cc (next minor, 0.8.0)

--- a/docs/superpowers/specs/2026-06-10-eval-trust-hook-rerank-design.md
+++ b/docs/superpowers/specs/2026-06-10-eval-trust-hook-rerank-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-10-eval-trust-hook-rerank-design
+title: "Eval Trust + Hook Rerank Decoupling (v0.9.1) — Design"
+status: shipped
+related:
+  - 2026-06-10-eval-trust-hook-rerank
+date: 2026-06-10
+---
+
 # Eval Trust + Hook Rerank Decoupling (v0.9.1) — Design
 
 **Date:** 2026-06-10

--- a/docs/superpowers/specs/2026-06-10-graph-aware-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-10-graph-aware-retrieval-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-10-graph-aware-retrieval-design
+title: "Design — Graph-aware retrieval (`related:` 1-hop expansion)"
+status: shipped
+related:
+  - 2026-06-10-graph-aware-retrieval
+date: 2026-06-10
+---
+
 # Design — Graph-aware retrieval (`related:` 1-hop expansion)
 
 **Date:** 2026-06-10 · **Status:** approved (brainstorm) · **Target:** carta-cc (next minor, 0.9.0) · **Phase:** 2 of 3 (follows the LLM reranker, [2026-06-09-llm-reranker-design.md](2026-06-09-llm-reranker-design.md))

--- a/docs/superpowers/specs/2026-06-10-note-capture-design.md
+++ b/docs/superpowers/specs/2026-06-10-note-capture-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-10-note-capture-design
+title: "Note Capture — Quirks & Notes (v0.10.0) — Design"
+status: shipped
+related:
+  - 2026-06-11-note-capture
+date: 2026-06-10
+---
+
 # Note Capture — Quirks & Notes (v0.10.0) — Design
 
 **Date:** 2026-06-10

--- a/docs/superpowers/specs/2026-06-12-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-06-12-data-integrity-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-12-data-integrity-design
+title: "Carta v0.11.0 — Data Integrity: point-ID collisions, empty-chunk fail-open, corpus repair"
+status: shipped
+related:
+  - 2026-06-12-data-integrity
+date: 2026-06-12
+---
+
 # Carta v0.11.0 — Data Integrity: point-ID collisions, empty-chunk fail-open, corpus repair
 
 **Date:** 2026-06-12

--- a/docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md
+++ b/docs/superpowers/specs/2026-06-12-visual-pool-dilution-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-12-visual-pool-dilution-design
+title: "Design — Visual-cap fusion (bound the `_visual` lane's share of the fused pool)"
+status: shipped
+related:
+  - 2026-06-12-visual-pool-dilution
+date: 2026-06-12
+---
+
 # Design — Visual-cap fusion (bound the `_visual` lane's share of the fused pool)
 
 **Date:** 2026-06-12 · **Status:** approved (brainstorm) · **Target:** carta-cc (next minor, 0.12.0) · **Phase:** 1 of 2 — the v0.12.0 retrieval-quality cycle (follows v0.11.0 data integrity [2026-06-12-data-integrity-design.md](2026-06-12-data-integrity-design.md); precedes #37 reranker demotion). Closes [#36](https://github.com/Ian-q/Carta/issues/36).

--- a/docs/superpowers/specs/2026-06-14-carta-status-command-design.md
+++ b/docs/superpowers/specs/2026-06-14-carta-status-command-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-14-carta-status-command-design
+title: "`carta status` — system-wide status command — design"
+status: shipped
+related:
+  - 2026-06-14-carta-status-command
+date: 2026-06-14
+---
+
 # `carta status` — system-wide status command — design
 
 **Date:** 2026-06-14

--- a/docs/superpowers/specs/2026-06-14-contextual-chunk-headers-design.md
+++ b/docs/superpowers/specs/2026-06-14-contextual-chunk-headers-design.md
@@ -1,3 +1,12 @@
+---
+id: 2026-06-14-contextual-chunk-headers-design
+title: "Design — Contextual chunk headers (prepend doc title + section heading to the embedded text)"
+status: shipped
+related:
+  - 2026-06-14-contextual-chunk-headers
+date: 2026-06-14
+---
+
 # Design — Contextual chunk headers (prepend doc title + section heading to the embedded text)
 
 **Date:** 2026-06-14 · **Status:** shipped — **title-only** variant (modest win: ET-embed hybrid-alone recall@5 0.887→0.903, MRR ↑, visual guard held; the `title + section` variant was flat — section heading diluted; see RESULTS.md 2026-06-14). Generalization check (grow eval ~15–20q) is the follow-up. · **Target:** carta-cc next minor (≈0.13.0) · **Phase:** first-stage recall — the lever identified by [#19](https://github.com/Ian-q/Carta/issues/19) after #36 (visual dilution, shipped) and #37 (reranker blend, abandoned — eval-disproven) both flowed back to "the gold doc isn't surfaced by first-stage retrieval at a useful rank." Header-only is the first experiment; chunk-size, query-expansion, and graph levers are documented as follow-ups.


### PR DESCRIPTION
## Summary

Most docs under `docs/superpowers/` lacked YAML frontmatter, so `carta scan` reported `stats.with_id: 0` repo-wide — cross-reference tracking and stale-doc detection couldn't work (doc-audit #1 — AUDIT-016, DOC-006).

## Changes

Add a consistent frontmatter block to all **23 specs, 23 plans, and 3 skill docs** (49 files), merging cleanly into the 7 that already carried partial frontmatter (preserving their `name`/`description`/`related_issue`).

Template:
```yaml
---
id: <filename-stem>          # stable, unique, greppable
title: <H1 of the doc>
status: shipped | superseded | draft
related: [<paired doc id>]   # spec <-> plan by shared slug; [] if none
date: YYYY-MM-DD             # filename prefix, else git first-commit date
---
```

- **`related`** links each spec ↔ plan pair by shared slug.
- **`status` was verified against the current code** (parallel read-only agents traced each doc's feature to its implementation): 47 docs map to shipped features; only `2026-05-05-stale-reference-detection-design` and the `carta-repair` skill stub remain `draft`.

## Acceptance

✅ `carta scan` now reports `with_id: 49` (was `0`).
✅ Agents can `grep "status: shipped"` to find authoritative docs.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)