### PR TITLE
feat: OCR-recover extraction_failed scanned PDFs (#38 part 1)

### DIFF
--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -595,16 +595,36 @@ def _embed_one_file(
     sidecar_updates["_vision_events"] = _page_events
 
     # Nothing extractable anywhere: no text was attempted, no image chunks were
-    # attempted, and no pages are queued for pass-2 visual embedding. Flag the
-    # file instead of recording a silent no-op as "embedded".
+    # attempted, and no pages are queued for pass-2 visual embedding.
     if (expected_text == 0 and expected_images == 0
             and not (_visual_queue_updates.get(VISUAL_PENDING_KEY) or [])):
-        sidecar_updates["status"] = "extraction_failed"
-        print(
-            f"Warning: {file_path.name}: 0 extractable characters — skipped "
-            f"(scanned PDF? OCR may be required)",
-            flush=True,
+        # Give OCR a chance before declaring failure (#38 part 1): a PDF with no
+        # extractable text is almost certainly scanned/flattened, so queue every
+        # page for the `--visual` drain (glm-ocr text + ColPali) rather than
+        # dead-ending. extraction_failed is reserved for inputs OCR can't help:
+        # non-PDFs, zero-page PDFs, or runs with visual/OCR disabled.
+        embed_cfg = cfg.get("embed", {})
+        ocr_recoverable = (
+            file_path.suffix == ".pdf"
+            and len(pages) > 0
+            and embed_cfg.get("two_pass_visual", True)
+            and embed_cfg.get("vision_routing", "auto") != "off"
         )
+        if ocr_recoverable:
+            add_pending_pages(sidecar_updates, list(range(1, len(pages) + 1)))
+            if verbose:
+                print(
+                    f"    {file_path.name}: 0 extractable text — queued "
+                    f"{len(pages)} page(s) for OCR (run `carta embed --visual`)",
+                    flush=True,
+                )
+        else:
+            sidecar_updates["status"] = "extraction_failed"
+            print(
+                f"Warning: {file_path.name}: 0 extractable characters — skipped "
+                f"(scanned PDF? OCR may be required)",
+                flush=True,
+            )
 
     # File fully embedded — clear any per-page resume checkpoint.
     if file_path.suffix == ".pdf":

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -434,12 +434,42 @@ def test_partial_empty_chunks_cleanup_gate_uses_nonempty_count(mock_upsert, mock
     mock_del.assert_called_once()
 
 
+@patch("carta.embed.pipeline._mark_or_collect_visual_pages", return_value={})
 @patch("carta.embed.pipeline.upsert_chunks", return_value=0)
 @patch("carta.embed.pipeline.extract_pdf_text_and_classify")
 @patch("carta.embed.pipeline.PageAnalyzer")
-def test_pdf_zero_usable_no_queue_marks_extraction_failed(
-        mock_analyzer, mock_extract, mock_upsert, tmp_path, capsys):
-    """A PDF with no extractable text and no pages queued for pass-2 is flagged."""
+def test_pdf_zero_usable_queues_all_pages_for_ocr(
+        mock_analyzer, mock_extract, mock_upsert, mock_mark, tmp_path):
+    """A textless PDF with nothing auto-queued is routed to OCR — every page is
+    queued for the --visual drain — instead of dead-ending at extraction_failed
+    (#38 part 1)."""
+    from carta.embed.pipeline import _embed_one_file
+    from carta.embed.visual_queue import VISUAL_PENDING_KEY
+    repo = tmp_path
+    doc = repo / "docs" / "scan.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4 fake")
+    mock_extract.return_value = (
+        [{"page": 1, "text": ""}, {"page": 2, "text": ""}], [])
+    cfg = {
+        "project_name": "test", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+    }
+    count, updates = _embed_one_file(doc, {"slug": "scan", "doc_type": "unknown"},
+                                     cfg, MagicMock(), repo, 800, 0.15)
+    assert count == 0
+    assert updates["status"] != "extraction_failed"
+    assert updates[VISUAL_PENDING_KEY] == [1, 2]
+
+
+@patch("carta.embed.pipeline._mark_or_collect_visual_pages", return_value={})
+@patch("carta.embed.pipeline.upsert_chunks", return_value=0)
+@patch("carta.embed.pipeline.extract_pdf_text_and_classify")
+@patch("carta.embed.pipeline.PageAnalyzer")
+def test_pdf_zero_usable_flags_when_vision_disabled(
+        mock_analyzer, mock_extract, mock_upsert, mock_mark, tmp_path, capsys):
+    """With OCR/vision disabled there is no recovery path, so a textless PDF is
+    still flagged extraction_failed."""
     from carta.embed.pipeline import _embed_one_file
     repo = tmp_path
     doc = repo / "docs" / "scan.pdf"
@@ -448,7 +478,8 @@ def test_pdf_zero_usable_no_queue_marks_extraction_failed(
     mock_extract.return_value = ([{"page": 1, "text": ""}], [])
     cfg = {
         "project_name": "test", "qdrant_url": "http://localhost:6333",
-        "embed": {"ollama_url": "http://x", "ollama_model": "m"},
+        "embed": {"ollama_url": "http://x", "ollama_model": "m",
+                  "vision_routing": "off"},
     }
     count, updates = _embed_one_file(doc, {"slug": "scan", "doc_type": "unknown"},
                                      cfg, MagicMock(), repo, 800, 0.15)

--- a/docs/superpowers/specs/2026-06-15-ocr-recover-extraction-failed-design.md
+++ b/docs/superpowers/specs/2026-06-15-ocr-recover-extraction-failed-design.md
@@ -1,0 +1,77 @@
+---
+id: 2026-06-15-ocr-recover-extraction-failed-design
+title: OCR recovery for extraction_failed scanned PDFs
+status: shipped
+related: [2026-06-15-visual-integrity-scanning-design]
+date: 2026-06-15
+related_issue: Ian-q/Carta#38
+---
+
+# OCR recovery for extraction_failed scanned PDFs (#38 part 1)
+
+v0.11.0 stops silently embedding empty chunks: a PDF whose text extraction
+yields nothing is flagged `status: extraction_failed` and then **dead-ends** —
+nothing ever routes it to OCR, so it stays unfindable (43 such files in the
+ET-embed corpus). Part 2 (`_visual` integrity) already shipped (#64).
+
+## Root cause (from code trace)
+
+`_embed_one_file` (`carta/embed/pipeline.py`) flags `extraction_failed` only
+when **all** of: zero text chunks, zero inline image chunks, and **no pages
+queued** for the two-pass `--visual` drain. A scanned page normally classifies
+as `FLATTENED` and gets queued — but when page classification fails (PyMuPDF
+error → `_page_classes_from_extraction is None`, fail-closed) or yields no
+image-heavy pages, nothing is queued and the textless PDF dead-ends. The OCR
+machinery (`run_visual_embed` → `SmartRouter._route_flattened` → glm-ocr) exists
+and works; it's just never reached for these files.
+
+## Design — give OCR a chance before flagging
+
+At the `extraction_failed` gate, before flagging a **PDF**, queue **every** page
+for the `--visual` drain instead. The drain (unchanged) runs glm-ocr text →
+`_doc` (hybrid index) **and** ColPali → `_visual` per page, so the file becomes
+findable. `extraction_failed` is reserved for cases OCR genuinely can't help:
+
+- non-PDF files (markdown, etc.) — no OCR path (existing line ~379, unchanged);
+- zero-page PDFs (`len(pages) == 0`);
+- visual/OCR disabled (`two_pass_visual` off, or `vision_routing == "off"`).
+
+The queued file keeps `status: embedded` with `visual_pending = [1..N]` — the
+same healthy two-pass state a normal scanned PDF reaches. Running
+`carta embed --visual` then drains it through OCR.
+
+### Why not flag-after-OCR-fails
+
+The drain already embeds each page with ColPali regardless of OCR yield, so a
+queued page is never a total loss (it's visually searchable even if glm-ocr
+returns no text). A future refinement could downgrade a file to
+`extraction_failed` if a drain produces neither OCR text nor ColPali points, but
+that requires per-file bookkeeping across the drain loop and is out of scope.
+
+## Implementation
+
+Single change in `_embed_one_file`'s zero-extractable gate: replace the
+unconditional `status = extraction_failed` with a branch that force-queues all
+pages (`add_pending_pages(sidecar_updates, range(1, len(pages)+1))`) when the
+file is an OCR-recoverable PDF, else flags as before.
+
+## Testing (TDD)
+
+- Textless PDF, nothing queued, visual enabled → all pages queued
+  (`visual_pending == [1..N]`), status NOT `extraction_failed`.
+- Textless PDF with `vision_routing: "off"` (or `two_pass_visual: false`) →
+  still `extraction_failed`.
+- Empty markdown (non-PDF) → still `extraction_failed` (unchanged).
+- PDF with image-heavy pages already queued → unchanged (not flagged).
+
+## Validation
+
+Mock-based TDD here; real-corpus validation is run by the maintainer against
+ET-embed (re-embed the 43 `extraction_failed` files, then `carta embed --visual`,
+and confirm they become findable).
+
+## Acceptance
+
+A scanned PDF that previously dead-ended at `extraction_failed` is instead
+queued for the OCR drain and recovered by `carta embed --visual`;
+`extraction_failed` remains only for genuinely unrecoverable inputs.


### PR DESCRIPTION
## Summary

v0.11.0 stopped silently embedding empty chunks: a PDF whose text extraction yields nothing is flagged `status: extraction_failed` and then **dead-ends** — nothing routed it to the OCR machinery that already exists, so it stayed unfindable (43 such files in the ET-embed corpus, e.g. the US-11965795 patent).

This is **part 1 of #38**. Part 2 (`_visual` integrity scanning + repair) shipped in #64.

## Root cause

`_embed_one_file` flags `extraction_failed` only when there are zero text chunks, zero inline image chunks, **and** no pages queued for the two-pass `--visual` drain. A scanned page normally classifies as `FLATTENED` and gets queued — but when page classification fails (PyMuPDF error → fail-closed) or yields no image-heavy pages, nothing is queued and the textless PDF dead-ends. The OCR path (`run_visual_embed` → `SmartRouter._route_flattened` → glm-ocr) exists; it was just never reached.

## Change — give OCR a chance before flagging

At the zero-extractable gate, a textless **PDF** now has **every page queued** for the `--visual` drain (glm-ocr text → `_doc` hybrid index + ColPali → `_visual`) instead of dead-ending. The file keeps `status: embedded` with `visual_pending = [1..N]` — the same healthy two-pass state a normal scanned PDF reaches — and `carta embed --visual` recovers it.

`extraction_failed` is reserved for inputs OCR genuinely can't help:
- non-PDF files (markdown, etc.) — unchanged;
- zero-page PDFs;
- runs with visual/OCR disabled (`two_pass_visual` off, or `vision_routing: "off"`).

## Testing (TDD)

- Textless PDF, nothing auto-queued, visual enabled → all pages queued (`visual_pending == [1..N]`), status not `extraction_failed`.
- Textless PDF with `vision_routing: "off"` → still `extraction_failed`.
- Empty markdown (non-PDF) → still `extraction_failed` (unchanged).
- PDF with image-heavy pages already queued → unchanged.

✅ Full suite: **936 passed, 2 skipped**.

## Validation

Mock-based TDD here. **Real-corpus validation is yours to run** against ET-embed: re-embed the `extraction_failed` files, run `carta embed --visual`, and confirm they become findable. Once confirmed, this + #64 close #38.

Refs #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)