### PR TITLE
feat: stale-reference diff-range scan — carta hook check --diff (#10 slice 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,9 @@ A second, opt-in hook — `carta hook` — installs a managed git `pre-push` (or
 `pre-commit`) shim that scans changed docs and warns when a section has been
 superseded by an authoritative doc in the graph. Warn-only by default; fail-open.
 Core in `carta/hook/stale_scan.py`; shim install/removal in `carta/hook/git_hook.py`;
-shared yes/no judge in `carta/hook/judge.py`.
+shared yes/no judge in `carta/hook/judge.py`. Run on demand as a whole-branch pre-PR
+audit with `carta hook check --diff [range]` (default range `<default-branch>...HEAD`;
+`--fail-on-stale` to exit non-zero).
 
 ### Sidecars
 

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -856,8 +856,12 @@ def cmd_hook(args):
         if not scfg.get("enabled", True):
             sys.exit(0)
         stage = args.stage
+        diff = getattr(args, "diff", None)
         try:
-            if stage == "pre-commit":
+            if diff is not None:
+                range_spec = diff or f"{stale_scan._default_branch(repo_root)}...HEAD"
+                docs = stale_scan.collect_range(repo_root, cfg, range_spec)
+            elif stage == "pre-commit":
                 docs = stale_scan.collect_staged(repo_root, cfg)
             else:
                 stdin_lines = [] if sys.stdin.isatty() else sys.stdin.read().splitlines()
@@ -873,7 +877,8 @@ def cmd_hook(args):
             print(f"carta stale-scan: scan error (fail-open): {e}", file=sys.stderr)
             sys.exit(0)
         _print_stale_result(result, scfg)
-        if result.findings and scfg.get("block_on_stale", False):
+        fail = getattr(args, "fail_on_stale", False) or scfg.get("block_on_stale", False)
+        if result.findings and fail:
             sys.exit(1)
         sys.exit(0)
 
@@ -1033,6 +1038,15 @@ def main():
     hook_install.add_argument("--uninstall", action="store_true", help="Remove the managed hook")
     hook_check = hook_sub.add_parser("check", help="Run the stale-reference scan (used by the git shim)")
     hook_check.add_argument("--stage", choices=["pre-push", "pre-commit"], default="pre-push")
+    hook_check.add_argument(
+        "--diff", nargs="?", const="", default=None, metavar="RANGE",
+        help="Scan docs changed across a git range instead of staged/pushed "
+             "(bare --diff uses <default-branch>...HEAD)",
+    )
+    hook_check.add_argument(
+        "--fail-on-stale", action="store_true",
+        help="Exit 1 if any stale finding (default: warn-only, exit 0)",
+    )
 
     args = parser.parse_args()
 

--- a/carta/hook/stale_scan.py
+++ b/carta/hook/stale_scan.py
@@ -149,6 +149,17 @@ def collect_pushed(repo_root: Path, cfg: dict, stdin_lines: list[str]) -> list[C
     if not stdin_lines:  # manual invocation — scan default-branch..HEAD
         ranges = [(f"{_default_branch(repo_root)}..HEAD", "HEAD")]
 
+    return _collect_from_ranges(repo_root, cfg, ranges)
+
+
+def _collect_from_ranges(
+    repo_root: Path, cfg: dict, ranges: list[tuple[str, str]]
+) -> list[ChangedDoc]:
+    """Collect in-scope changed docs across one or more (range_spec, tip_sha) pairs.
+
+    For each range, list ACM-changed paths, keep only in-scope docs, and read each
+    doc's content at that range's tip via `git show <tip>:<path>`. Deduped by path
+    (first range wins). Fails open per range and per file."""
     seen: dict[str, ChangedDoc] = {}
     for rng, tip in ranges:
         try:
@@ -165,6 +176,22 @@ def collect_pushed(repo_root: Path, cfg: dict, stdin_lines: list[str]) -> list[C
                 continue
             seen[rel] = ChangedDoc(path=rel, text=text)
     return list(seen.values())
+
+
+def _range_tip(range_spec: str) -> str:
+    """Right operand of a git range (`A..B` / `A...B` -> `B`); empty right side or a
+    bare ref -> `HEAD`. Used to read changed-file content at the tip of the range."""
+    for sep in ("...", ".."):
+        if sep in range_spec:
+            right = range_spec.split(sep, 1)[1].strip()
+            return right or "HEAD"
+    return range_spec.strip() or "HEAD"
+
+
+def collect_range(repo_root: Path, cfg: dict, range_spec: str) -> list[ChangedDoc]:
+    """Collect in-scope docs changed across an explicit git range, read at the range
+    tip. Used by the local on-demand pre-PR diff scan (`carta hook check --diff`)."""
+    return _collect_from_ranges(repo_root, cfg, [(range_spec, _range_tip(range_spec))])
 
 
 def run_stale_scan(repo_root, cfg, changed_docs, *, search_fn=None, judge_fn=None) -> StaleScanResult:

--- a/carta/hook/tests/test_stale_scan.py
+++ b/carta/hook/tests/test_stale_scan.py
@@ -203,3 +203,51 @@ def test_collect_pushed_new_branch_zero_oid(repo):
     stdin_lines = [f"refs/heads/feature {tip} refs/heads/feature {zero}"]
     docs = collect_pushed(repo, cfg, stdin_lines)
     assert [d.path for d in docs] == ["docs/a.md"]
+
+
+# ---------------------------------------------------------------------------
+# Task 1 (slice 2): _range_tip + collect_range + _collect_from_ranges refactor
+# ---------------------------------------------------------------------------
+
+from carta.hook.stale_scan import _range_tip, collect_range
+
+
+def test_range_tip_parses_two_and_three_dot():
+    assert _range_tip("a..b") == "b"
+    assert _range_tip("a...b") == "b"
+    assert _range_tip("main...HEAD") == "HEAD"
+    assert _range_tip("main...") == "HEAD"      # trailing-empty right side
+    assert _range_tip("origin/main..feature") == "feature"
+
+
+def test_collect_range_returns_scoped_docs_at_tip(repo):
+    (repo / "docs" / "a.md").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c1")
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True).stdout.strip()
+    (repo / "docs" / "a.md").write_text("## A\nv2 changed\n")
+    (repo / "docs" / "b.md").write_text("## B\nbrand new\n")
+    (repo / "src.py").write_text("print()\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c2")
+    cfg = {"docs_root": "docs/", "excluded_paths": []}
+    docs = collect_range(repo, cfg, f"{base}...HEAD")
+    paths = sorted(d.path for d in docs)
+    assert paths == ["docs/a.md", "docs/b.md"]     # src.py excluded by scope
+    by_path = {d.path: d.text for d in docs}
+    assert "v2 changed" in by_path["docs/a.md"]     # tip content, not v1
+    assert "brand new" in by_path["docs/b.md"]
+
+
+def test_collect_range_two_dot_range(repo):
+    (repo / "docs" / "a.md").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c1")
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True).stdout.strip()
+    (repo / "docs" / "a.md").write_text("## A\nv2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c2")
+    cfg = {"docs_root": "docs/", "excluded_paths": []}
+    docs = collect_range(repo, cfg, f"{base}..HEAD")
+    assert [d.path for d in docs] == ["docs/a.md"]
+    assert "v2" in docs[0].text

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -798,3 +798,100 @@ def test_cmd_hook_install_uses_git_root_not_carta_config(tmp_path):
     finally:
         os.chdir(cwd)
     assert (tmp_path / ".git" / "hooks" / "pre-push").exists()
+
+
+def test_cmd_hook_check_diff_uses_collect_range(tmp_path, monkeypatch, capsys):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleFinding, StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+
+    captured = {}
+    def fake_collect_range(repo_root, c, range_spec):
+        captured["range_spec"] = range_spec
+        return [object()]
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", fake_collect_range)
+    monkeypatch.setattr("carta.hook.stale_scan.collect_staged", lambda r, c: (_ for _ in ()).throw(AssertionError("collect_staged should not be called")))
+    monkeypatch.setattr("carta.hook.stale_scan.collect_pushed", lambda r, c, s: (_ for _ in ()).throw(AssertionError("collect_pushed should not be called")))
+    result = StaleScanResult(findings=[StaleFinding("docs/a.md", "## A", "snip", "docs/b.md", 0.9)], scanned=1)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: result)
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": False})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0
+    assert captured["range_spec"] == "origin/main...HEAD"
+    assert "may be stale" in capsys.readouterr().err
+
+
+def test_cmd_hook_check_diff_default_range(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+
+    captured = {}
+    def fake_collect_range(repo_root, c, range_spec):
+        captured["range_spec"] = range_spec
+        return [object()]
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", fake_collect_range)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: StaleScanResult(scanned=1))
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "", "fail_on_stale": False})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0
+    assert captured["range_spec"] == "main...HEAD"
+
+
+def test_cmd_hook_check_diff_fail_on_stale_exits_one(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleFinding, StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", lambda r, c, rng: [object()])
+    result = StaleScanResult(findings=[StaleFinding("docs/a.md", "## A", "s", "docs/b.md", 0.9)], scanned=1)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: result)
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": True})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 1
+
+
+def test_cmd_hook_check_diff_no_findings_exits_zero(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", lambda r, c, rng: [object()])
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: StaleScanResult(findings=[], scanned=1))
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": True})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0

--- a/docs/superpowers/plans/2026-06-16-stale-reference-diff-scan.md
+++ b/docs/superpowers/plans/2026-06-16-stale-reference-diff-scan.md
@@ -1,0 +1,469 @@
+# Stale-reference diff-range scan — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local, on-demand `carta hook check --diff [range]` mode that scans every doc changed across a git range (whole branch vs base) against the knowledge graph, reusing the slice-1 stale-scan core, with a `--fail-on-stale` opt-in exit code.
+
+**Architecture:** Factor the file-collection inner loop out of `collect_pushed` into a shared `_collect_from_ranges` helper; add a sibling `collect_range(repo_root, cfg, range_spec)` collector (deriving the range tip via `_range_tip`). Wire two new flags (`--diff`, `--fail-on-stale`) onto the existing `carta hook check` subcommand and branch the collection logic accordingly. Everything else (scan core, judge, config, plain reporter) is reused unchanged; fail-open is preserved everywhere.
+
+**Tech Stack:** Python 3.10+, argparse, `subprocess` (git), pytest + `unittest.mock`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `carta/hook/stale_scan.py` (modify) | Extract `_collect_from_ranges`; add `_range_tip` + `collect_range`; rewire `collect_pushed` to the shared helper |
+| `carta/hook/tests/test_stale_scan.py` (append) | Tests for `_range_tip` and `collect_range` (real temp git repo) |
+| `carta/cli.py` (modify) | `--diff` / `--fail-on-stale` on the `check` subparser; diff-aware collection + exit in `cmd_hook` |
+| `carta/tests/test_cli.py` (append) | Tests for `cmd_hook` `--diff` collection + exit codes |
+| `CLAUDE.md` (modify) | Note the `--diff` diff-range audit on the hook surface |
+| `docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md` (modify) | `status: draft` → `status: shipped` |
+
+**Run the whole suite with:** `python -m pytest carta/ -q`
+
+---
+
+## Task 1: `collect_range` + shared `_collect_from_ranges` refactor
+
+The slice-1 `collect_pushed` (in `carta/hook/stale_scan.py`) already contains the exact
+inner loop we need: diff a range, scope-filter, read each path at the range tip via
+`git show <tip>:<path>`, dedupe by path. Extract that loop into a shared helper, rewire
+`collect_pushed` to call it (behavior-preserving), then add `_range_tip` + `collect_range`.
+
+**Files:**
+- Modify: `carta/hook/stale_scan.py` (the collectors region, ~lines 134-167)
+- Test: `carta/hook/tests/test_stale_scan.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `carta/hook/tests/test_stale_scan.py`:
+
+```python
+from carta.hook.stale_scan import _range_tip, collect_range
+
+
+def test_range_tip_parses_two_and_three_dot():
+    assert _range_tip("a..b") == "b"
+    assert _range_tip("a...b") == "b"
+    assert _range_tip("main...HEAD") == "HEAD"
+    assert _range_tip("main...") == "HEAD"      # trailing-empty right side
+    assert _range_tip("origin/main..feature") == "feature"
+
+
+def test_collect_range_returns_scoped_docs_at_tip(repo):
+    # repo fixture (defined earlier in this file) is a fresh git repo with docs/.
+    (repo / "docs" / "a.md").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c1")
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True).stdout.strip()
+    (repo / "docs" / "a.md").write_text("## A\nv2 changed\n")
+    (repo / "docs" / "b.md").write_text("## B\nbrand new\n")
+    (repo / "src.py").write_text("print()\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c2")
+    cfg = {"docs_root": "docs/", "excluded_paths": []}
+    docs = collect_range(repo, cfg, f"{base}...HEAD")
+    paths = sorted(d.path for d in docs)
+    assert paths == ["docs/a.md", "docs/b.md"]     # src.py excluded by scope
+    by_path = {d.path: d.text for d in docs}
+    assert "v2 changed" in by_path["docs/a.md"]     # tip content, not v1
+    assert "brand new" in by_path["docs/b.md"]
+
+
+def test_collect_range_two_dot_range(repo):
+    (repo / "docs" / "a.md").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c1")
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True).stdout.strip()
+    (repo / "docs" / "a.md").write_text("## A\nv2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "c2")
+    cfg = {"docs_root": "docs/", "excluded_paths": []}
+    docs = collect_range(repo, cfg, f"{base}..HEAD")
+    assert [d.path for d in docs] == ["docs/a.md"]
+    assert "v2" in docs[0].text
+```
+
+> These tests reuse the `repo` pytest fixture and the `_git` helper already defined in
+> `test_stale_scan.py` by the slice-1 collector tests (Task 7). Do NOT redefine them.
+> `subprocess` is already imported at the top of the test file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest carta/hook/tests/test_stale_scan.py -k "range_tip or collect_range" -v`
+Expected: FAIL with `ImportError: cannot import name '_range_tip'` (or `collect_range`).
+
+- [ ] **Step 3: Refactor + implement**
+
+In `carta/hook/stale_scan.py`, replace the body of `collect_pushed` (currently lines
+~134-167) so its final collection loop is extracted into a shared helper, and add the
+new `_range_tip` + `collect_range`. The full replacement for the region from
+`def collect_pushed` through the end of that function:
+
+```python
+def collect_pushed(repo_root: Path, cfg: dict, stdin_lines: list[str]) -> list[ChangedDoc]:
+    ranges: list[tuple[str, str]] = []  # (range_spec, tip_sha)
+    for line in stdin_lines:
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        local_sha, remote_sha = parts[1], parts[3]
+        if set(local_sha) == {"0"}:
+            continue  # branch deletion — nothing to scan
+        if set(remote_sha) == {"0"}:
+            rng = _new_branch_range(repo_root, local_sha)
+        else:
+            rng = f"{remote_sha}..{local_sha}"
+        ranges.append((rng, local_sha))
+
+    if not stdin_lines:  # manual invocation — scan default-branch..HEAD
+        ranges = [(f"{_default_branch(repo_root)}..HEAD", "HEAD")]
+
+    return _collect_from_ranges(repo_root, cfg, ranges)
+
+
+def _collect_from_ranges(
+    repo_root: Path, cfg: dict, ranges: list[tuple[str, str]]
+) -> list[ChangedDoc]:
+    """Collect in-scope changed docs across one or more (range_spec, tip_sha) pairs.
+
+    For each range, list ACM-changed paths, keep only in-scope docs, and read each
+    doc's content at that range's tip via `git show <tip>:<path>`. Deduped by path
+    (first range wins). Fails open per range and per file."""
+    seen: dict[str, ChangedDoc] = {}
+    for rng, tip in ranges:
+        try:
+            out = _git(repo_root, "diff", "--name-only", "--diff-filter=ACM", rng)
+        except subprocess.CalledProcessError:
+            continue
+        for rel in out.splitlines():
+            rel = rel.strip()
+            if not rel or rel in seen or not _in_doc_scope(rel, cfg, repo_root):
+                continue
+            try:
+                text = _git(repo_root, "show", f"{tip}:{rel}")
+            except subprocess.CalledProcessError:
+                continue
+            seen[rel] = ChangedDoc(path=rel, text=text)
+    return list(seen.values())
+
+
+def _range_tip(range_spec: str) -> str:
+    """Right operand of a git range (`A..B` / `A...B` → `B`); empty right side or a
+    bare ref → `HEAD`. Used to read changed-file content at the tip of the range."""
+    for sep in ("...", ".."):
+        if sep in range_spec:
+            right = range_spec.split(sep, 1)[1].strip()
+            return right or "HEAD"
+    return range_spec.strip() or "HEAD"
+
+
+def collect_range(repo_root: Path, cfg: dict, range_spec: str) -> list[ChangedDoc]:
+    """Collect in-scope docs changed across an explicit git range, read at the range
+    tip. Used by the local on-demand pre-PR diff scan (`carta hook check --diff`)."""
+    return _collect_from_ranges(repo_root, cfg, [(range_spec, _range_tip(range_spec))])
+```
+
+- [ ] **Step 4: Run tests to verify they pass (new + existing collectors)**
+
+Run: `python -m pytest carta/hook/tests/test_stale_scan.py -v`
+Expected: PASS — the new `_range_tip`/`collect_range` tests pass AND every existing
+slice-1 test (including the three `collect_pushed`/`collect_staged` tests) stays green,
+proving the refactor is behavior-preserving.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/hook/stale_scan.py carta/hook/tests/test_stale_scan.py
+git commit -m "feat(hook): collect_range + shared range-collection helper (#10 slice 2)"
+```
+
+End the commit message with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 2: CLI `--diff` + `--fail-on-stale`
+
+**Files:**
+- Modify: `carta/cli.py` (the `check` subparser registration; the `action == "check"` branch of `cmd_hook`, ~lines 846-878)
+- Test: `carta/tests/test_cli.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `carta/tests/test_cli.py` (the file already has `import pytest` and the
+slice-1 cmd_hook tests):
+
+```python
+def test_cmd_hook_check_diff_uses_collect_range(tmp_path, monkeypatch, capsys):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleFinding, StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+
+    captured = {}
+    def fake_collect_range(repo_root, c, range_spec):
+        captured["range_spec"] = range_spec
+        return [object()]
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", fake_collect_range)
+    # If collect_range is wrongly bypassed, these would blow up the test:
+    monkeypatch.setattr("carta.hook.stale_scan.collect_staged", lambda r, c: (_ for _ in ()).throw(AssertionError("collect_staged should not be called")))
+    monkeypatch.setattr("carta.hook.stale_scan.collect_pushed", lambda r, c, s: (_ for _ in ()).throw(AssertionError("collect_pushed should not be called")))
+    result = StaleScanResult(findings=[StaleFinding("docs/a.md", "## A", "snip", "docs/b.md", 0.9)], scanned=1)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: result)
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": False})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0                         # warn-only default
+    assert captured["range_spec"] == "origin/main...HEAD"
+    assert "may be stale" in capsys.readouterr().err
+
+
+def test_cmd_hook_check_diff_default_range(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+
+    captured = {}
+    def fake_collect_range(repo_root, c, range_spec):
+        captured["range_spec"] = range_spec
+        return [object()]
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", fake_collect_range)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: StaleScanResult(scanned=1))
+
+    # bare --diff arrives as "" (argparse const); handler must resolve the default range.
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "", "fail_on_stale": False})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0
+    # repo_root (tmp_path) is not a git repo → _default_branch falls back to "main"
+    assert captured["range_spec"] == "main...HEAD"
+
+
+def test_cmd_hook_check_diff_fail_on_stale_exits_one(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleFinding, StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", lambda r, c, rng: [object()])
+    result = StaleScanResult(findings=[StaleFinding("docs/a.md", "## A", "s", "docs/b.md", 0.9)], scanned=1)
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: result)
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": True})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 1                          # --fail-on-stale + findings
+
+
+def test_cmd_hook_check_diff_no_findings_exits_zero(tmp_path, monkeypatch):
+    import carta.cli as cli
+    from carta.hook.stale_scan import StaleScanResult
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {"hooks": {"stale_scan": {"enabled": True, "block_on_stale": False}}}
+    monkeypatch.setattr(cli, "find_config", lambda: cfg_path)
+    monkeypatch.setattr("carta.config.load_config", lambda p: cfg)
+    monkeypatch.setattr("carta.hook.stale_scan.collect_range", lambda r, c, rng: [object()])
+    monkeypatch.setattr("carta.hook.stale_scan.run_stale_scan", lambda r, c, d: StaleScanResult(findings=[], scanned=1))
+
+    args = type("A", (), {"command": "hook", "hook_action": "check", "stage": "pre-push",
+                          "diff": "origin/main...HEAD", "fail_on_stale": True})()
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_hook(args)
+    assert exc.value.code == 0                          # no findings → exit 0 even with --fail-on-stale
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest carta/tests/test_cli.py -k "cmd_hook_check_diff" -v`
+Expected: FAIL — `AttributeError`/`TypeError` because `cmd_hook` doesn't yet read
+`args.diff` / `args.fail_on_stale` and still calls `collect_staged`/`collect_pushed`.
+
+- [ ] **Step 3: Add the two subparser flags**
+
+In `carta/cli.py`, find the `check` subparser registration (the line
+`hook_check = hook_sub.add_parser("check", ...)` followed by its
+`hook_check.add_argument("--stage", ...)`). Add immediately after the `--stage` line:
+
+```python
+    hook_check.add_argument(
+        "--diff", nargs="?", const="", default=None, metavar="RANGE",
+        help="Scan docs changed across a git range instead of staged/pushed "
+             "(bare --diff uses <default-branch>...HEAD)",
+    )
+    hook_check.add_argument(
+        "--fail-on-stale", action="store_true",
+        help="Exit 1 if any stale finding (default: warn-only, exit 0)",
+    )
+```
+
+- [ ] **Step 4: Branch the collection + exit logic in `cmd_hook`**
+
+In the `action == "check"` branch of `cmd_hook`, replace the collection `try/except`
+block AND the final exit block. Replace this current code:
+
+```python
+        stage = args.stage
+        try:
+            if stage == "pre-commit":
+                docs = stale_scan.collect_staged(repo_root, cfg)
+            else:
+                stdin_lines = [] if sys.stdin.isatty() else sys.stdin.read().splitlines()
+                docs = stale_scan.collect_pushed(repo_root, cfg, stdin_lines)
+        except Exception as e:
+            print(f"carta stale-scan: collection error (fail-open): {e}", file=sys.stderr)
+            sys.exit(0)
+        if not docs:
+            sys.exit(0)
+        try:
+            result = stale_scan.run_stale_scan(repo_root, cfg, docs)
+        except Exception as e:
+            print(f"carta stale-scan: scan error (fail-open): {e}", file=sys.stderr)
+            sys.exit(0)
+        _print_stale_result(result, scfg)
+        if result.findings and scfg.get("block_on_stale", False):
+            sys.exit(1)
+        sys.exit(0)
+```
+
+with:
+
+```python
+        stage = args.stage
+        diff = getattr(args, "diff", None)
+        try:
+            if diff is not None:
+                range_spec = diff or f"{stale_scan._default_branch(repo_root)}...HEAD"
+                docs = stale_scan.collect_range(repo_root, cfg, range_spec)
+            elif stage == "pre-commit":
+                docs = stale_scan.collect_staged(repo_root, cfg)
+            else:
+                stdin_lines = [] if sys.stdin.isatty() else sys.stdin.read().splitlines()
+                docs = stale_scan.collect_pushed(repo_root, cfg, stdin_lines)
+        except Exception as e:
+            print(f"carta stale-scan: collection error (fail-open): {e}", file=sys.stderr)
+            sys.exit(0)
+        if not docs:
+            sys.exit(0)
+        try:
+            result = stale_scan.run_stale_scan(repo_root, cfg, docs)
+        except Exception as e:
+            print(f"carta stale-scan: scan error (fail-open): {e}", file=sys.stderr)
+            sys.exit(0)
+        _print_stale_result(result, scfg)
+        fail = getattr(args, "fail_on_stale", False) or scfg.get("block_on_stale", False)
+        if result.findings and fail:
+            sys.exit(1)
+        sys.exit(0)
+```
+
+> `diff or <default>` resolves bare `--diff` (argparse `const=""`, falsy) to the default
+> range while keeping an explicit value. `stale_scan._default_branch` is module-qualified
+> (same module already imported as `stale_scan`). Collectors stay module-qualified so the
+> tests' monkeypatches bind.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest carta/tests/test_cli.py -k "cmd_hook" -v`
+Expected: PASS — the 4 new diff tests AND the slice-1 cmd_hook tests (no regression).
+
+- [ ] **Step 6: Confirm argparse wiring**
+
+Run: `python -m carta hook check --help`
+Expected: help text lists `--diff [RANGE]` and `--fail-on-stale`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add carta/cli.py carta/tests/test_cli.py
+git commit -m "feat(cli): carta hook check --diff / --fail-on-stale (#10 slice 2)"
+```
+
+End the commit message with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 3: Docs + full-suite verification + smoke
+
+**Files:**
+- Modify: `CLAUDE.md` (Hook section)
+- Modify: `docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md` (status → shipped)
+
+- [ ] **Step 1: Update CLAUDE.md hook surface**
+
+In `CLAUDE.md`, find the paragraph (added in slice 1) that begins "A second, opt-in hook
+— `carta hook` —" and append this sentence to the end of that paragraph:
+
+```markdown
+Run on demand as a whole-branch pre-PR audit with `carta hook check --diff [range]`
+(default range `<default-branch>...HEAD`; `--fail-on-stale` to exit non-zero).
+```
+
+- [ ] **Step 2: Mark the spec shipped**
+
+In `docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md`, change the
+frontmatter `status: draft` to `status: shipped`.
+
+- [ ] **Step 3: Run the FULL suite**
+
+Run: `python -m pytest carta/ -q`
+Expected: PASS — slice-1 baseline was 970 passed / 1 skipped; expect 970 + the new
+Task 1 & 2 tests, 0 failures, 1 skip.
+
+- [ ] **Step 4: Manual smoke (no graph required)**
+
+Run:
+```bash
+cd /tmp && rm -rf cartadifftest && mkdir cartadifftest && cd cartadifftest && git init -q
+# In a non-Carta repo, --diff check must fail open (exit 0):
+carta hook check --diff origin/main...HEAD; echo "exit: $?"
+```
+Expected: exit 0 (no Carta config → fail-open). `carta hook check --help` shows the new
+flags. (The real scan path needs a Carta-initialised repo with Qdrant/Ollama; that is
+covered by the unit tests and is the maintainer's corpus validation, not this commit.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md
+git commit -m "docs(hook): document carta hook check --diff; mark spec shipped (#10 slice 2)"
+```
+
+End the commit message with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** `--diff [range]` default-range resolution (Task 2 Steps 3-4); `collect_range` + shared loop (Task 1); `--fail-on-stale` / `block_on_stale` exit (Task 2 Step 4); no-regression for non-`--diff` `check` (slice-1 cmd_hook tests stay green); fail-open preserved (the collection/scan try/excepts are untouched in structure); docs + spec-shipped (Task 3). All spec sections map to a task.
+- **Type/interface consistency:** `collect_range(repo_root, cfg, range_spec)`; `_collect_from_ranges(repo_root, cfg, ranges: list[(rng, tip)])`; `_range_tip(range_spec) -> str`. `cmd_hook` calls `stale_scan.collect_range(repo_root, cfg, range_spec)` and `stale_scan._default_branch(repo_root)` — both real symbols in `stale_scan.py`.
+- **No core changes:** `run_stale_scan`, `_stale_judge`, `sections_from_markdown`, `chunk_text`, `StaleFinding`, `_print_stale_result`, and the `hooks.stale_scan` config block are all untouched.
+- **Monkeypatch binding:** all collectors/scan are referenced module-qualified (`stale_scan.X`) so the Task 2 tests bind, consistent with slice 1.

--- a/docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md
+++ b/docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md
@@ -1,0 +1,148 @@
+---
+id: 2026-06-16-stale-reference-diff-scan-design
+title: Stale-reference diff-range scan (local pre-PR audit)
+status: draft
+related: [2026-06-15-stale-reference-git-hook-design]
+date: 2026-06-16
+related_issue: Ian-q/Carta#10
+---
+
+# Stale-reference diff-range scan (#10, slice 2 of 4)
+
+## Background
+
+Slice 1 shipped the local stale-reference git hook: `carta hook install` writes a
+managed `pre-push` (or `pre-commit`) shim, and `carta hook check` collects the
+docs changed by the staged set / pushed commit range, sections them, searches the
+knowledge graph per section, and runs a small Ollama judge that warns when a
+section appears **superseded** by an authoritative doc in the graph. Everything
+fails open. The reusable core is `run_stale_scan` in `carta/hook/stale_scan.py`.
+
+Issue #10 originally framed slice 2 as a **CI / PR diff scan** (`carta scan
+--diff … --report github-annotations` emitting GitHub `::warning::` annotations).
+This spec deliberately **does not** build that. The scan is *semantic*: it needs
+the embedded knowledge graph (Qdrant) and an embedder (Ollama) reachable, plus a
+Carta config. A GitHub-hosted CI runner has none of these, so a remote-CI path
+would require exporting the embeddings as an artifact, standing up Qdrant + Ollama
+as service containers, importing, and scanning against a graph only as fresh as
+the last export — heavy infrastructure for a warn-only check.
+
+A developer's machine already runs the live graph. So slice 2 is reframed as a
+**local, on-demand pre-PR audit**: scan every doc changed across the whole branch
+versus its base, run locally against the live graph, with human-readable output.
+
+### How this differs from the slice-1 pre-push hook
+
+- The **pre-push hook** scans the docs changed in each push's *delta*, automatically, on every push.
+- The **diff-range scan** scans every doc changed across the **whole branch vs its base** (`<base>...HEAD`), **on demand**. You run it deliberately to review the entire PR's doc changes at once — before opening the PR, or while it's open to re-check.
+
+## Decision summary
+
+- **Local-first, not remote CI.** No GitHub annotations, no PR-comment posting, no sample CI workflow in this slice.
+- **Plain output only.** Reuse the existing `_print_stale_result` human reporter; no machine-readable format, and therefore no line-number / heading-line mapping (line numbers were only needed for annotations).
+- **Warn-only by default.** Exit 0 even on findings; `--fail-on-stale` (or `block_on_stale: true` in config) forces exit 1.
+
+## Design
+
+### CLI surface — two new flags on `carta hook check`
+
+```
+carta hook check [--stage pre-push|pre-commit] [--diff [RANGE]] [--fail-on-stale]
+```
+
+- `--diff [RANGE]` — scan the docs changed across a git range instead of the
+  staged set / pushed commits. The argument is optional:
+  - `--diff` (no value) → default range `<default-branch>...HEAD`, where the
+    default branch is resolved by the existing `_default_branch(repo_root)`
+    helper (falls back to `main`).
+  - `--diff origin/main...HEAD` (explicit value) → that range verbatim.
+  - When `--diff` is absent, `check` behaves exactly as in slice 1 (staged for
+    `pre-commit`, pushed-range for `pre-push`). `--diff` and `--stage` are
+    independent; `--stage` is ignored when `--diff` is supplied.
+- `--fail-on-stale` — exit 1 when any finding exists. Default (flag absent) stays
+  exit 0 (warn-only). `block_on_stale: true` in `hooks.stale_scan` config also
+  forces exit 1, so the flag is an ad-hoc, per-invocation equivalent.
+
+### New collector — `collect_range`
+
+Add to `carta/hook/stale_scan.py`:
+
+```
+collect_range(repo_root: Path, cfg: dict, range_spec: str) -> list[ChangedDoc]
+```
+
+- `git diff --name-only --diff-filter=ACM <range_spec>` lists changed paths.
+- Filter to Carta's doc scope via the existing `_in_doc_scope`.
+- Read each path's content **at the range tip** via `git show <tip>:<path>`,
+  where `tip` is the right operand of the range (`A..B` / `A...B` → `B`;
+  a trailing-empty right side, e.g. `A...`, → `HEAD`).
+- Fails open per file (a `git show` error skips that file).
+
+The slice-1 `collect_pushed` already contains this exact inner loop (diff a
+range, scope-filter, `git show <tip>:<path>`, dedupe). Factor that loop into a
+shared private helper (e.g. `_collect_range_docs(repo_root, cfg, rng, tip)`) and
+have both `collect_pushed` and `collect_range` call it, so the two collectors do
+not duplicate logic. This refactor must keep all existing slice-1 collector tests
+green (behavior-preserving).
+
+### Reused unchanged
+
+`run_stale_scan`, `_stale_judge` / `ollama_yesno`, the `hooks.stale_scan` config
+block (threshold, judge model, timeout, `max_judge_calls`, `block_on_stale`), and
+the `_print_stale_result` plain reporter in `carta/cli.py`. No new config keys; no
+new module; no change to `sections_from_markdown`, `chunk_text`, or `StaleFinding`.
+
+### `cmd_hook` check-path changes
+
+In the `action == "check"` branch of `cmd_hook`:
+
+1. Resolve config and `repo_root` as today (fail open on missing config → exit 0; disabled → exit 0).
+2. Collection:
+   - if `args.diff` is set → `range_spec = <default-branch>...HEAD` when the value
+     signals "use default", else the explicit value; `docs = stale_scan.collect_range(repo_root, cfg, range_spec)`.
+   - else → existing staged / pushed collection by stage.
+   - Collection errors fail open (exit 0), as in slice 1.
+3. No docs → exit 0.
+4. `result = stale_scan.run_stale_scan(repo_root, cfg, docs)` (fail open → exit 0 on error).
+5. `_print_stale_result(result, scfg)` (plain, to stderr).
+6. Exit 1 if `result.findings` **and** (`args.fail_on_stale` **or** `scfg["block_on_stale"]`); else exit 0.
+
+Collectors/scan stay module-qualified (`stale_scan.collect_range(...)`,
+`stale_scan.run_stale_scan(...)`) so tests can monkeypatch them, consistent with
+slice 1.
+
+## Out of scope (other #10 slices / deferred)
+
+- GitHub `::warning::` annotations and any `--report` format (deferred; revisit only if a graph-accessible runner is ever set up).
+- PR-comment posting via the GitHub API.
+- A sample/committed CI workflow, and any `carta export`/import-into-CI tooling.
+- Line-number / heading-line mapping of findings (only needed for annotations).
+- Scanning changed code/config (vs docs).
+- Query-time agent context hints (slice 3) and the expanded CLAUDE.md `/doc-search` block (slice 4).
+
+## Acceptance
+
+- `carta hook check --diff origin/main...HEAD` scans the docs changed on the
+  branch vs the given base and warns on superseded sections, using the live graph.
+- `carta hook check --diff` (no value) uses the `<default-branch>...HEAD` range.
+- With no `--diff`, `check` behaves exactly as slice 1 (no regression).
+- A run with findings exits 0 by default and exits 1 under `--fail-on-stale`
+  (or `block_on_stale: true`).
+- The scan fails open on any infrastructure error (no config, Qdrant/Ollama
+  unreachable, bad range) — never a non-zero exit from a transient failure.
+- `collect_range` and `collect_pushed` share one collection loop; all slice-1
+  collector tests remain green.
+- All new behaviour is covered by tests written test-first, and the full suite
+  stays green.
+
+## Testing approach
+
+- `collect_range` against a real temp git repo: a two-commit range surfaces the
+  changed doc at the tip's content; non-doc and out-of-scope paths are excluded;
+  an explicit `A..B` range and the default `<branch>...HEAD` range both work.
+- The shared-loop refactor: existing `collect_pushed` tests stay green unchanged.
+- `cmd_hook` with `--diff`: monkeypatch `stale_scan.collect_range` /
+  `run_stale_scan`; assert it collects via the range path and prints findings.
+- Exit codes: findings + `--fail-on-stale` → exit 1; findings without it → exit 0;
+  no findings → exit 0; default-range resolution when `--diff` has no value.
+- Argparse: `--diff` optional-value parsing (absent vs bare vs explicit).

--- a/docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md
+++ b/docs/superpowers/specs/2026-06-16-stale-reference-diff-scan-design.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-06-16-stale-reference-diff-scan-design
 title: Stale-reference diff-range scan (local pre-PR audit)
-status: draft
+status: shipped
 related: [2026-06-15-stale-reference-git-hook-design]
 date: 2026-06-16
 related_issue: Ian-q/Carta#10


### PR DESCRIPTION
## Summary

Adds a **local, on-demand pre-PR audit** mode to the stale-reference hook (issue #10, **slice 2 of 4**). `carta hook check` gains `--diff [range]` to scan every doc changed across a git range (whole branch vs base) against the knowledge graph, plus `--fail-on-stale` to opt into a non-zero exit.

```bash
carta hook check --diff origin/main...HEAD   # audit the whole branch's doc changes
carta hook check --diff                       # bare flag → default range <default-branch>...HEAD
carta hook check --diff origin/main...HEAD --fail-on-stale   # exit 1 on findings
```

### Why local, not remote CI
The original #10 sketch proposed a CI scan emitting GitHub `::warning::` annotations. We deliberately **didn't** build that: the scan is *semantic* — it needs the embedded knowledge graph (Qdrant) + an embedder (Ollama) + a Carta config, none of which a hosted CI runner has. Shipping the graph to CI (export → Qdrant/Ollama service containers → import) is heavy and goes stale. A dev's machine already runs the live graph, so the same diff-range scan runs **locally** with zero extra infra — run it before opening a PR, or while it's open to re-check. (Discussed and agreed during brainstorming; see spec.)

### How it differs from slice 1
The slice-1 **pre-push hook** scans each push's *delta* automatically. Slice 2 scans the **whole branch vs its base**, **on demand** — a deliberate one-shot audit of the entire PR's doc changes.

### What's new (additive; slice-1 core untouched)
- `collect_range(repo_root, cfg, range_spec)` in `stale_scan.py` — diff a range, scope-filter, read each doc at the range tip.
- `_collect_from_ranges` — the file-collection inner loop, **factored out of `collect_pushed`** (behavior-preserving) so both collectors share it; `_range_tip` derives the range's tip.
- `--diff [RANGE]` / `--fail-on-stale` on `carta hook check`; the check handler routes to `collect_range` when `--diff` is given and exits 1 only on `findings AND (--fail-on-stale OR block_on_stale)`.

**Reused unchanged:** `run_stale_scan`, the judge, `hooks.stale_scan` config, the plain reporter. No new config keys, no new module, no GitHub/annotation/line-number machinery.

## Test Plan
- [x] Full suite green: **977 passed, 1 skipped** (970 baseline + 7 new)
- [x] `collect_range` / `_range_tip` unit tests (real temp git repo: two/three-dot ranges, tip content, scope exclusion)
- [x] Refactor is behavior-preserving — all slice-1 `collect_pushed`/`collect_staged` tests stay green
- [x] `cmd_hook --diff`: routes to `collect_range`, resolves the default range (`main...HEAD`), and exit codes (warn-only default; `--fail-on-stale` → 1; no findings → 0)
- [x] Independent reviewer cleared the CLI integration (spec + quality)
- [x] Smoke: `--diff` (explicit and bare) in a non-Carta repo fails open (exit 0); `--help` shows both flags

Built TDD via subagent-driven development. Spec & plan: `docs/superpowers/specs|plans/2026-06-16-stale-reference-diff-scan*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)