### PR TITLE
fix: integrity-scanner & stale-discovery robustness (#40, #39)

### DIFF
--- a/carta/embed/induct.py
+++ b/carta/embed/induct.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import yaml
 
@@ -137,3 +137,38 @@ def read_sidecar(sidecar_path: Path) -> Optional[dict]:
             return yaml.safe_load(f)
     except (OSError, yaml.YAMLError):
         return None
+
+
+def iter_canonical_sidecars(repo_root: Path) -> Iterator[tuple[Path, dict]]:
+    """Yield ``(sidecar_path, data)`` for every canonically-located sidecar.
+
+    Walks ``.carta/sidecars/`` and yields only sidecars that:
+      - parse to a mapping (corrupt/non-dict files are skipped),
+      - carry a ``current_path``, and
+      - sit at the canonical location their ``current_path`` maps to — i.e.
+        their path under ``sidecars/`` equals ``sidecar_path(...)`` would
+        produce for that source.
+
+    This skips misplaced/nested junk copies (e.g. an accidental
+    ``.carta/sidecars/.worktrees/x/.carta/sidecars/foo.embed-meta.yaml`` whose
+    ``current_path`` resolves to a real repo file it does not own), which would
+    otherwise produce phantom duplicate entries in any sidecar scan.
+    """
+    sidecars_root = repo_root / ".carta" / "sidecars"
+    if not sidecars_root.exists():
+        return
+    for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
+        data = read_sidecar(sc_path)
+        if not isinstance(data, dict):
+            continue
+        current_path = data.get("current_path")
+        if not current_path:
+            continue
+        expected_rel = Path(current_path).with_suffix(".embed-meta.yaml")
+        try:
+            actual_rel = sc_path.relative_to(sidecars_root)
+        except ValueError:
+            continue
+        if actual_rel != expected_rel:
+            continue
+        yield sc_path, data

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -13,7 +13,7 @@ from qdrant_client import QdrantClient
 
 from carta.config import collection_name
 from carta.embed.lifecycle import compute_file_hash
-from carta.embed.induct import read_sidecar
+from carta.embed.induct import iter_canonical_sidecars
 
 
 def _scroll_all(client, coll: str):
@@ -85,61 +85,56 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
         if 0 < n < per_file_counts[fp]
     }
 
-    # Sidecar-side checks
+    # Sidecar-side checks. iter_canonical_sidecars skips corrupt/non-dict
+    # sidecars, those without a current_path, and misplaced/nested junk copies
+    # (e.g. an accidental .carta/sidecars/.worktrees/.../.carta/sidecars/... tree)
+    # whose current_path resolves to a real file they do not own (#40).
     count_mismatches: dict[str, dict] = {}
     stuck_stale: list[str] = []
 
-    sidecars_root = repo_root / ".carta" / "sidecars"
-    if sidecars_root.exists():
-        for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
-            sc = read_sidecar(sc_path)
-            if not isinstance(sc, dict):
-                # Corrupt sidecar (valid YAML but not a mapping) — one bad file
-                # must not blind the whole scan.
-                continue
-            rel = sc.get("current_path")
-            if not rel:
-                continue
+    for _sc_path, sc in iter_canonical_sidecars(repo_root):
+        rel = sc["current_path"]
 
-            status = sc.get("status")
-            # Missing entry means ZERO surviving points — a fully-lost file
-            # (e.g. every chunk shadowed by a legacy ID collision) is the
-            # strongest mismatch of all, not an exemption.
-            qdrant_count = per_file_counts.get(rel, 0)
-            sidecar_count = sc.get("chunk_count")
+        status = sc.get("status")
+        # Missing entry means ZERO surviving points — a fully-lost file
+        # (e.g. every chunk shadowed by a legacy ID collision) is the
+        # strongest mismatch of all, not an exemption.
+        qdrant_count = per_file_counts.get(rel, 0)
+        sidecar_count = sc.get("chunk_count")
 
-            # Stuck-stale: status is "stale" but file hash matches disk — a bug
-            # artifact, not a pending re-embed.
-            is_stuck = False
-            if status == "stale":
-                src = repo_root / rel
-                if src.exists():
-                    try:
-                        if compute_file_hash(src) == sc.get("file_hash"):
-                            is_stuck = True
-                            stuck_stale.append(rel)
-                    except OSError:
-                        pass
+        # Stuck-stale: status is "stale" but file hash matches disk — a bug
+        # artifact, not a pending re-embed.
+        is_stuck = False
+        if status == "stale":
+            src = repo_root / rel
+            if src.exists():
+                try:
+                    if compute_file_hash(src) == sc.get("file_hash"):
+                        is_stuck = True
+                        stuck_stale.append(rel)
+                except OSError:
+                    pass
 
-            # Count mismatch: sidecar chunk_count differs from Qdrant point count.
-            # Checked for "embedded" sidecars AND stuck-stale ones (their counts
-            # should agree with Qdrant — nothing is pending). Genuinely-stale
-            # sidecars (hash differs) are expected to be out of sync and exempt.
-            if (
-                (status == "embedded" or is_stuck)
-                and sidecar_count is not None
-                and sidecar_count != qdrant_count
-            ):
-                count_mismatches[rel] = {
-                    "sidecar": sidecar_count,
-                    "qdrant": qdrant_count,
-                }
+        # Count mismatch: sidecar chunk_count differs from Qdrant point count.
+        # Checked for "embedded" sidecars AND stuck-stale ones (their counts
+        # should agree with Qdrant — nothing is pending). Genuinely-stale
+        # sidecars (hash differs) are expected to be out of sync and exempt.
+        if (
+            (status == "embedded" or is_stuck)
+            and sidecar_count is not None
+            and sidecar_count != qdrant_count
+        ):
+            count_mismatches[rel] = {
+                "sidecar": sidecar_count,
+                "qdrant": qdrant_count,
+            }
 
-    # affected_files: union of everything needing re-embed or purge
-    # (stuck_stale excluded — repair marks them pending without full re-embed)
+    # affected_files: union of everything needing re-embed or purge.
+    # Slug collisions are intentionally EXCLUDED — with path-based point IDs
+    # same-slug files coexist safely; genuine legacy-collision damage (chunks
+    # shadowed by an old slug-keyed ID) still surfaces as a count_mismatch (#40).
+    # (stuck_stale also excluded — repair marks them pending without full re-embed.)
     affected: set[str] = set(empty_files) | set(partial_empty_files) | set(count_mismatches)
-    for files in slug_collisions.values():
-        affected.update(files)
 
     return {
         "slug_collisions": slug_collisions,

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -30,7 +30,7 @@ from carta.embed.embed import (
     SPARSE_VECTOR_NAME,
 )
 from carta.embed.sparse import embed_sparse_query
-from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path
+from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path, iter_canonical_sidecars
 from carta.embed.lifecycle import needs_rehash, compute_file_hash, mark_sidecar_stale, check_stale_alert, delete_other_points
 from carta.embed.visual_queue import add_pending_pages, move_to_done, VISUAL_PENDING_KEY, VISUAL_DONE_KEY, queue_summary, format_summary_line
 from carta.embed.colpali import is_colpali_available
@@ -179,24 +179,28 @@ def discover_pending_files(repo_root: Path) -> list[dict]:
 
 
 def discover_stale_files(repo_root: Path) -> list[Path]:
-    """Find all files with sidecars under .carta/sidecars/ marked status: stale.
+    """Find source files whose content has changed since they were last embedded.
+
+    A file is stale when it still exists, its sidecar recorded a ``file_hash``,
+    and the file's current content hash differs from that recorded hash. (The
+    old sidecar ``status: stale`` flag is no longer written — staleness now lives
+    in the Qdrant payload — so staleness is recomputed on demand here. See #39.)
 
     Returns list of source file paths.
     """
     results = []
-    sidecars_root = repo_root / ".carta" / "sidecars"
-    if not sidecars_root.exists():
-        return results
-    for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
-        data = read_sidecar(sc_path)
-        if data is None or data.get("status") != "stale":
+    for sc_path, data in iter_canonical_sidecars(repo_root):
+        recorded_hash = data.get("file_hash")
+        if not recorded_hash:
             continue
-        current_path = data.get("current_path")
-        if not current_path:
+        source_file = repo_root / data["current_path"]
+        if not source_file.exists():
             continue
-        source_file = repo_root / current_path
-        if source_file.exists():
-            results.append(source_file)
+        try:
+            if compute_file_hash(source_file) != recorded_hash:
+                results.append(source_file)
+        except OSError:
+            continue
     return results
 
 
@@ -1102,19 +1106,15 @@ def migrate_sidecars(repo_root: Path, verbose: bool = False) -> int:
 
 
 def detect_orphaned_sidecars(repo_root: Path) -> list[Path]:
-    """Return sidecar paths under .carta/sidecars/ whose current_path source no longer exists."""
+    """Return sidecar paths under .carta/sidecars/ whose current_path source no longer exists.
+
+    Uses iter_canonical_sidecars, so corrupt sidecars, those without a
+    current_path, and misplaced/nested junk copies are skipped (a junk copy is
+    not a real sidecar of this repo even if its current_path source is missing).
+    """
     orphans = []
-    sidecars_root = repo_root / ".carta" / "sidecars"
-    if not sidecars_root.exists():
-        return orphans
-    for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
-        data = read_sidecar(sc_path)
-        if data is None:
-            continue
-        current_path = data.get("current_path")
-        if not current_path:
-            continue  # skip pre-lifecycle sidecars without current_path
-        if not (repo_root / current_path).exists():
+    for sc_path, data in iter_canonical_sidecars(repo_root):
+        if not (repo_root / data["current_path"]).exists():
             orphans.append(sc_path)
     return orphans
 

--- a/carta/tests/test_induct.py
+++ b/carta/tests/test_induct.py
@@ -1,8 +1,9 @@
 """Tests for carta embed induction (sidecar generation)."""
 
 import pytest
+import yaml
 from pathlib import Path
-from carta.embed.induct import generate_sidecar_stub
+from carta.embed.induct import generate_sidecar_stub, iter_canonical_sidecars
 
 
 class TestGenerateSidecarStub:
@@ -109,3 +110,40 @@ class TestDocTypeResolution:
     def test_malformed_frontmatter_falls_back_to_path(self, tmp_path):
         stub = self._stub(tmp_path, "docs/quirks/x.md", "---\n: : bad yaml [\n---\nBody")
         assert stub["doc_type"] == "quirk"
+
+
+class TestIterCanonicalSidecars:
+    """iter_canonical_sidecars yields only well-placed, well-formed sidecars."""
+
+    def _write(self, repo_root, rel, data):
+        sc = repo_root / ".carta" / "sidecars" / rel
+        sc.parent.mkdir(parents=True, exist_ok=True)
+        sc.write_text(yaml.dump(data))
+        return sc
+
+    def test_yields_canonical_sidecar(self, tmp_path):
+        sc = self._write(tmp_path, "docs/a.embed-meta.yaml",
+                         {"current_path": "docs/a.md", "status": "embedded"})
+        out = list(iter_canonical_sidecars(tmp_path))
+        assert [p for p, _ in out] == [sc]
+        assert out[0][1]["current_path"] == "docs/a.md"
+
+    def test_skips_nested_junk_copy(self, tmp_path):
+        # A misplaced copy whose current_path points at a real-looking repo file
+        # but whose on-disk location is NOT the canonical path for that file.
+        self._write(tmp_path, ".worktrees/x/.carta/sidecars/docs/a.embed-meta.yaml",
+                    {"current_path": "docs/a.md", "status": "embedded"})
+        assert list(iter_canonical_sidecars(tmp_path)) == []
+
+    def test_skips_non_dict_sidecar(self, tmp_path):
+        sc = tmp_path / ".carta" / "sidecars" / "bad.embed-meta.yaml"
+        sc.parent.mkdir(parents=True, exist_ok=True)
+        sc.write_text("- just\n- a\n- list\n")
+        assert list(iter_canonical_sidecars(tmp_path)) == []
+
+    def test_skips_sidecar_without_current_path(self, tmp_path):
+        self._write(tmp_path, "docs/a.embed-meta.yaml", {"status": "embedded"})
+        assert list(iter_canonical_sidecars(tmp_path)) == []
+
+    def test_empty_when_no_sidecars_dir(self, tmp_path):
+        assert list(iter_canonical_sidecars(tmp_path)) == []

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -27,8 +27,10 @@ CFG = {"project_name": "test", "qdrant_url": "http://localhost:6333",
 
 
 def _write_sidecar(tmp_path, rel_path, chunk_count, status, file_hash):
-    """Write a minimal sidecar YAML under tmp_path/.carta/sidecars/."""
-    sc_path = tmp_path / ".carta" / "sidecars" / (rel_path + ".embed-meta.yaml")
+    """Write a minimal sidecar YAML at its canonical .carta/sidecars/ location
+    (the path sidecar_path() produces — with_suffix semantics, matching prod)."""
+    from carta.embed.induct import sidecar_path
+    sc_path = sidecar_path(tmp_path / rel_path, tmp_path)
     sc_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "current_path": rel_path,
@@ -62,6 +64,39 @@ class TestScanCorpusIntegrity:
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
         assert report["slug_collisions"] == {
             "readme": sorted(["docs/ci/README.md", "docs/diagrams/README.md"])}
+
+    def test_slug_collisions_are_not_affected_files(self, tmp_path):
+        """Same-slug files are healthy under path-based IDs — reported as
+        informational but never queued for repair (#40)."""
+        pts = [
+            _point("docs/a/README.md", "readme", 0, "x"),
+            _point("docs/b/README.md", "readme", 0, "y"),
+        ]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert "readme" in report["slug_collisions"]
+        assert report["affected_files"] == []
+
+    def test_nested_junk_sidecar_is_ignored(self, tmp_path):
+        """A misplaced/nested sidecar copy whose current_path resolves to a real
+        file must not produce phantom stuck-stale / count-mismatch entries (#40)."""
+        src = tmp_path / "docs" / "real.md"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("real content")
+        real_hash = compute_file_hash(src)
+        # Canonical sidecar: embedded, counts agree with Qdrant — perfectly clean.
+        _write_sidecar(tmp_path, "docs/real.md", 1, "embedded", real_hash)
+        # Junk nested copy claiming the same current_path but stuck-stale-looking.
+        junk = (tmp_path / ".carta" / "sidecars" / ".worktrees" / "x"
+                / ".carta" / "sidecars" / "docs" / "real.embed-meta.yaml")
+        junk.parent.mkdir(parents=True, exist_ok=True)
+        junk.write_text(yaml.dump({"current_path": "docs/real.md", "chunk_count": 99,
+                                   "status": "stale", "file_hash": real_hash}))
+
+        pts = [_point("docs/real.md", "real", 0, "real content")]
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
+        assert report["stuck_stale"] == []
+        assert report["count_mismatches"] == {}
+        assert report["affected_files"] == []
 
     def test_detects_empty_text_files(self, tmp_path):
         pts = [
@@ -152,15 +187,19 @@ class TestScanCorpusIntegrity:
         ]
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
 
+        # Slug collisions are informational only (healthy with path-based IDs),
+        # so the README pair must NOT be in affected_files (#40).
         expected_affected = sorted([
-            "docs/ci/README.md",
-            "docs/diagrams/README.md",
             "docs/empty.pdf",
             "docs/partial.pdf",
             "docs/mismatch.md",
         ])
         assert report["affected_files"] == expected_affected
         assert "docs/stale.md" not in report["affected_files"]
+        assert report["slug_collisions"] == {
+            "readme": sorted(["docs/ci/README.md", "docs/diagrams/README.md"])}
+        assert "docs/ci/README.md" not in report["affected_files"]
+        assert "docs/diagrams/README.md" not in report["affected_files"]
 
     def test_missing_collection(self, tmp_path):
         client = MagicMock()

--- a/carta/tests/test_mcp_server.py
+++ b/carta/tests/test_mcp_server.py
@@ -62,101 +62,57 @@ def test_scope_parameter_validation():
 
 
 class TestDiscoverStaleFilesIntegration:
-    """Test discover_stale_files with the pipeline."""
+    """discover_stale_files (MCP carta_embed scope='stale') returns files whose
+    content changed since embed — current hash != sidecar file_hash (#39)."""
 
-    def test_discover_stale_files_returns_stale_paths(self):
-        """Two sidecars, one stale, one embedded -> returns one Path."""
-        import tempfile
-        from carta.embed.pipeline import discover_stale_files
+    def _sidecar(self, repo_root, rel, file_hash):
         from carta.embed.induct import sidecar_path as get_sidecar_path
+        sc = get_sidecar_path(repo_root / rel, repo_root)
+        sc.parent.mkdir(parents=True, exist_ok=True)
+        sc.write_text(yaml.dump({
+            "slug": Path(rel).stem, "current_path": rel,
+            "status": "embedded", "file_hash": file_hash,
+        }))
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            repo_root = Path(tmpdir)
-
-            # Create docs directory
-            docs_dir = repo_root / "docs"
-            docs_dir.mkdir()
-
-            # Create first file with stale sidecar in .carta/sidecars/
-            stale_file = docs_dir / "stale.md"
-            stale_file.write_text("# Stale Document")
-            sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-            sc_dir.mkdir(parents=True)
-            with open(sc_dir / "stale.embed-meta.yaml", "w") as f:
-                yaml.dump({"status": "stale", "slug": "stale", "current_path": "docs/stale.md"}, f)
-
-            # Create second file with embedded sidecar
-            embedded_file = docs_dir / "embedded.md"
-            embedded_file.write_text("# Embedded Document")
-            with open(sc_dir / "embedded.embed-meta.yaml", "w") as f:
-                yaml.dump({"status": "embedded", "slug": "embedded", "current_path": "docs/embedded.md"}, f)
-
-            # Call discover_stale_files
-            results = discover_stale_files(repo_root)
-
-            # Should return only the stale file
-            assert len(results) == 1
-            assert results[0] == stale_file
-
-    def test_discover_stale_files_returns_empty_when_none_stale(self):
-        """No stale sidecars -> returns empty list."""
+    def test_returns_files_whose_hash_changed(self):
         import tempfile
         from carta.embed.pipeline import discover_stale_files
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
+            (repo_root / "docs").mkdir()
+            changed = repo_root / "docs" / "changed.md"
+            changed.write_text("# new content")
+            self._sidecar(repo_root, "docs/changed.md", "stalehash000")  # != real
 
-            # Create docs directory
-            docs_dir = repo_root / "docs"
-            docs_dir.mkdir()
+            assert discover_stale_files(repo_root) == [changed]
 
-            # Create file with embedded sidecar in .carta/sidecars/docs/
-            embedded_file = docs_dir / "embedded.md"
-            embedded_file.write_text("# Embedded Document")
-            sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-            sc_dir.mkdir(parents=True, exist_ok=True)
-            embedded_sidecar = sc_dir / "embedded.embed-meta.yaml"
-            with open(embedded_sidecar, "w") as f:
-                yaml.dump({"status": "embedded", "slug": "embedded", "current_path": "docs/embedded.md"}, f)
+    def test_returns_empty_when_hash_matches(self):
+        import tempfile
+        from carta.embed.pipeline import discover_stale_files
+        from carta.embed.lifecycle import compute_file_hash
 
-            # Call discover_stale_files
-            results = discover_stale_files(repo_root)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            (repo_root / "docs").mkdir()
+            same = repo_root / "docs" / "same.md"
+            same.write_text("# unchanged")
+            self._sidecar(repo_root, "docs/same.md", compute_file_hash(same))
 
-            # Should return empty list
-            assert results == []
+            assert discover_stale_files(repo_root) == []
 
-    def test_discover_stale_files_skips_missing_status(self):
-        """Sidecar missing status key -> not included in results."""
+    def test_skips_sidecar_without_recorded_hash(self):
         import tempfile
         from carta.embed.pipeline import discover_stale_files
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
+            (repo_root / "docs").mkdir()
+            f = repo_root / "docs" / "nohash.md"
+            f.write_text("# content")
+            self._sidecar(repo_root, "docs/nohash.md", None)
 
-            # Create docs directory
-            docs_dir = repo_root / "docs"
-            docs_dir.mkdir()
-
-            # Create file with sidecar missing status in .carta/sidecars/
-            file_no_status = docs_dir / "no_status.md"
-            file_no_status.write_text("# Document")
-            sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-            sc_dir.mkdir(parents=True)
-            with open(sc_dir / "no_status.embed-meta.yaml", "w") as f:
-                yaml.dump({"slug": "no_status", "current_path": "docs/no_status.md"}, f)
-
-            # Create file with stale sidecar
-            stale_file = docs_dir / "stale.md"
-            stale_file.write_text("# Stale Document")
-            with open(sc_dir / "stale.embed-meta.yaml", "w") as f:
-                yaml.dump({"status": "stale", "slug": "stale", "current_path": "docs/stale.md"}, f)
-
-            # Call discover_stale_files
-            results = discover_stale_files(repo_root)
-
-            # Should return only the stale file
-            assert len(results) == 1
-            assert results[0] == stale_file
+            assert discover_stale_files(repo_root) == []
 
 
 def test_remember_returns_ok_shape(tmp_path):

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -11,6 +11,7 @@ import yaml
 
 from carta.embed.pipeline import run_embed_file, run_embed, discover_stale_files, migrate_sidecars, detect_orphaned_sidecars
 from carta.embed.induct import sidecar_path as get_sidecar_path
+from carta.embed.lifecycle import compute_file_hash
 from carta.config import find_config
 
 
@@ -409,65 +410,50 @@ class TestRunEmbedStaleAlert:
 
 
 class TestDiscoverStaleFiles:
-    """Test discover_stale_files helper function."""
+    """discover_stale_files returns files whose content changed since embed —
+    current content hash differs from the sidecar's recorded file_hash (#39)."""
 
-    def test_discover_stale_files_returns_stale_paths(self, temp_repo):
+    def _sidecar(self, repo_root, rel, file_hash):
+        sc = get_sidecar_path(repo_root / rel, repo_root)
+        sc.parent.mkdir(parents=True, exist_ok=True)
+        sc.write_text(yaml.dump({
+            "slug": Path(rel).stem, "current_path": rel,
+            "status": "embedded", "file_hash": file_hash,
+        }))
+        return sc
+
+    def test_returns_files_whose_hash_changed(self, temp_repo):
         repo_root, cfg = temp_repo
-        docs_dir = repo_root / "docs"
-        docs_dir.mkdir()
+        (repo_root / "docs").mkdir()
+        changed = repo_root / "docs" / "changed.md"
+        changed.write_text("# new content")
+        self._sidecar(repo_root, "docs/changed.md", "stalehash000")  # != real hash
 
-        stale_file = docs_dir / "stale.md"
-        stale_file.write_text("# Stale Document")
-        sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-        sc_dir.mkdir(parents=True)
-        with open(sc_dir / "stale.embed-meta.yaml", "w") as f:
-            yaml.dump({"status": "stale", "slug": "stale", "current_path": "docs/stale.md"}, f)
+        assert discover_stale_files(repo_root) == [changed]
 
-        embedded_file = docs_dir / "embedded.md"
-        embedded_file.write_text("# Embedded Document")
-        with open(sc_dir / "embedded.embed-meta.yaml", "w") as f:
-            yaml.dump({"status": "embedded", "slug": "embedded", "current_path": "docs/embedded.md"}, f)
-
-        results = discover_stale_files(repo_root)
-
-        assert len(results) == 1
-        assert results[0] == stale_file
-
-    def test_discover_stale_files_returns_empty_when_none_stale(self, temp_repo):
+    def test_skips_files_whose_hash_matches(self, temp_repo):
         repo_root, cfg = temp_repo
-        docs_dir = repo_root / "docs"
-        docs_dir.mkdir()
+        (repo_root / "docs").mkdir()
+        same = repo_root / "docs" / "same.md"
+        same.write_text("# unchanged")
+        self._sidecar(repo_root, "docs/same.md", compute_file_hash(same))
 
-        embedded_file = docs_dir / "embedded.md"
-        embedded_file.write_text("# Embedded Document")
-        sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-        sc_dir.mkdir(parents=True)
-        with open(sc_dir / "embedded.embed-meta.yaml", "w") as f:
-            yaml.dump({"status": "embedded", "slug": "embedded", "current_path": "docs/embedded.md"}, f)
+        assert discover_stale_files(repo_root) == []
 
-        results = discover_stale_files(repo_root)
-        assert results == []
-
-    def test_discover_stale_files_skips_missing_status(self, temp_repo):
+    def test_skips_sidecar_without_recorded_hash(self, temp_repo):
         repo_root, cfg = temp_repo
-        docs_dir = repo_root / "docs"
-        docs_dir.mkdir()
+        (repo_root / "docs").mkdir()
+        f = repo_root / "docs" / "nohash.md"
+        f.write_text("# content")
+        self._sidecar(repo_root, "docs/nohash.md", None)
 
-        file_no_status = docs_dir / "no_status.md"
-        file_no_status.write_text("# Document")
-        sc_dir = repo_root / ".carta" / "sidecars" / "docs"
-        sc_dir.mkdir(parents=True)
-        with open(sc_dir / "no_status.embed-meta.yaml", "w") as f:
-            yaml.dump({"slug": "no_status", "current_path": "docs/no_status.md"}, f)
+        assert discover_stale_files(repo_root) == []
 
-        stale_file = docs_dir / "stale.md"
-        stale_file.write_text("# Stale Document")
-        with open(sc_dir / "stale.embed-meta.yaml", "w") as f:
-            yaml.dump({"status": "stale", "slug": "stale", "current_path": "docs/stale.md"}, f)
+    def test_skips_when_source_missing(self, temp_repo):
+        repo_root, cfg = temp_repo
+        self._sidecar(repo_root, "docs/gone.md", "abc123")  # no source file written
 
-        results = discover_stale_files(repo_root)
-        assert len(results) == 1
-        assert results[0] == stale_file
+        assert discover_stale_files(repo_root) == []
 
 
 class TestVisionIntegration:
@@ -957,6 +943,17 @@ class TestDetectOrphanedSidecars:
         repo_root, cfg = temp_repo
         orphans = detect_orphaned_sidecars(repo_root)
         assert orphans == []
+
+    def test_skips_nested_junk_sidecar(self, temp_repo):
+        """A misplaced/nested sidecar copy is not a real sidecar, so it must not
+        be reported as an orphan even when its current_path source is missing."""
+        repo_root, cfg = temp_repo
+        junk = (repo_root / ".carta" / "sidecars" / ".worktrees" / "x"
+                / ".carta" / "sidecars" / "docs" / "gone.embed-meta.yaml")
+        junk.parent.mkdir(parents=True, exist_ok=True)
+        junk.write_text("slug: gone\nstatus: embedded\ncurrent_path: docs/gone.pdf\n")
+
+        assert detect_orphaned_sidecars(repo_root) == []
 
 
 class TestRunEmbedStatusWriter:

--- a/docs/superpowers/specs/2026-06-15-integrity-scanner-stale-discovery-design.md
+++ b/docs/superpowers/specs/2026-06-15-integrity-scanner-stale-discovery-design.md
@@ -1,0 +1,87 @@
+---
+id: 2026-06-15-integrity-scanner-stale-discovery-design
+title: Integrity-scanner & stale-discovery robustness (post-v0.11.0)
+status: shipped
+related: []
+date: 2026-06-15
+related_issue: Ian-q/Carta#40, Ian-q/Carta#39, Ian-q/Carta#11
+---
+
+# Integrity-scanner & stale-discovery robustness (post-v0.11.0)
+
+A cluster of post-v0.11.0 integrity/sidecar issues that share the same code
+(the `.carta/sidecars/` walks). Ships as one PR; #11 is closed as
+already-resolved.
+
+## Findings
+
+- **#11 is already implemented.** `carta/audit/audit.py::detect_missing_source_sidecars`
+  is the first-class orphan audit category #11 asked for — exact schema
+  (`id`, `category`, `severity`, `sidecar_path`, `missing_source`), wired into
+  `run_audit`, with all three requested tests. Shipped in `a9bd34f`
+  (2026-04-21), two weeks before #11 was filed. Only residual: the pipeline-side
+  `detect_orphaned_sidecars` duplicate. **Close #11; fold the dedup into this PR.**
+- **#40 is real** — two bugs in `carta/embed/integrity.py::scan_corpus_integrity`.
+- **#39 is real** — `discover_stale_files` reads a sidecar status that nothing
+  writes anymore.
+
+## Design
+
+### Shared helper — `induct.py::iter_canonical_sidecars(repo_root)`
+
+Yields `(sidecar_path, data)` for every sidecar under `.carta/sidecars/` that:
+parses to a `dict`, has a `current_path`, and is **canonically located** —
+its on-disk path under `sidecars/` equals `Path(current_path).with_suffix(".embed-meta.yaml")`
+(the inverse of `sidecar_path`). Misplaced/nested junk copies (e.g.
+`.carta/sidecars/.worktrees/x/.carta/sidecars/foo.embed-meta.yaml` whose
+`current_path` resolves to a real repo file) are skipped. One place for the
+walk + path-validation, reused by the functions below.
+
+### #40 — `scan_corpus_integrity`
+
+1. **Slug collisions are informational, not "affected".** With path-based point
+   IDs, multiple files sharing a filename stem is healthy coexistence. Keep
+   `slug_collisions` in the report but drop it from `affected_files`; genuine
+   legacy-collision damage still surfaces via `count_mismatches` (a fully
+   shadowed file shows fewer Qdrant points than its sidecar `chunk_count`).
+2. **Junk-sidecar defense.** Use `iter_canonical_sidecars` for the sidecar walk
+   so nested/misplaced copies no longer produce phantom stuck-stale entries and
+   false count mismatches that repair can never converge on.
+
+### #39 — `discover_stale_files` (MCP `carta_embed scope='stale'`)
+
+`mark_sidecar_stale` only stamps the Qdrant payload `status: stale`; nothing
+writes `status: stale` into the sidecar YAML, so the old status read returned
+nothing. Redefine staleness as **content drift, computed on demand**: a file is
+stale when it exists, its sidecar records a `file_hash`, and
+`compute_file_hash(file) != file_hash`. Walk via `iter_canonical_sidecars`.
+
+### #11 dedup — `detect_orphaned_sidecars`
+
+Reimplement on top of `iter_canonical_sidecars` (drops duplicated walk logic and
+gains the junk-skip). Keep it as the embed-time stderr warning source.
+
+## Testing (TDD)
+
+- `iter_canonical_sidecars`: canonical kept; nested/misplaced junk skipped;
+  non-dict skipped; missing `current_path` skipped.
+- `scan_corpus_integrity`: slug collisions reported but absent from
+  `affected_files`; nested junk sidecar ignored. Update
+  `test_affected_files_unions_everything`.
+- `discover_stale_files`: stale when hash differs; not stale when hash matches;
+  skipped when no recorded hash / source missing; junk skipped. Replace the old
+  status-based tests in `test_pipeline.py` and `test_mcp_server.py`.
+- `detect_orphaned_sidecars`: existing tests stay green; add a junk-skip test.
+
+## Acceptance
+
+- `carta doctor` reports clean on a corpus whose only "issue" is same-slug files.
+- `embed --repair` no longer re-embeds same-slug files indefinitely.
+- Nested junk sidecar trees no longer pollute the scan.
+- MCP `carta_embed scope='stale'` returns files whose content changed since embed.
+- #11 closed; no duplicated orphan-detection walk.
+
+## Out of scope
+
+- `_visual` collection integrity (#38).
+- Auto-deletion/triage of orphaned sidecars; a standalone `carta migrate`.


### PR DESCRIPTION
## Summary

A post-v0.11.0 cluster of integrity/sidecar issues that share the `.carta/sidecars/` walks. Surfaced by dogfooding `carta doctor` / `embed --repair` on the ET-embed corpus.

## #40 — `scan_corpus_integrity`

1. **Slug collisions are informational, not "affected".** With path-based point IDs (v0.11.0), multiple files sharing a filename stem is healthy coexistence — but the scanner still pushed every same-slug group into `affected_files`, so `embed --repair` re-embedded them forever and `doctor` never reported clean (ET-embed: 9 READMEs + 2 ARCHITECTUREs permanently "affected"). `slug_collisions` is still reported for visibility; genuine legacy-collision damage (chunks shadowed by an old slug-keyed ID) still surfaces via `count_mismatches`.
2. **Junk-sidecar defense.** Nested/misplaced sidecar copies (e.g. accidental `.carta/sidecars/.worktrees/.../.carta/sidecars/...` trees whose `current_path` resolves to real files) no longer produce phantom stuck-stale / count-mismatch entries that repair can never converge on.

## #39 — `discover_stale_files` (MCP `carta_embed scope='stale'`)

`mark_sidecar_stale` only stamps the **Qdrant payload** `status: stale`; nothing writes `status: stale` into the **sidecar YAML** anymore, but `discover_stale_files` read exactly that — so the scope was starved to always-empty. Staleness is now **content drift computed on demand**: a file is stale when it exists, its sidecar recorded a `file_hash`, and the current content hash differs.

## Shared helper

New `induct.iter_canonical_sidecars(repo_root)` yields only canonically-located sidecars (skips corrupt / no-`current_path` / misplaced copies). Used by `scan_corpus_integrity`, `discover_stale_files`, and `detect_orphaned_sidecars` so the junk-defense lives in one place.

## #11 (separate)

Closed as already-resolved — `audit.detect_missing_source_sidecars` has been the first-class orphan audit category since `a9bd34f` (with the exact schema #11 asked for and all three requested tests). This PR only folds the pipeline-side `detect_orphaned_sidecars` onto the shared helper, which was #11's noted residual.

## Testing (TDD)

New/updated tests for the helper, slug-collisions-not-affected, nested-junk-skip, and hash-based stale discovery (replacing the obsolete status-based tests in `test_pipeline.py` + `test_mcp_server.py`).

✅ Full suite: **928 passed, 2 skipped**.

Closes #40
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)