### PR TITLE
feat: _visual collection integrity scanning + repair (#38 part 2)

### DIFF
--- a/carta/cli.py
+++ b/carta/cli.py
@@ -522,7 +522,10 @@ def cmd_doctor(args):
                 print(_json.dumps(doc, indent=2))
             else:
                 print("\n📦 Corpus integrity")
-                if not report["affected_files"] and not report["stuck_stale"]:
+                visual_mm = report.get("visual_count_mismatches", {})
+                orphan_vis = report.get("orphaned_visual_files", [])
+                if (not report["affected_files"] and not report["stuck_stale"]
+                        and not visual_mm and not orphan_vis):
                     print("  ✅ no issues found")
                 else:
                     for slug, files in report["slug_collisions"].items():
@@ -535,8 +538,11 @@ def cmd_doctor(args):
                         print(f"  ⚠️  count mismatch: {fp} (sidecar {c['sidecar']} vs qdrant {c['qdrant']})")
                     if report["stuck_stale"]:
                         print(f"  ⚠️  {len(report['stuck_stale'])} sidecar(s) stuck 'stale' with unchanged files")
-                    print(f"  → run `carta embed --repair` to fix "
-                          f"({len(report['affected_files'])} file(s) affected)")
+                    for fp, c in visual_mm.items():
+                        print(f"  ⚠️  visual count mismatch: {fp} (sidecar {c['sidecar']} vs qdrant {c['qdrant']})")
+                    for fp in orphan_vis:
+                        print(f"  ⚠️  orphaned visual points: {fp}")
+                    print("  → run `carta embed --repair` to fix")
         except Exception as e:
             if args.json:
                 # Still emit one valid JSON document; note the skipped check

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -39,13 +39,17 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
 
     Returns a dict with keys:
         slug_collisions:      {slug: [file_path, ...]} — slugs with >1 file_path
+                              (informational; path-based IDs make this harmless)
         empty_files:          [file_path] — every point for the file has empty text
         partial_empty_files:  {file_path: n_empty} — some (not all) points empty
         count_mismatches:     {file_path: {"sidecar": n, "qdrant": n}}
         stuck_stale:          [rel_path] — status="stale" but file hash matches disk
-        affected_files:       sorted union of files needing re-embed/purge
-                              (slug collision + empty + partial + mismatches;
-                               stuck_stale excluded — repair handles those separately)
+        affected_files:       sorted union of _doc files needing re-embed/purge
+                              (empty + partial + count mismatches; slug collisions
+                               and stuck_stale excluded)
+        visual_count_mismatches: {file_path: {"sidecar": n_done, "qdrant": n}} —
+                              sidecar visual_done count vs _visual point count
+        orphaned_visual_files: [file_path] — _visual points whose source is gone
     """
     if client is None:
         client = QdrantClient(url=cfg["qdrant_url"], timeout=30)
@@ -85,11 +89,24 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
         if 0 < n < per_file_counts[fp]
     }
 
+    # _visual collection tallies: point count per file_path (#38 part 2).
+    visual_coll = collection_name(cfg, "visual")
+    visual_per_file_counts: dict[str, int] = defaultdict(int)
+    if client.collection_exists(visual_coll):
+        for payload in _scroll_all(client, visual_coll):
+            visual_per_file_counts[payload.get("file_path", "")] += 1
+    # Orphaned visual points: _visual points for a source no longer on disk.
+    orphaned_visual_files = sorted(
+        fp for fp in visual_per_file_counts
+        if fp and not (repo_root / fp).exists()
+    )
+
     # Sidecar-side checks. iter_canonical_sidecars skips corrupt/non-dict
     # sidecars, those without a current_path, and misplaced/nested junk copies
     # (e.g. an accidental .carta/sidecars/.worktrees/.../.carta/sidecars/... tree)
     # whose current_path resolves to a real file they do not own (#40).
     count_mismatches: dict[str, dict] = {}
+    visual_count_mismatches: dict[str, dict] = {}
     stuck_stale: list[str] = []
 
     for _sc_path, sc in iter_canonical_sidecars(repo_root):
@@ -129,6 +146,16 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
                 "qdrant": qdrant_count,
             }
 
+        # Visual count mismatch: sidecar visual_done count vs _visual point
+        # count. Files no longer on disk surface as orphaned_visual_files (#38).
+        visual_done_count = len(sc.get("visual_done") or [])
+        visual_qdrant = visual_per_file_counts.get(rel, 0)
+        if (repo_root / rel).exists() and visual_done_count != visual_qdrant:
+            visual_count_mismatches[rel] = {
+                "sidecar": visual_done_count,
+                "qdrant": visual_qdrant,
+            }
+
     # affected_files: union of everything needing re-embed or purge.
     # Slug collisions are intentionally EXCLUDED — with path-based point IDs
     # same-slug files coexist safely; genuine legacy-collision damage (chunks
@@ -143,4 +170,6 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
         "count_mismatches": count_mismatches,
         "stuck_stale": sorted(stuck_stale),
         "affected_files": sorted(affected),
+        "visual_count_mismatches": visual_count_mismatches,
+        "orphaned_visual_files": orphaned_visual_files,
     }

--- a/carta/embed/repair.py
+++ b/carta/embed/repair.py
@@ -5,6 +5,12 @@ generation, any legacy ID), then force re-embed through the fixed pipeline.
 Files that no longer exist on disk, or whose extraction yields nothing, end up
 purged + flagged rather than re-upserted. Stuck-stale sidecars get their status
 corrected in place.
+
+For the _visual collection (#38 part 2): orphaned visual points (source gone)
+are purged, while count mismatches for live files are re-queued for the
+`--visual` drain rather than deleted — ColPali embeddings can't be re-created
+deterministically, but the visual point IDs are idempotent so a re-drain
+overwrites in place.
 """
 from __future__ import annotations
 
@@ -32,11 +38,14 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
     report = scan_corpus_integrity(cfg, repo_root, client=client)
     coll = collection_name(cfg, "doc")
 
-    if not report["affected_files"] and not report["stuck_stale"]:
+    if (not report["affected_files"] and not report["stuck_stale"]
+            and not report.get("orphaned_visual_files")
+            and not report.get("visual_count_mismatches")):
         if verbose:
             print("Corpus integrity: nothing to repair.", flush=True)
         return {"affected": 0, "repaired": 0, "purged_only": 0,
-                "flagged": 0, "queued_visual": 0, "failed": 0, "stale_fixed": 0}
+                "flagged": 0, "queued_visual": 0, "failed": 0, "stale_fixed": 0,
+                "visual_purged": 0, "visual_requeued": 0}
 
     repaired = purged_only = flagged = queued_visual = failed = 0
     for rel in report["affected_files"]:
@@ -88,6 +97,41 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
                 _update_sidecar(sc, {"status": "embedded", "stale_as_of": None})
                 stale_fixed += 1
 
+    # _visual collection repair (#38 part 2).
+    visual_coll = collection_name(cfg, "visual")
+    visual_purged = visual_requeued = 0
+
+    # Orphaned visual points (source gone): safe to purge — nothing to re-create.
+    for rel in report.get("orphaned_visual_files", []):
+        try:
+            _delete_file_points(client, visual_coll, rel)
+            visual_purged += 1
+            if verbose:
+                print(f"  purged orphaned _visual points for {rel}", flush=True)
+        except Exception as e:
+            print(f"  Warning: could not purge _visual points for {rel} — {e}", flush=True)
+
+    # Count mismatches (source present): re-queue for re-drain, NEVER delete.
+    # ColPali embeddings aren't deterministically reproducible, but the visual
+    # point IDs are idempotent, so `carta embed --visual` overwrites in place.
+    if report.get("visual_count_mismatches"):
+        from carta.embed.pipeline import _update_sidecar
+        for rel in report["visual_count_mismatches"]:
+            sc_path = sidecar_path(repo_root / rel, repo_root)
+            sc = read_sidecar(sc_path) or {}
+            pages = sorted(set((sc.get("visual_done") or [])
+                               + (sc.get("visual_pending") or [])))
+            if not pages or not sc_path.exists():
+                continue
+            _update_sidecar(sc_path, {"visual_pending": pages, "visual_done": []})
+            visual_requeued += 1
+            if verbose:
+                print(
+                    f"  re-queued {len(pages)} visual page(s) for {rel}; "
+                    f"run `carta embed --visual` to re-drain",
+                    flush=True,
+                )
+
     summary = {
         "affected": len(report["affected_files"]),
         "repaired": repaired,
@@ -96,13 +140,16 @@ def run_repair(repo_root: Path, cfg: dict, verbose: bool = True) -> dict:
         "queued_visual": queued_visual,
         "failed": failed,
         "stale_fixed": stale_fixed,
+        "visual_purged": visual_purged,
+        "visual_requeued": visual_requeued,
     }
     if verbose:
         print(
             f"Repair complete: {repaired} re-embedded, {purged_only} purged, "
             f"{flagged} flagged extraction_failed, {queued_visual} queued for "
             f"visual pass, {failed} failed, "
-            f"{stale_fixed} stale sidecar(s) corrected.",
+            f"{stale_fixed} stale sidecar(s) corrected, "
+            f"{visual_requeued} visual re-queued, {visual_purged} visual purged.",
             flush=True,
         )
     return summary

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -343,6 +343,17 @@ class TestDoctorCorpusIntegrity:
         "affected_files": [],
     }
 
+    _VISUAL_ISSUES_REPORT = {
+        "slug_collisions": {},
+        "empty_files": [],
+        "partial_empty_files": {},
+        "count_mismatches": {},
+        "stuck_stale": [],
+        "affected_files": [],
+        "visual_count_mismatches": {"docs/scan.pdf": {"sidecar": 3, "qdrant": 1}},
+        "orphaned_visual_files": ["docs/gone.pdf"],
+    }
+
     def _make_args(self, json_flag=False):
         from unittest.mock import MagicMock
         args = MagicMock()
@@ -417,6 +428,34 @@ class TestDoctorCorpusIntegrity:
         assert "Corpus integrity" in out
         assert "no issues found" in out
         assert "carta embed --repair" not in out
+
+    def test_doctor_reports_visual_issues(self, tmp_path, capsys):
+        """Visual-only issues (no _doc problems) must still surface + nudge repair."""
+        from unittest.mock import patch
+        from carta import cli
+
+        cfg_file = tmp_path / ".carta" / "config.yaml"
+        cfg_file.parent.mkdir()
+        cfg_file.write_text(
+            "project_name: test\nqdrant_url: http://localhost:6333\n"
+        )
+
+        with patch("carta.cli.find_config", return_value=cfg_file), \
+             patch("carta.embed.integrity.scan_corpus_integrity",
+                   return_value=self._VISUAL_ISSUES_REPORT), \
+             patch("carta.install.preflight.PreflightChecker") as MockChecker, \
+             patch("carta.install.auto_fix.AutoInstaller"):
+            self._make_preflight_mock(MockChecker)
+            try:
+                cli.cmd_doctor(self._make_args())
+            except SystemExit:
+                pass
+
+        out = capsys.readouterr().out
+        assert "no issues found" not in out
+        assert "docs/scan.pdf" in out   # visual count mismatch surfaced
+        assert "docs/gone.pdf" in out   # orphaned visual surfaced
+        assert "carta embed --repair" in out
 
     def test_doctor_outside_project(self, capsys):
         """find_config raises FileNotFoundError — doctor finishes, no integrity section."""

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -3,6 +3,7 @@ import yaml
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from carta.config import collection_name
 from carta.embed.integrity import scan_corpus_integrity
 from carta.embed.lifecycle import compute_file_hash
 from carta.embed.repair import run_repair
@@ -15,11 +16,26 @@ def _point(file_path, slug, chunk_index, text):
     return p
 
 
-def _client_with_points(points):
+def _vpoint(file_path, page_num):
+    """A _visual collection point (payload carries file_path + page_num)."""
+    p = MagicMock()
+    p.payload = {"file_path": file_path, "page_num": page_num,
+                 "doc_type": "visual_page"}
+    return p
+
+
+def _client_with_collections(by_coll: dict):
+    """MagicMock Qdrant client whose collection_exists/scroll dispatch on the
+    collection name. by_coll maps collection name -> list of points."""
     client = MagicMock()
-    client.collection_exists.return_value = True
-    client.scroll.return_value = (points, None)  # single page
+    client.collection_exists.side_effect = lambda c: c in by_coll
+    client.scroll.side_effect = lambda coll, **kw: (by_coll.get(coll, []), None)
     return client
+
+
+def _client_with_points(points):
+    """Single-collection (_doc) client — back-compat for existing tests."""
+    return _client_with_collections({collection_name(CFG, "doc"): points})
 
 
 CFG = {"project_name": "test", "qdrant_url": "http://localhost:6333",
@@ -51,6 +67,18 @@ def _write_sidecar_at_production_path(tmp_path, rel_path, chunk_count, status, f
     with open(sc, "w") as f:
         yaml.dump({"current_path": rel_path, "chunk_count": chunk_count,
                    "status": status, "file_hash": file_hash}, f)
+    return sc
+
+
+def _write_visual_sidecar(tmp_path, rel_path, visual_done, visual_pending=None):
+    """Write a canonical sidecar tracking visual_done/visual_pending pages."""
+    from carta.embed.induct import sidecar_path
+    sc = sidecar_path(tmp_path / rel_path, tmp_path)
+    sc.parent.mkdir(parents=True, exist_ok=True)
+    sc.write_text(yaml.dump({
+        "current_path": rel_path, "status": "embedded",
+        "visual_done": list(visual_done), "visual_pending": list(visual_pending or []),
+    }))
     return sc
 
 
@@ -218,7 +246,9 @@ class TestScanCorpusIntegrity:
         page2 = [_point("docs/b.md", "b", 0, "world")]
 
         client = MagicMock()
-        client.collection_exists.return_value = True
+        # Only the _doc collection exists here, so the _visual scan is skipped
+        # and scroll is called exactly twice (the two _doc pages).
+        client.collection_exists.side_effect = lambda c: c == collection_name(CFG, "doc")
         # First call returns page1 with a non-None offset; second returns page2 with None
         client.scroll.side_effect = [
             (page1, "cursor-abc"),
@@ -287,6 +317,54 @@ class TestScannerRobustness:
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
         assert report["count_mismatches"] == {"docs/lost.md": {"sidecar": 5, "qdrant": 0}}
         assert "docs/lost.md" in report["affected_files"]
+
+
+class TestVisualIntegrityScan:
+    """scan_corpus_integrity also audits the _visual collection (#38 part 2)."""
+
+    def test_visual_count_mismatch_detected(self, tmp_path):
+        """Sidecar visual_done count != _visual point count → mismatch."""
+        src = tmp_path / "docs" / "scan.pdf"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("pdf bytes")
+        _write_visual_sidecar(tmp_path, "docs/scan.pdf", visual_done=[1, 2, 3])
+        client = _client_with_collections({
+            collection_name(CFG, "doc"): [],
+            collection_name(CFG, "visual"): [_vpoint("docs/scan.pdf", 1)],
+        })
+        report = scan_corpus_integrity(CFG, tmp_path, client=client)
+        assert report["visual_count_mismatches"] == {
+            "docs/scan.pdf": {"sidecar": 3, "qdrant": 1}}
+
+    def test_visual_counts_match_is_clean(self, tmp_path):
+        src = tmp_path / "docs" / "ok.pdf"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("pdf bytes")
+        _write_visual_sidecar(tmp_path, "docs/ok.pdf", visual_done=[1, 2])
+        client = _client_with_collections({
+            collection_name(CFG, "doc"): [],
+            collection_name(CFG, "visual"): [
+                _vpoint("docs/ok.pdf", 1), _vpoint("docs/ok.pdf", 2)],
+        })
+        report = scan_corpus_integrity(CFG, tmp_path, client=client)
+        assert report["visual_count_mismatches"] == {}
+
+    def test_orphaned_visual_points_when_source_gone(self, tmp_path):
+        """_visual points for a file whose source no longer exists → orphan."""
+        client = _client_with_collections({
+            collection_name(CFG, "doc"): [],
+            collection_name(CFG, "visual"): [
+                _vpoint("docs/gone.pdf", 1), _vpoint("docs/gone.pdf", 2)],
+        })
+        report = scan_corpus_integrity(CFG, tmp_path, client=client)
+        assert report["orphaned_visual_files"] == ["docs/gone.pdf"]
+        # source-gone files are orphans, not count mismatches
+        assert report["visual_count_mismatches"] == {}
+
+    def test_no_visual_collection_is_safe(self, tmp_path):
+        report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points([]))
+        assert report["visual_count_mismatches"] == {}
+        assert report["orphaned_visual_files"] == []
 
 
 class TestRunRepair:
@@ -486,3 +564,54 @@ class TestRunRepair:
         assert summary["stale_fixed"] == 0
         out = capsys.readouterr().out
         assert "nothing to repair" in out.lower()
+
+
+class TestVisualRepair:
+    """run_repair handles _visual integrity issues (#38 part 2)."""
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_orphaned_visual_points_are_purged(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        """A file gone from disk with _visual points → purge those points."""
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {}, "stuck_stale": [], "affected_files": [],
+            "visual_count_mismatches": {}, "orphaned_visual_files": ["docs/gone.pdf"],
+        }
+        summary = run_repair(tmp_path, CFG)
+
+        assert mock_qc.return_value.delete.call_count == 1   # purged from _visual
+        mock_reembed.assert_not_called()
+        assert summary["visual_purged"] == 1
+        assert summary["visual_requeued"] == 0
+
+    @patch("carta.embed.repair.run_embed_file")
+    @patch("carta.embed.repair.scan_corpus_integrity")
+    @patch("carta.embed.repair.QdrantClient")
+    def test_visual_mismatch_requeues_without_deleting(
+            self, mock_qc, mock_scan, mock_reembed, tmp_path):
+        """A count mismatch (source present) re-queues for re-drain and never
+        deletes _visual points (ColPali embeddings can't be re-created)."""
+        src = tmp_path / "docs" / "scan.pdf"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_bytes(b"%PDF-1.4 fake")
+        _write_visual_sidecar(tmp_path, "docs/scan.pdf",
+                              visual_done=[1, 2, 3], visual_pending=[])
+        mock_scan.return_value = {
+            "slug_collisions": {}, "empty_files": [], "partial_empty_files": {},
+            "count_mismatches": {}, "stuck_stale": [], "affected_files": [],
+            "visual_count_mismatches": {"docs/scan.pdf": {"sidecar": 3, "qdrant": 1}},
+            "orphaned_visual_files": [],
+        }
+        summary = run_repair(tmp_path, CFG)
+
+        mock_qc.return_value.delete.assert_not_called()  # never destroy visual points
+        mock_reembed.assert_not_called()
+        assert summary["visual_requeued"] == 1
+        # Sidecar reset: every page pending again, none done — ready to re-drain.
+        from carta.embed.induct import sidecar_path, read_sidecar
+        sc = read_sidecar(sidecar_path(tmp_path / "docs/scan.pdf", tmp_path))
+        assert sc["visual_pending"] == [1, 2, 3]
+        assert sc["visual_done"] == []

--- a/docs/superpowers/specs/2026-06-15-visual-integrity-scanning-design.md
+++ b/docs/superpowers/specs/2026-06-15-visual-integrity-scanning-design.md
@@ -1,0 +1,86 @@
+---
+id: 2026-06-15-visual-integrity-scanning-design
+title: _visual collection integrity scanning + repair
+status: shipped
+related: []
+date: 2026-06-15
+related_issue: Ian-q/Carta#38
+---
+
+# `_visual` collection integrity scanning + repair (#38 part 2)
+
+`scan_corpus_integrity` and `embed --repair` only operate on the `_doc`
+collection. The `_visual` collection (ColPali page embeddings produced by the
+two-pass `carta embed --visual` drain) has no integrity coverage — count drift
+between a sidecar's `visual_done` pages and the actual `_visual` points, and
+orphaned visual points for deleted sources, go undetected. This is #38 part 2;
+part 1 (OCR-recovery of `extraction_failed` files) is a separate follow-up.
+
+## Background
+
+- `_visual` points live in `collection_name(cfg, "visual")`, keyed by a
+  deterministic, idempotent id `md5(file_path:visual:page_num)` — **no
+  generation**, so a re-drain overwrites in place.
+- Each point payload carries `file_path` and `page_num`.
+- Sidecars track visual state in `visual_pending` / `visual_done` (1-indexed
+  page lists). `len(visual_done)` is the count of pages already visual-embedded.
+- v0.11.0 recorded decision: **repair must not purge what it cannot re-create.**
+  ColPali embeddings are not deterministically reproducible, so repair must
+  *re-queue for re-drain*, never blind-delete (except when the source is gone).
+
+## Design
+
+### Scanning — extend `scan_corpus_integrity` (`carta/embed/integrity.py`)
+
+After the existing `_doc` scan, also scan the `_visual` collection:
+
+- Scroll `collection_name(cfg, "visual")` (if it exists), tallying point count
+  per `file_path`.
+- **`visual_count_mismatches`** `{rel: {"sidecar": len(visual_done), "qdrant": n}}`
+  — for each canonical sidecar whose **source exists**, where the recorded
+  `visual_done` count differs from the `_visual` point count. (Both-zero is not
+  a mismatch.)
+- **`orphaned_visual_files`** `[rel]` — `file_path`s present in `_visual` whose
+  source file no longer exists on disk (purgeable).
+
+These are returned as new report keys. They are kept **separate** from
+`affected_files` (which carries `_doc` re-embed semantics); `_visual` is repaired
+on its own track.
+
+### Repair — extend `run_repair` (`carta/embed/repair.py`)
+
+After the `_doc` repair loop:
+
+- **`orphaned_visual_files`** (source gone) → delete that file's `_visual`
+  points. Safe: nothing to re-create. Count `visual_purged`.
+- **`visual_count_mismatches`** (source exists) → **re-queue, never delete**:
+  reset the sidecar so every visual page (`visual_done ∪ visual_pending`) becomes
+  `visual_pending` and `visual_done = []`, then tell the user to run
+  `carta embed --visual` to re-drain (idempotent ids overwrite in place). Count
+  `visual_requeued`.
+
+New summary keys: `visual_purged`, `visual_requeued`.
+
+## Testing (TDD)
+
+- Scan: count mismatch detected (`visual_done` vs `_visual`); clean when counts
+  agree; orphaned `_visual` points (source gone) reported; empty/safe when no
+  `_visual` collection.
+- Repair: orphaned visual → points purged; mismatch (source exists) → sidecar
+  re-queued (`visual_pending` repopulated, `visual_done` cleared), points NOT
+  deleted.
+- Refactor the `test_integrity.py` client helper to dispatch by collection so
+  `_doc`-only tests are unaffected by the new `_visual` scan.
+
+## Acceptance
+
+- `carta doctor` / `embed --repair` surface `_visual` count drift and orphaned
+  visual points.
+- Repair re-queues mismatched files for re-drain (never destroying
+  un-recreatable embeddings) and purges only truly-orphaned visual points.
+
+## Out of scope
+
+- OCR-recovery of `extraction_failed` files (#38 part 1 — follow-up).
+- `_visual` points that exist for a file with no sidecar but a present source
+  (rare; not addressed here).


### PR DESCRIPTION
## Summary

`scan_corpus_integrity` and `embed --repair` only covered the `_doc` collection. The `_visual` collection — ColPali page embeddings produced by the two-pass `carta embed --visual` drain — had **no integrity coverage**, so count drift between a sidecar's `visual_done` pages and the actual `_visual` points, and orphaned visual points for deleted sources, went undetected.

This is **part 2 of #38**. Part 1 (OCR-recovery of `extraction_failed` files) is a separate follow-up.

## Changes

**Scanning** (`carta/embed/integrity.py`) — new report keys:
- `visual_count_mismatches` — `{file_path: {"sidecar": visual_done_count, "qdrant": n}}` for files still on disk whose recorded visual page count differs from the `_visual` point count.
- `orphaned_visual_files` — `_visual` points whose source file no longer exists.

**Repair** (`carta/embed/repair.py`):
- Orphaned visual points (source gone) → **purged** (nothing to re-create).
- Count mismatches (source present) → **re-queued** for the `--visual` drain (`visual_pending` reset to all pages, `visual_done` cleared) and **never deleted**. ColPali embeddings aren't deterministically reproducible, but the visual point IDs are idempotent, so a re-drain overwrites in place — honoring the v0.11.0 *"repair must not purge what it cannot re-create"* rule.

**Doctor** (`carta/cli.py`): surfaces visual count mismatches + orphaned visual points and nudges `carta embed --repair`.

## Testing (TDD)

New tests for `_visual` scanning (count mismatch / clean / orphaned / no-collection), repair (purge orphans; re-queue-not-delete mismatches), and the doctor display. The `test_integrity.py` client helper now dispatches per-collection so `_doc`-only tests are unaffected.

✅ Full suite: **935 passed, 2 skipped**.

Refs #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)