### PR TITLE
feat: CLAUDE.md /doc-search guidance block in bootstrap (#10 slice 4)

### DIFF
--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -421,14 +421,56 @@ def _create_mcp_configs(project_root: Path) -> None:
     print(f"  MCP configs: {opencode_path}")
 
 
+_CARTA_CLAUDE_SENTINEL = "<!-- carta:guidance:start -->"
+_CARTA_CLAUDE_LEGACY = "Carta is active"
+
+
+def _carta_claude_block(project_name: str) -> str:
+    """The Carta /doc-search guidance block injected into a project's CLAUDE.md.
+
+    Wrapped in carta:guidance markers for idempotent (re)writes; the trailing
+    'Carta is active' comment is both a diagnostic breadcrumb and the legacy
+    idempotency string."""
+    return (
+        "<!-- carta:guidance:start -->\n"
+        "## Carta Knowledge Graph\n"
+        "\n"
+        "**Search the docs before you assume.** This project's specs (components, protocols,\n"
+        "config keys, design decisions) may have changed since the code — or your training — was\n"
+        "written. Carta provides semantic search over them via `/doc-search`.\n"
+        "\n"
+        "**Run `/doc-search` whenever a prompt names one of these — query it like so:**\n"
+        "\n"
+        "| Prompt mentions… | Search |\n"
+        "|---|---|\n"
+        "| A component or module | `/doc-search \"<name> responsibilities\"` |\n"
+        "| An API, protocol, or data format | `/doc-search \"<name> spec\"` |\n"
+        "| A config key or flag | `/doc-search \"<key> configuration\"` |\n"
+        "| A file/path or a design decision | `/doc-search \"<topic> design\"` |\n"
+        "\n"
+        "Maintenance (only when asked, or after editing docs): `/doc-audit` (flag\n"
+        "stale/contradictory docs), `/doc-embed` (re-index).\n"
+        "\n"
+        f"<!-- Carta is active. Collections: {project_name}_doc, "
+        f"{project_name}_session, {project_name}_notes -->\n"
+        "<!-- carta:guidance:end -->\n"
+    )
+
+
 def _append_claude_md(project_root: Path, project_name: str) -> None:
+    """Inject the Carta guidance block into CLAUDE.md (create if absent, append if
+    present). Idempotent: skips if the block marker or the legacy 'Carta is active'
+    string is already present."""
     claude_md = project_root / "CLAUDE.md"
-    note = f"\n<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_notes -->\n"
+    block = _carta_claude_block(project_name)
     if claude_md.exists():
-        if "Carta is active" in claude_md.read_text():
+        text = claude_md.read_text(encoding="utf-8")
+        if _CARTA_CLAUDE_SENTINEL in text or _CARTA_CLAUDE_LEGACY in text:
             return
-        with open(claude_md, "a") as f:
-            f.write(note)
+        with open(claude_md, "a", encoding="utf-8") as f:
+            f.write("\n" + block)
+    else:
+        claude_md.write_text(f"# {project_name}\n\n{block}", encoding="utf-8")
 
 
 def _create_agents_md(project_root: Path, project_name: str) -> None:

--- a/carta/install/tests/test_bootstrap.py
+++ b/carta/install/tests/test_bootstrap.py
@@ -261,3 +261,57 @@ def test_remove_plugin_cache_assertion_on_residue(tmp_path, capsys):
     assert result is False
     captured = capsys.readouterr()
     assert "plugin cache residue" in captured.err
+
+
+def test_carta_claude_block_content():
+    from carta.install.bootstrap import _carta_claude_block
+    block = _carta_claude_block("acme")
+    assert "<!-- carta:guidance:start -->" in block
+    assert "<!-- carta:guidance:end -->" in block
+    assert "## Carta Knowledge Graph" in block
+    assert "Search the docs before you assume." in block
+    assert '`/doc-search "<name> responsibilities"`' in block   # trigger table row
+    assert "/doc-audit" in block and "/doc-embed" in block       # maintenance line
+    # collections comment interpolates the project name and stays inside the block
+    assert "Carta is active. Collections: acme_doc, acme_session, acme_notes" in block
+
+
+def test_append_claude_md_appends_to_existing(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    (tmp_path / "CLAUDE.md").write_text("# My Project\n\nExisting guidance.\n")
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Existing guidance." in content                       # prior content preserved
+    assert "## Carta Knowledge Graph" in content
+    assert content.count("<!-- carta:guidance:start -->") == 1
+
+
+def test_append_claude_md_creates_when_absent(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    assert not (tmp_path / "CLAUDE.md").exists()
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert content.startswith("# acme")
+    assert "## Carta Knowledge Graph" in content
+    assert "<!-- carta:guidance:start -->" in content
+
+
+def test_append_claude_md_idempotent_on_marker(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    (tmp_path / "CLAUDE.md").write_text("# My Project\n")
+    _append_claude_md(tmp_path, "acme")
+    _append_claude_md(tmp_path, "acme")                          # second call is a no-op
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert content.count("<!-- carta:guidance:start -->") == 1
+
+
+def test_append_claude_md_skips_legacy_oneliner(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    # A repo bootstrapped by an older Carta has only the legacy comment.
+    (tmp_path / "CLAUDE.md").write_text(
+        "# My Project\n\n<!-- Carta is active. Collections: acme_doc, acme_session, acme_notes -->\n"
+    )
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "<!-- carta:guidance:start -->" not in content        # not upgraded / not doubled
+    assert content.count("Carta is active") == 1

--- a/docs/superpowers/plans/2026-06-16-claude-md-doc-search-guidance.md
+++ b/docs/superpowers/plans/2026-06-16-claude-md-doc-search-guidance.md
@@ -1,0 +1,239 @@
+# CLAUDE.md /doc-search guidance block — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `carta init`'s CLAUDE.md injection from a one-line comment into an on-by-default `## Carta Knowledge Graph` guidance block that tells any agent the knowledge graph exists, when to `/doc-search`, and how — creating CLAUDE.md if absent, appending if present, idempotently.
+
+**Architecture:** A pure `_carta_claude_block(project_name)` builds the marker-wrapped block; the reworked `_append_claude_md` writes it (create-if-absent / append-if-present) guarded against double-injection by the start marker or the legacy `"Carta is active"` string.
+
+**Tech Stack:** Python 3.10+ (stdlib `pathlib`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `carta/install/bootstrap.py` (modify) | Add `_carta_claude_block`; rework `_append_claude_md` (create/append/idempotent) |
+| `carta/install/tests/test_bootstrap.py` (modify) | New unit tests for the block + the three write paths; keep the existing append test green |
+| `docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md` (modify) | `status: draft` → `status: shipped` |
+
+**Run the whole suite with:** `python -m pytest carta/ -q`
+
+---
+
+## Task 1: `_carta_claude_block` + reworked `_append_claude_md`
+
+The current `_append_claude_md` (in `carta/install/bootstrap.py`) appends a single
+`<!-- Carta is active. Collections: … -->` comment, only if CLAUDE.md exists. Replace it
+with a block-writer that creates-if-absent, appends-if-present, and is idempotent.
+
+**Files:**
+- Modify: `carta/install/bootstrap.py` (`_append_claude_md`, ~lines 424-431)
+- Test: `carta/install/tests/test_bootstrap.py` (append new tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `carta/install/tests/test_bootstrap.py`:
+
+```python
+def test_carta_claude_block_content():
+    from carta.install.bootstrap import _carta_claude_block
+    block = _carta_claude_block("acme")
+    assert "<!-- carta:guidance:start -->" in block
+    assert "<!-- carta:guidance:end -->" in block
+    assert "## Carta Knowledge Graph" in block
+    assert "Search the docs before you assume." in block
+    assert '`/doc-search "<name> responsibilities"`' in block   # trigger table row
+    assert "/doc-audit" in block and "/doc-embed" in block       # maintenance line
+    # collections comment interpolates the project name and stays inside the block
+    assert "Carta is active. Collections: acme_doc, acme_session, acme_notes" in block
+
+
+def test_append_claude_md_appends_to_existing(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    (tmp_path / "CLAUDE.md").write_text("# My Project\n\nExisting guidance.\n")
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Existing guidance." in content                       # prior content preserved
+    assert "## Carta Knowledge Graph" in content
+    assert content.count("<!-- carta:guidance:start -->") == 1
+
+
+def test_append_claude_md_creates_when_absent(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    assert not (tmp_path / "CLAUDE.md").exists()
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert content.startswith("# acme")
+    assert "## Carta Knowledge Graph" in content
+    assert "<!-- carta:guidance:start -->" in content
+
+
+def test_append_claude_md_idempotent_on_marker(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    (tmp_path / "CLAUDE.md").write_text("# My Project\n")
+    _append_claude_md(tmp_path, "acme")
+    _append_claude_md(tmp_path, "acme")                          # second call is a no-op
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert content.count("<!-- carta:guidance:start -->") == 1
+
+
+def test_append_claude_md_skips_legacy_oneliner(tmp_path):
+    from carta.install.bootstrap import _append_claude_md
+    # A repo bootstrapped by an older Carta has only the legacy comment.
+    (tmp_path / "CLAUDE.md").write_text(
+        "# My Project\n\n<!-- Carta is active. Collections: acme_doc, acme_session, acme_notes -->\n"
+    )
+    _append_claude_md(tmp_path, "acme")
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "<!-- carta:guidance:start -->" not in content        # not upgraded / not doubled
+    assert content.count("Carta is active") == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest carta/install/tests/test_bootstrap.py -k "carta_claude_block or append_claude_md" -v`
+Expected: FAIL — `ImportError: cannot import name '_carta_claude_block'` and/or the
+append/create/idempotent assertions fail against the current one-line implementation.
+
+- [ ] **Step 3: Implement the block builder + reworked writer**
+
+In `carta/install/bootstrap.py`, replace the current `_append_claude_md` function
+(the 8-line version that appends only the `note` comment) with the following — the new
+`_carta_claude_block` helper, two module-local sentinel constants, and the reworked
+`_append_claude_md`:
+
+```python
+_CARTA_CLAUDE_SENTINEL = "<!-- carta:guidance:start -->"
+_CARTA_CLAUDE_LEGACY = "Carta is active"
+
+
+def _carta_claude_block(project_name: str) -> str:
+    """The Carta /doc-search guidance block injected into a project's CLAUDE.md.
+
+    Wrapped in carta:guidance markers for idempotent (re)writes; the trailing
+    'Carta is active' comment is both a diagnostic breadcrumb and the legacy
+    idempotency string."""
+    return (
+        "<!-- carta:guidance:start -->\n"
+        "## Carta Knowledge Graph\n"
+        "\n"
+        "**Search the docs before you assume.** This project's specs (components, protocols,\n"
+        "config keys, design decisions) may have changed since the code — or your training — was\n"
+        "written. Carta provides semantic search over them via `/doc-search`.\n"
+        "\n"
+        "**Run `/doc-search` whenever a prompt names one of these — query it like so:**\n"
+        "\n"
+        "| Prompt mentions… | Search |\n"
+        "|---|---|\n"
+        "| A component or module | `/doc-search \"<name> responsibilities\"` |\n"
+        "| An API, protocol, or data format | `/doc-search \"<name> spec\"` |\n"
+        "| A config key or flag | `/doc-search \"<key> configuration\"` |\n"
+        "| A file/path or a design decision | `/doc-search \"<topic> design\"` |\n"
+        "\n"
+        "Maintenance (only when asked, or after editing docs): `/doc-audit` (flag\n"
+        "stale/contradictory docs), `/doc-embed` (re-index).\n"
+        "\n"
+        f"<!-- Carta is active. Collections: {project_name}_doc, "
+        f"{project_name}_session, {project_name}_notes -->\n"
+        "<!-- carta:guidance:end -->\n"
+    )
+
+
+def _append_claude_md(project_root: Path, project_name: str) -> None:
+    """Inject the Carta guidance block into CLAUDE.md (create if absent, append if
+    present). Idempotent: skips if the block marker or the legacy 'Carta is active'
+    string is already present."""
+    claude_md = project_root / "CLAUDE.md"
+    block = _carta_claude_block(project_name)
+    if claude_md.exists():
+        text = claude_md.read_text(encoding="utf-8")
+        if _CARTA_CLAUDE_SENTINEL in text or _CARTA_CLAUDE_LEGACY in text:
+            return
+        with open(claude_md, "a", encoding="utf-8") as f:
+            f.write("\n" + block)
+    else:
+        claude_md.write_text(f"# {project_name}\n\n{block}", encoding="utf-8")
+```
+
+> Note: the block contains non-ASCII (`…`, `—`), so all reads/writes use
+> `encoding="utf-8"` to stay correct on non-UTF-8-default platforms (e.g. Windows).
+
+- [ ] **Step 4: Run tests to verify they pass (new + the existing append test)**
+
+Run: `python -m pytest carta/install/tests/test_bootstrap.py -v`
+Expected: PASS — the 5 new tests pass AND the existing `test_bootstrap_appends_claude_md`
+stays green (it asserts `"Carta is active" in content`, still true because the collections
+comment lives inside the block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/install/bootstrap.py carta/install/tests/test_bootstrap.py
+git commit -m "feat(init): full /doc-search guidance block in CLAUDE.md bootstrap (#10 slice 4)"
+```
+
+End the commit message with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 2: Mark spec shipped + full-suite verification + smoke
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md`
+
+- [ ] **Step 1: Mark the spec shipped**
+
+In `docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md`, change the
+frontmatter `status: draft` to `status: shipped`.
+
+- [ ] **Step 2: Run the FULL suite**
+
+Run: `python -m pytest carta/ -q`
+Expected: PASS — slice-1/2 baseline was 977 passed / 1 skipped; expect 977 + the 5 new
+Task 1 tests, 0 failures, 1 skip.
+
+- [ ] **Step 3: Manual smoke (no services required)**
+
+Run (exercises both the create and append paths via the real functions):
+```bash
+cd /tmp && rm -rf cartamdtest && mkdir -p cartamdtest/empty cartamdtest/existing
+printf '# Existing\n\nSome notes.\n' > cartamdtest/existing/CLAUDE.md
+WT=/Users/ian/dev/doc-audit-cc/.claude/worktrees/scanner-noise-fixes
+PYTHONPATH="$WT" python -c "
+from pathlib import Path
+from carta.install.bootstrap import _append_claude_md
+_append_claude_md(Path('/tmp/cartamdtest/empty'), 'demo')
+_append_claude_md(Path('/tmp/cartamdtest/existing'), 'demo')
+_append_claude_md(Path('/tmp/cartamdtest/existing'), 'demo')  # idempotent
+for p in ['empty/CLAUDE.md', 'existing/CLAUDE.md']:
+    t = Path('/tmp/cartamdtest', p).read_text()
+    print(p, '| starts#', t.startswith('# '), '| blocks', t.count('carta:guidance:start'), '| has table', '/doc-search \"<name> spec\"' in t)
+"
+rm -rf /tmp/cartamdtest
+```
+Expected: `empty/CLAUDE.md` starts with `#` and has exactly 1 block; `existing/CLAUDE.md`
+has exactly 1 block (idempotent across the two calls) and preserves "Some notes."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md
+git commit -m "docs: mark CLAUDE.md guidance spec shipped (#10 slice 4)"
+```
+
+End the commit message with a blank line then:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** block content + markers (Task 1 `_carta_claude_block`); append/create/idempotent-marker/idempotent-legacy (Task 1 tests + writer); on-by-default & no config gate (no config touched); collections comment interpolation (block); spec-shipped + verify (Task 2). All spec sections map to a task.
+- **No regression:** the existing `test_bootstrap_appends_claude_md` stays green unchanged (asserts `"Carta is active"`, still present). Do NOT delete or weaken it.
+- **Encoding:** all CLAUDE.md reads/writes use `encoding="utf-8"` because the block has `…`/`—`.
+- **Scope:** only `_append_claude_md`/`_carta_claude_block` change. Do not touch `_create_agents_md`, the `anchor_doc` config, or this repo's own CLAUDE.md.

--- a/docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md
@@ -1,0 +1,151 @@
+---
+id: 2026-06-16-claude-md-doc-search-guidance-design
+title: CLAUDE.md /doc-search guidance block in bootstrap
+status: draft
+related: [2026-06-15-stale-reference-git-hook-design, 2026-06-16-stale-reference-diff-scan-design]
+date: 2026-06-16
+related_issue: Ian-q/Carta#10
+---
+
+# CLAUDE.md /doc-search guidance block (#10, slice 4 of 4)
+
+## Background
+
+Issue #10's fourth mechanism is "improved CLAUDE.md anchor-doc guidance": make it
+obvious to every agent — without prior context — that a queryable knowledge graph
+exists, **when** to search it, and the exact skill to invoke (`/doc-search`). The
+stale-reference detectors (slices 1-2) are only half the story; an agent also needs
+to *proactively* search before assuming it knows the current spec.
+
+Today `carta init`'s `_append_claude_md(project_root, project_name)` in
+`carta/install/bootstrap.py` appends a single HTML comment to an existing CLAUDE.md:
+
+```
+<!-- Carta is active. Collections: <p>_doc, <p>_session, <p>_notes -->
+```
+
+guarded by a `"Carta is active"` substring check, and **only if CLAUDE.md already
+exists** (no file → no write). This slice expands that into a real, on-by-default
+`/doc-search` guidance block.
+
+Slice 3 (query-time context hints) needs no work: the existing `UserPromptSubmit`
+proactive-recall hook already injects scored doc hits on every prompt through a
+three-zone relevance gate. This slice (4) is the last of #10.
+
+## Decision summary
+
+- **On by default.** The block is part of what `carta init` writes — no config gate
+  (matches issue #10's acceptance: everything off-by-default *except* the CLAUDE.md block).
+- **Create-if-absent.** If the repo has no CLAUDE.md, create a minimal one (`# <project>`
+  heading + the block). If it exists, append the block.
+- **Full guidance block**, refined by a `claude-md-improver` pass: lead with the
+  imperative, a trigger→query table (no duplicated "examples"), and demoted maintenance
+  commands so `/doc-search` stands alone.
+- **Idempotent.** Skip if the block's start marker *or* the legacy `"Carta is active"`
+  string is already present (re-running `carta init`, or upgrading a repo that has the
+  old one-liner, never double-injects).
+- **Generic content.** No project-specific examples (the issue's Teensy/CAN specifics
+  are dropped); categories are component/API/config/path/design-decision.
+- **Does not** retro-edit this Carta repo's own CLAUDE.md — only future `carta init` runs.
+
+## Design
+
+### The injected block
+
+`_carta_claude_block(project_name: str) -> str` returns (pure function, testable):
+
+```markdown
+<!-- carta:guidance:start -->
+## Carta Knowledge Graph
+
+**Search the docs before you assume.** This project's specs (components, protocols,
+config keys, design decisions) may have changed since the code — or your training — was
+written. Carta provides semantic search over them via `/doc-search`.
+
+**Run `/doc-search` whenever a prompt names one of these — query it like so:**
+
+| Prompt mentions… | Search |
+|---|---|
+| A component or module | `/doc-search "<name> responsibilities"` |
+| An API, protocol, or data format | `/doc-search "<name> spec"` |
+| A config key or flag | `/doc-search "<key> configuration"` |
+| A file/path or a design decision | `/doc-search "<topic> design"` |
+
+Maintenance (only when asked, or after editing docs): `/doc-audit` (flag
+stale/contradictory docs), `/doc-embed` (re-index).
+
+<!-- Carta is active. Collections: {project_name}_doc, {project_name}_session, {project_name}_notes -->
+<!-- carta:guidance:end -->
+```
+
+`{project_name}` is interpolated. The `Carta is active. Collections:` comment is kept
+**inside** the block (preserves the existing diagnostic breadcrumb and the legacy
+idempotency string).
+
+### `_append_claude_md` rework
+
+```
+SENTINEL = "<!-- carta:guidance:start -->"
+LEGACY   = "Carta is active"
+
+def _append_claude_md(project_root, project_name):
+    claude_md = project_root / "CLAUDE.md"
+    block = _carta_claude_block(project_name)
+    if claude_md.exists():
+        text = claude_md.read_text()
+        if SENTINEL in text or LEGACY in text:
+            return                      # idempotent — already injected (new or legacy)
+        with open(claude_md, "a") as f:
+            f.write("\n" + block)
+    else:
+        claude_md.write_text(f"# {project_name}\n\n{block}")
+```
+
+- Existing CLAUDE.md without Carta → append the block (leading newline for separation).
+- Existing CLAUDE.md with the new marker OR the legacy `"Carta is active"` line → no-op.
+- No CLAUDE.md → create `# <project_name>\n\n<block>`.
+
+### Constraints / interfaces
+
+- `_carta_claude_block` is the single source of the block text; `_append_claude_md`
+  is the only writer. One responsibility each.
+- No new config keys. `anchor_doc` (default `"CLAUDE.md"`) is unchanged; this slice
+  keeps the hard-coded `CLAUDE.md` target the current code already uses (honoring a
+  custom `anchor_doc` path is out of scope — see below).
+
+## Out of scope
+
+- Honoring a non-default `anchor_doc` path (the current code already hard-codes
+  `CLAUDE.md`; not regressing, not extending).
+- Config-gating the block (issue says it is the one on-by-default behavior).
+- Editing the existing AGENTS.md generator (`_create_agents_md`) — separate artifact.
+- Retro-editing this Carta repo's own CLAUDE.md.
+- Upgrading a repo's pre-existing legacy one-liner to the full block (treated as
+  "already injected" → skipped, to avoid mangling user CLAUDE.md files).
+
+## Acceptance
+
+- After `carta init` in a repo **with** a CLAUDE.md lacking Carta content, the file
+  gains the full `## Carta Knowledge Graph` block (markers, trigger table, `/doc-search`
+  primary, collections comment).
+- After `carta init` in a repo **without** a CLAUDE.md, a new CLAUDE.md is created with
+  a `# <project>` heading and the block.
+- Re-running `carta init` does not duplicate the block (start marker present → skip).
+- A repo whose CLAUDE.md already has the legacy `"Carta is active"` one-liner is left
+  unchanged (no second block appended).
+- The interpolated collections comment names `<project>_doc/_session/_notes`.
+- All new behaviour is covered by tests written test-first; the full suite stays green.
+
+## Testing approach
+
+- `_carta_claude_block("acme")` returns text containing the start/end markers,
+  `## Carta Knowledge Graph`, the `/doc-search` trigger table, the maintenance line,
+  and `acme_doc`/`acme_session`/`acme_notes` in the collections comment.
+- Append path: a tmp CLAUDE.md with prior content gains the block exactly once; prior
+  content is preserved.
+- Create path: no CLAUDE.md → file created with `# <project>` heading + block.
+- Idempotency: second `_append_claude_md` call (new marker present) → no change;
+  a CLAUDE.md seeded with only the legacy `"Carta is active"` line → no change.
+- Preserve/adjust any existing `_append_claude_md` test that asserted the old
+  one-line-only behavior (update it to expect the block while keeping the
+  `Carta is active. Collections:` substring assertion valid).

--- a/docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-md-doc-search-guidance-design.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-06-16-claude-md-doc-search-guidance-design
 title: CLAUDE.md /doc-search guidance block in bootstrap
-status: draft
+status: shipped
 related: [2026-06-15-stale-reference-git-hook-design, 2026-06-16-stale-reference-diff-scan-design]
 date: 2026-06-16
 related_issue: Ian-q/Carta#10


### PR DESCRIPTION
## Summary

Final slice of issue #10 (**slice 4 of 4**). Expands `carta init`'s CLAUDE.md injection from a one-line comment into an **on-by-default `## Carta Knowledge Graph` guidance block** so any agent — without prior context — knows the knowledge graph exists, *when* to search it, and the exact skill (`/doc-search`).

### What changed
- New pure helper `_carta_claude_block(project_name)` builds a marker-wrapped (`<!-- carta:guidance:start/end -->`) block: an imperative lead ("Search the docs before you assume"), a trigger→query table (component / API-protocol-format / config key / file-path-or-design-decision), and demoted maintenance commands so `/doc-search` stands alone.
- Reworked `_append_claude_md`: **creates** CLAUDE.md if absent (`# <project>` + block), **appends** if present, **idempotent** (skips if the start marker *or* the legacy `"Carta is active"` string is present — so re-running `carta init`, or a repo with the old one-liner, never double-injects). UTF-8 reads/writes (block has `…`/`—`).
- The legacy `<!-- Carta is active. Collections: … -->` comment is kept **inside** the block (diagnostic breadcrumb + back-compat).

### Block content was vetted
Ran the `claude-md-improver` skill on a sample CLAUDE.md with the block (scored 86/100); adopted its three suggestions — imperative-first, table instead of duplicated triggers/examples, and demoting `/doc-audit`/`/doc-embed` to maintenance.

### Scope
On by default (no config gate — matches #10's acceptance). Does **not** retro-edit this repo's own CLAUDE.md, honor a custom `anchor_doc` path, or touch the AGENTS.md generator.

## Test Plan
- [x] Full suite green: **975 passed, 1 skipped** (970 base on `origin/main` + 5 new; slice 2's +7 are on the separate PR #67)
- [x] New unit tests: block content (markers, table, `/doc-search`, interpolated collections); append-to-existing (block once, prior content preserved); create-when-absent; idempotent on marker; skip legacy one-liner
- [x] Existing `test_bootstrap_appends_claude_md` stays green unchanged
- [x] Smoke: empty dir → CLAUDE.md created w/ 1 block; existing file → 1 block across two calls (idempotent), prior content preserved

### Note on #10 completion
This is the last of #10's four mechanisms. **Slice 3 (query-time context hints) needs no code** — the existing `UserPromptSubmit` proactive-recall hook (`carta/hook/hook.py`) already injects scored doc hits on every prompt through a three-zone relevance gate (the issue's "distinct from proactive_recall" premise assumed session-start-only, which isn't the case). Once this and #67 (slice 2) merge, #10 is fully addressed.

Built TDD via subagent-driven development. Spec & plan: `docs/superpowers/specs|plans/2026-06-16-claude-md-doc-search-guidance*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)