### PR TITLE
fix: finish vision-model default cleanup (#56)

### DIFF
--- a/carta/cli.py
+++ b/carta/cli.py
@@ -33,7 +33,7 @@ def _detect_ram_gb():
 
 
 def _recommend_vision_workers(ram_gb: float) -> int:
-    """Heuristic: parallel qwen2.5vl:7b slots that fit without thrashing.
+    """Heuristic: parallel qwen3-vl:8b slots that fit without thrashing.
 
     Reserves ~17 GB (≈8 GB OS + ≈9 GB OCR model resident) and assumes each
     additional vision-model parallel slot needs ~8 GB. Capped at 4 to keep

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -1201,7 +1201,7 @@ def test_build_perf_context_picks_up_models_and_workers():
     cfg = {
         "embed": {
             "ollama_model": "nomic-embed-text:latest",
-            "ollama_vision_model": "qwen2.5vl:7b",
+            "ollama_vision_model": "qwen3-vl:8b",
             "ocr_model": "glm-ocr:latest",
             "vision_workers": 4,
             "embedding_workers": 8,
@@ -1210,7 +1210,7 @@ def test_build_perf_context_picks_up_models_and_workers():
     ctx = _build_perf_context(cfg)
     assert ctx["models"] == {
         "embedding": "nomic-embed-text:latest",
-        "vision":    "qwen2.5vl:7b",
+        "vision":    "qwen3-vl:8b",
         "ocr":       "glm-ocr:latest",
     }
     assert ctx["workers"] == {"vision": 4, "embedding": 8}

--- a/carta/hook/tests/test_hook.py
+++ b/carta/hook/tests/test_hook.py
@@ -24,7 +24,7 @@ def _make_cfg(high=0.85, low=0.60, max_results=5, judge_timeout_s=3):
             "low_threshold": low,
             "max_results": max_results,
             "judge_timeout_s": judge_timeout_s,
-            "ollama_model": "qwen2.5:0.5b",
+            "ollama_model": "qwen3.5:0.8b",
         },
         "embed": {
             "ollama_url": "http://localhost:11434",

--- a/carta/install/auto_fix.py
+++ b/carta/install/auto_fix.py
@@ -351,7 +351,7 @@ class AutoInstaller:
         return {
             "nomic-embed-text": "ollama pull nomic-embed-text",
             "qwen3-vl:8b": "ollama pull qwen3-vl:8b",
-            "qwen2.5:0.5b": "ollama pull qwen2.5:0.5b",
+            "qwen3.5:0.8b": "ollama pull qwen3.5:0.8b",
         }
 
     def print_setup_guide(self, result: PreflightResult) -> None:

--- a/carta/install/tests/test_auto_fix.py
+++ b/carta/install/tests/test_auto_fix.py
@@ -8,3 +8,11 @@ def test_suggest_model_pulls_uses_current_vision_default():
     pulls = AutoInstaller(interactive=False).suggest_model_pulls()
     assert pulls.get("qwen3-vl:8b") == "ollama pull qwen3-vl:8b"
     assert "qwen2.5vl:7b" not in pulls
+
+
+def test_suggest_model_pulls_judge_matches_preflight():
+    """The pull map's judge entry must match what preflight checks
+    (qwen3.5:0.8b) — not the retired qwen2.5:0.5b judge default (#56)."""
+    pulls = AutoInstaller(interactive=False).suggest_model_pulls()
+    assert pulls.get("qwen3.5:0.8b") == "ollama pull qwen3.5:0.8b"
+    assert "qwen2.5:0.5b" not in pulls

--- a/carta/vision/router.py
+++ b/carta/vision/router.py
@@ -139,7 +139,7 @@ class SmartRouter:
         self.cfg = cfg
         embed = cfg.get("embed", {})
         self.ocr_model: str = embed.get("ocr_model", "glm-ocr:latest")
-        self.vision_model: str = embed.get("ollama_vision_model", "qwen2.5vl:7b")
+        self.vision_model: str = embed.get("ollama_vision_model", "qwen3-vl:8b")
         self.ollama_url: str = embed.get("ollama_url", "http://localhost:11434")
         self.flattened_min_yield: int = embed.get("vision_flattened_min_yield", 50)
         self.max_images_per_page: int = embed.get("vision_max_images_per_page", 4)

--- a/carta/vision/tests/test_router.py
+++ b/carta/vision/tests/test_router.py
@@ -30,6 +30,18 @@ def _pixmap(content: bytes = b"fakepng") -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+class TestVisionModelDefault:
+    def test_defaults_to_current_vision_model(self):
+        """When config omits ollama_vision_model, SmartRouter falls back to the
+        current default (qwen3-vl:8b) — not the retired qwen3-vl:8b (#56)."""
+        router = SmartRouter(_cfg())
+        assert router.vision_model == "qwen3-vl:8b"
+
+
+# ---------------------------------------------------------------------------
 # _route dispatch
 # ---------------------------------------------------------------------------
 
@@ -557,9 +569,9 @@ class TestCheckpointHelpers:
         from carta.vision.router import save_vision_checkpoint, load_vision_checkpoint
         p = tmp_path / "cp.json"
         chunks = [{"text": "page 1 text", "model_used": "glm-ocr"}]
-        save_vision_checkpoint(p, Path("/x.pdf"), "qwen2.5vl:7b", "glm-ocr:latest",
+        save_vision_checkpoint(p, Path("/x.pdf"), "qwen3-vl:8b", "glm-ocr:latest",
                                [{"page_num": 1, "chunks": chunks}])
-        out = load_vision_checkpoint(p, "qwen2.5vl:7b", "glm-ocr:latest")
+        out = load_vision_checkpoint(p, "qwen3-vl:8b", "glm-ocr:latest")
         assert out == {1: chunks}
 
     def test_save_is_atomic_no_temp_files_left(self, tmp_path):
@@ -575,7 +587,7 @@ class TestExtractPdfResume:
     def test_resume_skips_pages_in_checkpoint(self, tmp_path):
         from carta.vision.router import SmartRouter, save_vision_checkpoint
 
-        router = SmartRouter(_cfg(ollama_vision_model="qwen2.5vl:7b",
+        router = SmartRouter(_cfg(ollama_vision_model="qwen3-vl:8b",
                                   ocr_model="glm-ocr:latest"))
         cp = tmp_path / "cp.json"
         prior = [
@@ -583,7 +595,7 @@ class TestExtractPdfResume:
              "text": "cached p1", "model_used": "glm-ocr",
              "page_class": "structured_text", "content_type": "structured_text"},
         ]
-        save_vision_checkpoint(cp, Path("/x.pdf"), "qwen2.5vl:7b", "glm-ocr:latest",
+        save_vision_checkpoint(cp, Path("/x.pdf"), "qwen3-vl:8b", "glm-ocr:latest",
                                [{"page_num": 1, "chunks": prior}])
 
         new_chunk = {"doc_type": "image_description", "page_num": 2, "image_index": 0,
@@ -619,7 +631,7 @@ class TestExtractPdfResume:
     def test_checkpoint_is_updated_after_each_page(self, tmp_path):
         from carta.vision.router import SmartRouter, load_vision_checkpoint
 
-        router = SmartRouter(_cfg(ollama_vision_model="qwen2.5vl:7b",
+        router = SmartRouter(_cfg(ollama_vision_model="qwen3-vl:8b",
                                   ocr_model="glm-ocr:latest",
                                   vision_workers=1))
         cp = tmp_path / "cp.json"
@@ -645,7 +657,7 @@ class TestExtractPdfResume:
                 router.extract_pdf(Path("/x.pdf"), checkpoint_path=cp)
 
         # After successful extraction, both pages are recorded in checkpoint.
-        out = load_vision_checkpoint(cp, "qwen2.5vl:7b", "glm-ocr:latest")
+        out = load_vision_checkpoint(cp, "qwen3-vl:8b", "glm-ocr:latest")
         assert sorted(out.keys()) == [1, 2]
 
 


### PR DESCRIPTION
## Summary

Follow-up to #45 / PR #55, which aligned the user-facing and `carta doctor` paths on `qwen3-vl:8b` but deliberately left a few non-user-facing references to keep that PR scoped. This finishes the job.

## Changes

- **`carta/vision/router.py`** — `SmartRouter` fallback default `qwen2.5vl:7b` → `qwen3-vl:8b` (only used when config omits the key; `DEFAULTS` already set `qwen3-vl:8b`).
- **`carta/install/auto_fix.py`** — `suggest_model_pulls()` judge entry `qwen2.5:0.5b` → `qwen3.5:0.8b`, matching what `preflight.py` checks (a *separate* judge-model drift the issue flagged).
- **`carta/cli.py`** — vision worker-count heuristic comment now says `qwen3-vl:8b`.
- **Test fixtures** — `test_embed.py`, `test_router.py`, and the hook judge fixture in `test_hook.py` updated off the retired model names for consistency.
- **Regression tests** — added: `SmartRouter` default `== qwen3-vl:8b`; pull-map judge entry `== qwen3.5:0.8b` and `qwen2.5:0.5b` absent (alongside the existing #45 guard).

## Acceptance

✅ `grep -rn "qwen2.5vl" carta` returns only the #45/#56 regression guards (assertions that the retired model is *absent*).
✅ `auto_fix` judge entry matches `preflight` (`qwen3.5:0.8b`).
✅ Full suite: **919 passed, 2 skipped** — no regressions.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)