### PR TITLE
v0.12.0: pre-ET-embed reliability & correctness audit (CA-1..27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **carta-cc** are documented here. The format is loosely b
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-06-16
+
+### Fixed — pre-ET-embed reliability & correctness audit (CA-1..CA-27)
+A 40-agent audit before a full corpus re-embed surfaced 27 high/critical issues; the blocker set is fixed here. Full report + disposition: `docs/audits/2026-06-16-pre-reembed-code-audit.md`.
+- **Honest embed success accounting (CA-1/4/6/7).** The pipeline marked a file `embedded` from reaching the end of the run, not from confirming its vectors persisted — so a transient Ollama/Qdrant blip silently zeroed out whole files (or dropped 32-chunk batches) with a green summary and never retried. Files that don't fully persist now get a re-pickable `embed_failed`/`partial` status (re-discovered and retried on the next run, counted separately, non-zero CLI exit); transient batch upserts retry instead of dropping on first error; the write-path Qdrant client timeout is raised 5s→30s; and a non-768-dim embedding model fails loudly (`EmbedDimError`) instead of silently upserting nothing.
+- **Encoding robustness (CA-13/22).** A UTF-8 BOM or a single non-UTF8 byte no longer silently drops a markdown file from the index or crashes the whole `carta scan` / graph build — markdown is read with `utf-8-sig` + `errors="replace"`.
+- **`carta init` builds the hybrid schema (CA-10/27).** Init created unnamed-dense collections over raw HTTP while the embed path expects named dense+bm25; because existing collections are skipped, an init-before-embed project was permanently stuck on dense-only retrieval (BM25+RRF hybrid silently off). Init now routes through `ensure_collection` (single source of truth) and warns on a pre-existing legacy collection instead of rubber-stamping it.
+- **Integrity scan & cleanup (CA-14/15).** `carta doctor` no longer reports every embedded `_notes` document as a false `sidecar N vs qdrant 0` count-mismatch (it now scrolls `_notes` and routes each sidecar's count to the collection its doc_type lands in); stale-generation cleanup (`delete_other_points`) retries transient errors and warns loudly on final failure.
+- **Trustworthy verification tooling (CA-17/20/23/26).** `carta audit` scrolls **all** points via the Qdrant cursor (was silently capped at the first 1000 on real corpora); `carta eval` warns on a partial reranker fail-open and rejects blank/empty expectations that silently skewed recall; graph-aware search now uses the real repo root (it was globbing the empty `.carta` dir — a silent no-op).
+- **`--timeout 0` / `file_timeout_s: 0` means unbounded (CA-3)**, matching `visual_timeout_s` — not a literal `join(0)` that instantly timed out every file and still exited 0.
+- **Single-writer embed lock (CA-2/5/12).** `--repair`, `--visual`, targeted `--files`, and the MCP `carta_embed` tool now share one `.carta/embed.lock` with the full pipeline (new `carta/embed/lock.py`), so concurrent writers can't delete each other's just-written points; MCP returns a `busy` error instead of racing.
+
 ### Fixed
 - **Visual pool dilution (#36).** Cross-collection RRF fusion interleaved text and visual
   hits ~1:1 by rank, so once a `_visual` collection had content ~half of every query's

--- a/carta/audit/audit.py
+++ b/carta/audit/audit.py
@@ -78,36 +78,29 @@ def _build_qdrant_chunk_index(client: QdrantClient, collection_name: str) -> dic
     index = {}
 
     try:
-        # Scroll through all chunks
-        points, _ = client.scroll(
-            collection_name=collection_name,
-            limit=1000,  # Qdrant scroll batch size
-        )
-
-        while points:
+        # Scroll through ALL chunks using Qdrant's returned cursor. The previous
+        # code passed offset=len(points) (i.e. the integer 1000), which is invalid
+        # against UUID-keyed point IDs — so any collection with >1000 points was
+        # silently truncated to the first batch, corrupting every downstream
+        # detector on real corpora (audit CA-17). Mirror integrity._scroll_all.
+        offset = None
+        while True:
+            points, offset = client.scroll(
+                collection_name=collection_name,
+                limit=1000,  # Qdrant scroll batch size
+                offset=offset,
+            )
             for point in points:
                 sidecar_id = point.payload.get("sidecar_id")
                 if not sidecar_id:
                     continue  # Skip pre-999.1 chunks
-
-                if sidecar_id not in index:
-                    index[sidecar_id] = []
-
-                index[sidecar_id].append({
+                index.setdefault(sidecar_id, []).append({
                     "id": point.id,
                     "payload": point.payload,
-                    "chunk_index": point.payload.get("chunk_index")
+                    "chunk_index": point.payload.get("chunk_index"),
                 })
-
-            # Continue scrolling if more points
-            if len(points) < 1000:
+            if offset is None:
                 break
-
-            points, _ = client.scroll(
-                collection_name=collection_name,
-                limit=1000,
-                offset=len(points),
-            )
     except Exception:
         # Collection doesn't exist or is unreachable; return empty index
         pass

--- a/carta/audit/tests/test_audit.py
+++ b/carta/audit/tests/test_audit.py
@@ -141,6 +141,19 @@ class TestBuildQdrantChunkIndex:
         assert len(index) == 1
         assert "sidecar_1" in index
 
+    def test_paginates_past_first_batch_via_cursor(self):
+        """Audit must scroll ALL points via the returned cursor, not cap at the first
+        batch (offset was len(points), wrong for UUID-keyed points) — audit CA-17."""
+        mock_client = Mock()
+        page1 = [Mock(id="s1-0", payload={"sidecar_id": "s1", "chunk_index": 0})]
+        page2 = [Mock(id="s2-0", payload={"sidecar_id": "s2", "chunk_index": 0})]
+        mock_client.scroll.side_effect = [(page1, "cursor"), (page2, None)]
+
+        index = _build_qdrant_chunk_index(mock_client, "test_doc")
+
+        assert "s1" in index
+        assert "s2" in index  # second page must be fetched via the returned cursor
+
 
 class TestDetectOrphanedChunks:
     """Test detection of orphaned chunks."""

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -302,8 +302,19 @@ def cmd_embed(args):
             f"Re-run with --timeout {suggested} to give them more time.",
             file=sys.stderr,
         )
+    failed = summary.get("failed", [])
+    partial = summary.get("partial", [])
+    if failed or partial:
+        print(
+            f"\nWarning: {len(failed)} file(s) failed to embed and {len(partial)} "
+            f"only partially embedded (transient Ollama/Qdrant errors?). They were NOT "
+            f"marked done — re-run `carta embed` to retry them.",
+            file=sys.stderr,
+        )
     _notify_if_update(cfg_path, cfg)
-    if summary["errors"]:
+    # Exit non-zero on errors OR incomplete embeds so a bulk re-embed can never
+    # report false-green when files silently failed/partially embedded.
+    if summary["errors"] or failed or partial:
         sys.exit(1)
 
 def cmd_search(args):

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -95,58 +95,9 @@ def _notify_if_update(cfg_path=None, cfg=None):
         pass
 
 
-def _embed_lock_read_pid(lock_path: Path):
-    try:
-        return int(lock_path.read_text().strip())
-    except (ValueError, OSError):
-        return None
-
-
-def _embed_lock_pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    else:
-        return True
-
-
-def _acquire_embed_lock(lock_path: Path) -> None:
-    """Ensure only one live embed process; create lock atomically; remove stale locks."""
-    while True:
-        if not lock_path.exists():
-            try:
-                fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-                with os.fdopen(fd, "w") as f:
-                    f.write(str(os.getpid()))
-                return
-            except FileExistsError:
-                continue
-
-        existing_pid = _embed_lock_read_pid(lock_path)
-        if existing_pid is None or existing_pid <= 0:
-            try:
-                lock_path.unlink(missing_ok=True)
-            except OSError:
-                pass
-            continue
-
-        if _embed_lock_pid_alive(existing_pid):
-            print(
-                f"carta embed is already running (PID: {existing_pid}). "
-                "Wait for it to finish or remove .carta/embed.lock if it is stale.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        try:
-            lock_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+# The single-writer embed lock lives in carta.embed.lock so the CLI and the MCP
+# carta_embed tool share one lock per project — exactly one writer per project so
+# concurrent runs cannot delete each other's just-written points (audit CA-2/5/12).
 
 
 def cmd_scan(args):
@@ -179,6 +130,7 @@ def cmd_scan(args):
 def cmd_embed(args):
     from carta.config import load_config
     from carta.embed.pipeline import run_embed, run_embed_file
+    from carta.embed.lock import acquire as _acquire_embed_lock, EmbedLockHeld
     from carta.ui import Progress
     import time
 
@@ -199,6 +151,37 @@ def cmd_embed(args):
     timeout_override = getattr(args, "timeout", None)
     if timeout_override is not None:
         cfg.setdefault("embed", {})["file_timeout_s"] = timeout_override
+
+    # Single-writer lock for ALL mutating embed paths — full pipeline, --repair,
+    # --visual, and targeted --files. Previously only the full-pipeline branch
+    # locked, so a --repair / --visual / --files run (or a concurrent MCP
+    # carta_embed) could race its cleanup-delete against another writer and drop
+    # freshly-written points (audit CA-2/5/12).
+    lock_path = cfg_path.parent / "embed.lock"
+    try:
+        _acquire_embed_lock(lock_path)
+    except EmbedLockHeld as e:
+        print(
+            f"carta embed is already running (PID: {e.pid}). Wait for it to finish "
+            f"or remove .carta/embed.lock if it is stale.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    def _remove_lock():
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    atexit.register(_remove_lock)
+
+    def _signal_handler(signum, frame):
+        _remove_lock()
+        sys.exit(128 + signum)
+
+    for _sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(_sig, _signal_handler)
 
     # --repair: detect and fix corpus-integrity issues, then exit.
     # `is True` (not `if args.repair`) — rejects truthy MagicMocks in tests.
@@ -257,25 +240,7 @@ def cmd_embed(args):
         _notify_if_update(cfg_path, cfg)
         sys.exit(1 if errors else 0)
 
-    # FT-5: Concurrency lock — only one embed process at a time (atomic create + stale PID).
-    lock_path = cfg_path.parent / "embed.lock"
-    _acquire_embed_lock(lock_path)
-
-    def _remove_lock():
-        try:
-            lock_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-
-    atexit.register(_remove_lock)
-
-    def _signal_handler(signum, frame):
-        _remove_lock()
-        sys.exit(128 + signum)
-
-    for _sig in (signal.SIGTERM, signal.SIGINT):
-        signal.signal(_sig, _signal_handler)
-
+    # Lock already acquired at the top of cmd_embed (covers all mutating branches).
     repo_root = cfg_path.parent.parent
 
     with Progress() as progress:
@@ -924,7 +889,7 @@ def main():
     embed_p.add_argument(
         "files",
         nargs="*",
-        help="Specific file(s) to embed immediately (skips full pipeline and lock)",
+        help="Specific file(s) to embed immediately (skips the discovery scan)",
     )
     embed_p.add_argument(
         "--timeout",

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -659,6 +659,17 @@ def cmd_eval(args):
     print(f"queries={metrics['n_queries']}  recall@{k}={metrics['recall_at_k']:.3f}  MRR={metrics['mrr']:.3f}")
     if rerank_requested:
         print(f"rerank: applied on {rerank_applied_count}/{query_count} queries")
+        # Partial fail-open: a 0.8B reranker degrading on N/Q queries still prints a
+        # mostly-reranked score that an operator may trust for a go/no-go call. Make
+        # the partial case a loud stderr warning so it can't be mistaken for clean
+        # (the total-fail-open case below hard-fails) — audit CA-20.
+        if query_count and 0 < rerank_applied_count < query_count:
+            print(
+                f"Warning: reranker failed open on {query_count - rerank_applied_count}/"
+                f"{query_count} queries — these are PARTIALLY reranked numbers, not a "
+                f"clean reranked run; treat the score with caution.",
+                file=sys.stderr,
+            )
     else:
         print("rerank: not requested")
     for row in metrics["per_query"]:

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -46,6 +46,22 @@ BATCH_SIZE = 32
 # Reduce batch size to stay under Qdrant's 32MB payload limit
 VISUAL_BATCH_SIZE = 4
 
+# Write-path Qdrant client timeout (s). The bulk re-embed upserts dense+sparse
+# batches; the old 5s default could time out under load and silently drop a whole
+# batch of already-embedded chunks. Reads/diagnostics already use 30s.
+UPSERT_CLIENT_TIMEOUT_S = 30
+# Retry a failed batch upsert this many times before giving up (transient 5xx/reset).
+UPSERT_MAX_ATTEMPTS = 3
+
+
+class EmbedDimError(RuntimeError):
+    """Embedding model returned a vector whose length != VECTOR_DIM.
+
+    A model misconfiguration (e.g. pointing embed.ollama_model at a non-768 model)
+    must fail loudly instead of every batch being rejected by Qdrant and swallowed
+    as a silent zero-vector 'success'.
+    """
+
 
 _CONTEXT_OVERFLOW = "the input length exceeds the context length"
 
@@ -220,7 +236,7 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
 
     if client is None:
         qdrant_url = cfg["qdrant_url"]
-        client = QdrantClient(url=qdrant_url, timeout=5)
+        client = QdrantClient(url=qdrant_url, timeout=UPSERT_CLIENT_TIMEOUT_S)
     ensure_collection(client, coll_name)
 
     # Determine schema ONCE before the chunk loop so every point in this batch
@@ -228,6 +244,12 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     is_hybrid = collection_is_hybrid(client, coll_name)
 
     def build_point(chunk: dict, vec: list[float]) -> PointStruct:
+        if len(vec) != VECTOR_DIM:
+            raise EmbedDimError(
+                f"Embedding model '{model}' returned dim {len(vec)}, expected "
+                f"{VECTOR_DIM}. The collection schema is fixed at {VECTOR_DIM}-d — "
+                f"reconfigure embed.ollama_model or recreate the collection."
+            )
         # The payload's doc_generation and the generation baked into the point
         # ID must agree — generation cleanup deletes by payload value.
         generation = chunk.get("doc_generation", 1)
@@ -267,12 +289,21 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
     def flush(batch: list[PointStruct]) -> int:
         if not batch:
             return 0
-        try:
-            client.upsert(collection_name=coll_name, points=batch)
-            return len(batch)
-        except Exception as e:
-            print(f"Warning: batch upsert failed — {e}", flush=True)
-            return 0
+        last_exc = None
+        for _attempt in range(UPSERT_MAX_ATTEMPTS):
+            try:
+                client.upsert(collection_name=coll_name, points=batch)
+                return len(batch)
+            except Exception as e:  # transient 5xx / timeout / connection reset
+                last_exc = e
+        # All retries exhausted: the batch is lost. The caller's returned count
+        # therefore falls short of the expected chunk count, which _embed_one_file
+        # surfaces as a partial/failed (re-pickable) status — never silent success.
+        print(
+            f"Warning: batch upsert failed after {UPSERT_MAX_ATTEMPTS} attempts — {last_exc}",
+            flush=True,
+        )
+        return 0
 
     upserted = 0
     batch: list[PointStruct] = []
@@ -283,6 +314,8 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
             try:
                 vec = get_embedding(_embed_input(chunk), ollama_url=ollama_url, model=model)
                 batch.append(build_point(chunk, vec))
+            except EmbedDimError:
+                raise  # model/collection dim mismatch — abort loudly, never swallow
             except Exception as e:
                 print(f"Warning: skipping chunk {chunk_id} — {e}", flush=True)
                 continue
@@ -303,6 +336,8 @@ def upsert_chunks(chunks: list[dict], cfg: dict, client: QdrantClient = None) ->
                 try:
                     vec = fut.result()
                     batch.append(build_point(chunk, vec))
+                except EmbedDimError:
+                    raise  # model/collection dim mismatch — abort loudly, never swallow
                 except Exception as e:
                     print(f"Warning: skipping chunk {chunk_id} — {e}", flush=True)
                     continue
@@ -373,7 +408,7 @@ def upsert_visual_pages(
 
     if client is None:
         qdrant_url = cfg["qdrant_url"]
-        client = QdrantClient(url=qdrant_url, timeout=5)
+        client = QdrantClient(url=qdrant_url, timeout=UPSERT_CLIENT_TIMEOUT_S)
     ensure_visual_collection(client, coll_name)
 
     upserted = 0

--- a/carta/embed/integrity.py
+++ b/carta/embed/integrity.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from qdrant_client import QdrantClient
 
-from carta.config import collection_name
+from carta.config import collection_name, collection_for_doc_type
 from carta.embed.lifecycle import compute_file_hash
 from carta.embed.induct import iter_canonical_sidecars
 
@@ -101,6 +101,15 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
         if fp and not (repo_root / fp).exists()
     )
 
+    # _notes collection tallies (CA-15): note doc_types (quirk/bug-note/helpful-note)
+    # route to {project}_notes via collection_for_doc_type, NOT _doc. Counting their
+    # sidecar chunk_count against _doc made every embedded note a false count-mismatch.
+    notes_coll = collection_name(cfg, "notes")
+    notes_per_file_counts: dict[str, int] = defaultdict(int)
+    if notes_coll != coll and client.collection_exists(notes_coll):
+        for payload in _scroll_all(client, notes_coll):
+            notes_per_file_counts[payload.get("file_path", "")] += 1
+
     # Sidecar-side checks. iter_canonical_sidecars skips corrupt/non-dict
     # sidecars, those without a current_path, and misplaced/nested junk copies
     # (e.g. an accidental .carta/sidecars/.worktrees/.../.carta/sidecars/... tree)
@@ -113,10 +122,18 @@ def scan_corpus_integrity(cfg: dict, repo_root: Path, client=None) -> dict:
         rel = sc["current_path"]
 
         status = sc.get("status")
+        # Route the count comparison to the collection this sidecar's doc_type
+        # actually lands in (notes -> _notes, everything else -> _doc), so notes
+        # are not falsely flagged as "sidecar N vs qdrant 0" (CA-15).
+        routed_counts = (
+            notes_per_file_counts
+            if collection_for_doc_type(cfg, sc.get("doc_type", "unknown")) == notes_coll
+            else per_file_counts
+        )
         # Missing entry means ZERO surviving points — a fully-lost file
         # (e.g. every chunk shadowed by a legacy ID collision) is the
         # strongest mismatch of all, not an exemption.
-        qdrant_count = per_file_counts.get(rel, 0)
+        qdrant_count = routed_counts.get(rel, 0)
         sidecar_count = sc.get("chunk_count")
 
         # Stuck-stale: status is "stale" but file hash matches disk — a bug

--- a/carta/embed/lifecycle.py
+++ b/carta/embed/lifecycle.py
@@ -168,6 +168,13 @@ def is_protected_doc_type(doc_type: str) -> bool:
     return doc_type in PROTECTED_DOC_TYPES
 
 
+# Retry stale-point cleanup this many times before giving up. Cleanup is the sole
+# mechanism that removes superseded generations (search applies no generation
+# filter), so a transient failure that goes un-retried leaves old chunks
+# permanently searchable until `carta embed --repair`.
+DELETE_MAX_ATTEMPTS = 3
+
+
 def delete_other_points(
     client, collection_name: str, rel_path: str, keep_ids: list[str]
 ) -> None:
@@ -176,17 +183,26 @@ def delete_other_points(
     Runs after a successful, complete upsert. Catches everything the
     generation arithmetic missed: legacy slug-keyed points (different IDs),
     stale generations, and tail chunks of files that shrank — regardless of
-    what doc_generation they carry.  Best-effort: errors are reported but
-    never fail the embed that just succeeded.
+    what doc_generation they carry.  Best-effort: errors are retried then
+    reported, but never fail the embed that just succeeded.
     """
     selector = Filter(
         must=[FieldCondition(key="file_path", match=MatchValue(value=rel_path))],
         must_not=[HasIdCondition(has_id=keep_ids)],
     )
-    try:
-        client.delete(collection_name=collection_name, points_selector=selector)
-    except Exception as e:
-        print(f"Warning: stale-point cleanup failed for {rel_path} — {e}", flush=True)
+    last_exc = None
+    for _attempt in range(DELETE_MAX_ATTEMPTS):
+        try:
+            client.delete(collection_name=collection_name, points_selector=selector)
+            return
+        except Exception as e:  # transient 5xx / timeout / connection reset
+            last_exc = e
+    print(
+        f"Warning: stale-point cleanup FAILED for {rel_path} after "
+        f"{DELETE_MAX_ATTEMPTS} attempts — old chunks may resurface in search "
+        f"until `carta embed --repair`: {last_exc}",
+        flush=True,
+    )
 
 
 def check_stale_alert(stale_count: int, total_count: int, threshold: float) -> str | None:

--- a/carta/embed/lock.py
+++ b/carta/embed/lock.py
@@ -1,0 +1,124 @@
+"""Single-writer embed lock shared by every mutating embed entry point.
+
+Only one embed / repair / visual run may write a project's Qdrant collections at a
+time. Otherwise one run's stale-point cleanup (delete_other_points, which deletes
+every point for a file except the IDs *this* run just wrote) can delete points the
+*other* run just wrote — corrupting the collection mid-run. The CLI (`carta embed`
+and its ``--repair`` / ``--visual`` / ``--files`` branches) and the MCP
+``carta_embed`` tool all acquire this lock so there is exactly one writer per
+project (audit CA-2/5/12).
+"""
+from __future__ import annotations
+
+import atexit
+import os
+import signal
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class EmbedLockHeld(Exception):
+    """Raised when the embed lock is already held by another live process."""
+
+    def __init__(self, pid: int):
+        self.pid = pid
+        super().__init__(f"embed already running (PID {pid})")
+
+
+def _read_pid(lock_path: Path):
+    try:
+        return int(lock_path.read_text().strip())
+    except (ValueError, OSError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def _safe_unlink(lock_path: Path) -> None:
+    try:
+        lock_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def acquire(lock_path: Path) -> None:
+    """Create the lock atomically, reclaiming a stale one (dead PID).
+
+    Raises:
+        EmbedLockHeld: if another *live* process already holds the lock.
+    """
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    while True:
+        if not lock_path.exists():
+            try:
+                fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                with os.fdopen(fd, "w") as f:
+                    f.write(str(os.getpid()))
+                return
+            except FileExistsError:
+                continue  # lost the race; re-evaluate the holder
+
+        existing_pid = _read_pid(lock_path)
+        if existing_pid is None or existing_pid <= 0:
+            _safe_unlink(lock_path)  # corrupt/empty lock — reclaim
+            continue
+        if _pid_alive(existing_pid):
+            raise EmbedLockHeld(existing_pid)
+        _safe_unlink(lock_path)  # stale lock from a dead PID — reclaim
+
+
+@contextmanager
+def embed_lock(lock_path: Path):
+    """Hold the single-writer embed lock for the duration of the block.
+
+    Registers atexit + SIGTERM/SIGINT cleanup so an abrupt exit doesn't strand the
+    lock. Signal handlers are skipped when not on the main thread (e.g. under the
+    MCP event loop), where ``signal.signal`` raises ValueError; atexit still covers
+    cleanup there.
+
+    Raises:
+        EmbedLockHeld: if another live process holds the lock.
+    """
+    acquire(lock_path)
+    released = {"v": False}
+
+    def _release():
+        if released["v"]:
+            return
+        released["v"] = True
+        _safe_unlink(lock_path)
+
+    atexit.register(_release)
+
+    prev_handlers = {}
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            prev_handlers[sig] = signal.signal(
+                sig, lambda signum, frame: (_release(), sys.exit(128 + signum))
+            )
+        except (ValueError, OSError):
+            pass  # not the main thread — atexit still handles cleanup
+
+    try:
+        yield
+    finally:
+        _release()
+        for sig, handler in prev_handlers.items():
+            try:
+                signal.signal(sig, handler)
+            except (ValueError, OSError, TypeError):
+                pass

--- a/carta/embed/parse.py
+++ b/carta/embed/parse.py
@@ -174,7 +174,10 @@ def extract_markdown_text(md_path: Path) -> tuple[list[dict], dict]:
     Returns:
         Tuple of (sections, frontmatter_meta dict).
     """
-    return sections_from_markdown(md_path.read_text(encoding="utf-8"))
+    # utf-8-sig strips a leading BOM (which would otherwise defeat frontmatter
+    # detection and the H1 title scan); errors="replace" keeps a stray non-UTF8
+    # byte from raising and silently dropping the whole file from the index.
+    return sections_from_markdown(md_path.read_text(encoding="utf-8-sig", errors="replace"))
 
 
 def _estimate_tokens(text: str) -> int:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -28,6 +28,7 @@ from carta.embed.embed import (
     _point_id_versioned,
     DENSE_VECTOR_NAME,
     SPARSE_VECTOR_NAME,
+    UPSERT_CLIENT_TIMEOUT_S,
 )
 from carta.embed.sparse import embed_sparse_query
 from carta.embed.induct import generate_sidecar_stub, read_sidecar, write_sidecar, sidecar_path, iter_canonical_sidecars
@@ -157,7 +158,11 @@ def _update_sidecar(sidecar_path: Path, updates: dict) -> None:
 
 
 def discover_pending_files(repo_root: Path) -> list[dict]:
-    """Find all sidecars under .carta/sidecars/ with status: pending.
+    """Find all sidecars under .carta/sidecars/ awaiting (re-)embedding.
+
+    Picks the re-pickable statuses: ``pending`` (never embedded) plus
+    ``embed_failed`` and ``partial`` — a transient embed failure or a partial
+    upsert must be retried on the next run, not silently stranded as if done.
 
     Returns list of dicts: sidecar data + 'sidecar_path' + 'file_path'.
     """
@@ -167,7 +172,7 @@ def discover_pending_files(repo_root: Path) -> list[dict]:
         return results
     for sc_path in sidecars_root.rglob("*.embed-meta.yaml"):
         data = read_sidecar(sc_path)
-        if data is None or data.get("status") != "pending":
+        if data is None or data.get("status") not in ("pending", "embed_failed", "partial"):
             continue
         current_path = data.get("current_path")
         if not current_path:
@@ -657,6 +662,20 @@ def _embed_one_file(
             flush=True,
         )
 
+    # Honest success accounting: if text/image chunks were attempted but not all
+    # persisted, do NOT report a clean "embedded". Downgrade to a re-pickable
+    # status so discovery retries the file and the summary/operator see the gap.
+    # Files whose pages are queued for the visual/OCR drain are not failures —
+    # their text legitimately lands in pass 2 — so they are excluded here.
+    visual_pending = bool(_visual_queue_updates.get(VISUAL_PENDING_KEY))
+    attempted = expected_text + expected_images
+    persisted = count + image_chunk_count
+    if sidecar_updates.get("status") == "embedded" and attempted > 0 and not visual_pending:
+        if persisted == 0:
+            sidecar_updates["status"] = "embed_failed"
+        elif persisted < attempted:
+            sidecar_updates["status"] = "partial"
+
     return count + image_chunk_count, sidecar_updates
 
 
@@ -1008,7 +1027,7 @@ def run_visual_embed(
         summary["status"] = "visual_unavailable"
         return summary
 
-    client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=UPSERT_CLIENT_TIMEOUT_S)
     queued = _discover_visual_pending(repo_root)
     summary["files"] = len(queued)
     total_pages = sum(len(sc.get(VISUAL_PENDING_KEY, []) or []) for _, sc in queued)
@@ -1233,7 +1252,7 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
 
     # Mark chunks as stale in Qdrant (with migration boundary guard)
     if sidecar_data.get("sidecar_id"):
-        client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
+        client = QdrantClient(url=cfg["qdrant_url"], timeout=UPSERT_CLIENT_TIMEOUT_S)
         mark_sidecar_stale(client, collection_name(cfg, "doc"), sidecar_data.get("sidecar_id"), now)
 
     # Proceed with re-embedding
@@ -1245,7 +1264,7 @@ def run_embed_file(path: Path, cfg: dict, force: bool = False, verbose: bool = F
         "generation": new_generation,
     }
 
-    client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=UPSERT_CLIENT_TIMEOUT_S)
     ensure_collection(client, collection_name(cfg, "doc"))
 
     chunking = cfg.get("embed", {}).get("chunking", {})
@@ -1276,10 +1295,16 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
 
     Returns:
         {"embedded": int, "skipped": int, "extraction_failed": int,
+         "failed": list[str], "partial": list[str],
          "errors": list[str], "timed_out": list[str]}
+
+    "failed"/"partial" hold the names of files whose chunks did not fully persist
+    (transient Ollama/Qdrant errors). Their sidecars keep a re-pickable status so
+    discover_pending_files retries them on the next run — they are never counted
+    as "embedded".
     """
     summary: dict = {"embedded": 0, "skipped": 0, "extraction_failed": 0,
-                     "errors": [], "timed_out": []}
+                     "failed": [], "partial": [], "errors": [], "timed_out": []}
 
     # Migrate any co-located sidecars from old format to .carta/sidecars/
     migrate_sidecars(repo_root, verbose=verbose)
@@ -1288,8 +1313,7 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
     if verbose:
         print("carta embed: checking Qdrant connectivity...", flush=True)
     try:
-        client = QdrantClient(url=cfg["qdrant_url"], timeout=5)
-        client.get_collections()
+        QdrantClient(url=cfg["qdrant_url"], timeout=5).get_collections()
     except Exception as e:
         err = (
             f"carta embed: ERROR — Qdrant is not reachable at {cfg['qdrant_url']}.\n"
@@ -1299,6 +1323,11 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
         print(err, file=sys.stderr, flush=True)
         summary["errors"].append(err)
         return summary
+
+    # Working client for the embed loop: a longer timeout than the fail-fast
+    # preflight above so bulk dense+sparse upserts don't spuriously time out
+    # (and silently drop a batch) when Qdrant is briefly busy under a large re-embed.
+    client = QdrantClient(url=cfg["qdrant_url"], timeout=UPSERT_CLIENT_TIMEOUT_S)
 
     coll_name = collection_name(cfg, "doc")
     ensure_collection(client, coll_name)
@@ -1449,16 +1478,28 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
                         progress.vision_done(vision_events)
                 elif verbose:
                     print(f"  [{idx}/{total}] OK: {file_path.name} — {count} chunk(s) in {elapsed:.1f}s", flush=True)
-                if sidecar_updates.get("status") == "extraction_failed":
+                st = sidecar_updates.get("status")
+                if st == "embed_failed":
+                    summary["failed"].append(file_path.name)
+                    perf_status = "failed"
+                    status.file_done(errors=1)
+                elif st == "partial":
+                    summary["partial"].append(file_path.name)
+                    perf_status = "partial"
+                    status.file_done(errors=1)
+                elif st == "extraction_failed":
                     summary["extraction_failed"] += 1
+                    perf_status = "ok"
+                    status.file_done(embedded=1, chunks=count)
                 else:
                     summary["embedded"] += 1
+                    perf_status = "ok"
+                    status.file_done(embedded=1, chunks=count)
                 _write_perf_log_entry(perf_log_path, {
-                    **perf_context, "file": rel_file, "status": "ok",
+                    **perf_context, "file": rel_file, "status": perf_status,
                     "chunks": count, "elapsed_s": round(elapsed, 2),
                     "vision_strategies": _summarize_vision_strategies(vision_events),
                 })
-                status.file_done(embedded=1, chunks=count)
     except BaseException:
         status.finish("failed")
         raise

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1427,7 +1427,11 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
                 target=_worker, daemon=True, name=f"carta-embed-{file_path.name}"
             )
             worker.start()
-            worker.join(timeout=file_timeout_s)
+            # file_timeout_s <= 0 means UNBOUNDED (matches visual_timeout_s "0 =
+            # unbounded"). A literal join(0) returns instantly and flags every file
+            # as TIMEOUT — embedding nothing while still exiting 0 (audit CA-3).
+            join_timeout = file_timeout_s if (file_timeout_s and file_timeout_s > 0) else None
+            worker.join(timeout=join_timeout)
             elapsed = time.monotonic() - t0
 
             if worker.is_alive():

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1685,7 +1685,10 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     from pathlib import Path
 
     top_n = cfg.get("search", {}).get("top_n", 5)
-    repo_root = Path(find_config()).parent
+    # find_config() returns <repo>/.carta/config.yaml; the repo root is its
+    # GRANDPARENT. (.parent alone is the .carta dir, which holds no project docs —
+    # that made graph expansion a silent no-op, audit CA-23.)
+    repo_root = Path(find_config()).parent.parent
 
     # Compute effective retrieval depth.
     # When reranking is enabled, fetch candidate_pool docs per collection so

--- a/carta/embed/tests/test_contextual_header.py
+++ b/carta/embed/tests/test_contextual_header.py
@@ -144,7 +144,7 @@ def test_upsert_embeds_header_but_payload_keeps_raw_text():
 
     def fake_dense(text, **kw):
         captured["dense"] = text
-        return [0.0] * 8
+        return [0.0] * 768  # must match VECTOR_DIM (dim is now validated)
 
     def fake_sparse(text, **kw):
         captured["sparse"] = text

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -628,6 +628,31 @@ def test_run_embed_qdrant_unreachable(mock_qdrant_cls, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# parse.py — encoding robustness (audit Group C: CA-13, BOM)
+# ---------------------------------------------------------------------------
+
+def test_extract_markdown_text_handles_utf8_bom(tmp_path):
+    """A UTF-8 BOM must not defeat frontmatter detection or leak YAML into the body."""
+    from carta.embed.parse import extract_markdown_text
+    md = tmp_path / "doc.md"
+    md.write_bytes("﻿---\ntitle: Hello\n---\n\n# Body\n\nsome text".encode("utf-8"))
+    sections, fm = extract_markdown_text(md)
+    assert fm.get("title") == "Hello"
+    body = " ".join(s["text"] for s in sections)
+    assert "title: Hello" not in body  # frontmatter stripped, not embedded as body
+
+
+def test_extract_markdown_text_tolerates_non_utf8_bytes(tmp_path):
+    """A stray non-UTF8 byte must not crash extraction (else the file is silently
+    dropped from the index with no bookkeeping)."""
+    from carta.embed.parse import extract_markdown_text
+    md = tmp_path / "doc.md"
+    md.write_bytes(b"# Title\n\ncaf\xe9 not utf8 here\n")  # 0xe9 = latin-1 'e-acute'
+    sections, _fm = extract_markdown_text(md)  # must not raise
+    assert sections, "should still produce content rather than dropping the file"
+
+
+# ---------------------------------------------------------------------------
 # pipeline.py — honest embed success accounting (audit Group A: CA-1/4/6/7)
 # ---------------------------------------------------------------------------
 

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -628,6 +628,145 @@ def test_run_embed_qdrant_unreachable(mock_qdrant_cls, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# pipeline.py — honest embed success accounting (audit Group A: CA-1/4/6/7)
+# ---------------------------------------------------------------------------
+
+def _write_md_with_pending_sidecar(tmp_path, rel="docs/spec.md", slug="spec"):
+    """Create a markdown source + a pending sidecar under .carta/sidecars/."""
+    import yaml as _yaml
+    src = tmp_path / rel
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("hello")
+    sc = tmp_path / ".carta" / "sidecars" / Path(rel).with_suffix(".embed-meta.yaml")
+    sc.parent.mkdir(parents=True, exist_ok=True)
+    sc.write_text(_yaml.dump({
+        "slug": slug, "doc_type": "spec", "status": "pending", "current_path": rel,
+    }))
+    return src, sc
+
+
+_NO_HEADER_CFG = {
+    **MINIMAL_CFG,
+    "embed": {
+        **MINIMAL_CFG["embed"],
+        "two_pass_visual": False,
+        "chunking": {"max_tokens": 800, "overlap_fraction": 0.15, "contextual_header": False},
+    },
+}
+
+
+@patch("carta.embed.pipeline.QdrantClient")
+@patch("carta.embed.pipeline.upsert_chunks")
+@patch("carta.embed.pipeline.chunk_text")
+@patch("carta.embed.pipeline.extract_markdown_text")
+def test_run_embed_total_persist_failure_not_marked_embedded(
+    mock_extract, mock_chunk, mock_upsert, mock_qdrant_cls, tmp_path
+):
+    """A file whose chunks all fail to persist (upsert returns 0 while text was
+    expected) must NOT be counted as embedded nor stamped status='embedded'."""
+    import yaml as _yaml
+    mock_qdrant_cls.return_value = MagicMock()
+    mock_extract.return_value = ([{"page": 1, "text": "hello", "headings": []}], {})
+    mock_chunk.return_value = [
+        {"text": "chunk a", "chunk_index": 0},
+        {"text": "chunk b", "chunk_index": 1},
+    ]
+    mock_upsert.return_value = 0  # nothing persisted despite 2 expected text chunks
+
+    _src, sc = _write_md_with_pending_sidecar(tmp_path)
+    result = run_embed(tmp_path, _NO_HEADER_CFG)
+
+    assert result["embedded"] == 0, "0 persisted vectors must not count as embedded"
+    assert "spec.md" in result["failed"]
+    updated = _yaml.safe_load(sc.read_text())
+    assert updated["status"] == "embed_failed"
+
+
+@patch("carta.embed.pipeline.QdrantClient")
+@patch("carta.embed.pipeline.upsert_chunks")
+@patch("carta.embed.pipeline.chunk_text")
+@patch("carta.embed.pipeline.extract_markdown_text")
+def test_run_embed_partial_persist_not_marked_embedded(
+    mock_extract, mock_chunk, mock_upsert, mock_qdrant_cls, tmp_path
+):
+    """A partial upsert (some batches lost) must be re-pickable, not 'embedded'."""
+    import yaml as _yaml
+    mock_qdrant_cls.return_value = MagicMock()
+    mock_extract.return_value = ([{"page": 1, "text": "hello", "headings": []}], {})
+    mock_chunk.return_value = [
+        {"text": "chunk a", "chunk_index": 0},
+        {"text": "chunk b", "chunk_index": 1},
+    ]
+    mock_upsert.return_value = 1  # only 1 of 2 expected text chunks persisted
+
+    _src, sc = _write_md_with_pending_sidecar(tmp_path)
+    result = run_embed(tmp_path, _NO_HEADER_CFG)
+
+    assert result["embedded"] == 0
+    assert "spec.md" in result["partial"]
+    updated = _yaml.safe_load(sc.read_text())
+    assert updated["status"] == "partial"
+
+
+def test_discover_pending_files_repicks_failed_and_partial(tmp_path):
+    """Re-pickable statuses (embed_failed, partial) must be re-discovered so a
+    transient failure is retried on the next run."""
+    import yaml as _yaml
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+    (doc_dir / "a.md").write_text("a")
+    (doc_dir / "b.md").write_text("b")
+    sc_dir = tmp_path / ".carta" / "sidecars" / "docs"
+    sc_dir.mkdir(parents=True)
+    (sc_dir / "a.embed-meta.yaml").write_text(_yaml.dump(
+        {"slug": "a", "status": "embed_failed", "current_path": "docs/a.md"}))
+    (sc_dir / "b.embed-meta.yaml").write_text(_yaml.dump(
+        {"slug": "b", "status": "partial", "current_path": "docs/b.md"}))
+
+    pending = discover_pending_files(tmp_path)
+    assert {p["slug"] for p in pending} == {"a", "b"}
+
+
+def test_upsert_chunks_raises_on_embedding_dim_mismatch():
+    """A model whose vectors aren't VECTOR_DIM must fail loudly, not be silently
+    rejected batch-by-batch and reported as success."""
+    from carta.embed.embed import EmbedDimError
+    chunks = [{
+        "slug": "d", "text": "hello", "chunk_index": 0,
+        "file_path": "docs/d.md", "doc_type": "spec",
+    }]
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    with patch("carta.embed.embed.get_embedding", return_value=[0.0] * 100):
+        with pytest.raises(EmbedDimError):
+            upsert_chunks(chunks, MINIMAL_CFG, client=client)
+
+
+def test_upsert_chunks_retries_transient_batch_upsert_failure():
+    """A transient batch-upsert error must be retried, not dropped on first failure
+    (which would silently lose up to BATCH_SIZE already-embedded chunks)."""
+    client = MagicMock()
+    client.collection_exists.return_value = True
+    calls = {"n": 0}
+
+    def flaky_upsert(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient 503")
+        return None
+
+    client.upsert.side_effect = flaky_upsert
+    chunks = [{
+        "slug": "d", "text": "hello", "chunk_index": 0,
+        "file_path": "docs/d.md", "doc_type": "spec",
+    }]
+    with patch("carta.embed.embed.get_embedding", return_value=[0.1] * 768):
+        n = upsert_chunks(chunks, MINIMAL_CFG, client=client)
+    assert n == 1, "retry should persist the batch after a transient failure"
+    assert calls["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
 # pipeline.py — run_search (mocked Qdrant + Ollama)
 # ---------------------------------------------------------------------------
 

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -861,6 +861,28 @@ def test_run_search_query_failure_raises(mock_qdrant_cls, mock_embed, mock_find_
     assert mock_client.query_points.call_count == 3
 
 
+def test_run_embed_zero_timeout_means_unbounded_not_instant_timeout(tmp_path, monkeypatch):
+    """file_timeout_s=0 must mean UNBOUNDED (matching visual_timeout_s '0 = unbounded'),
+    not a literal join(0) that instantly flags every file TIMEOUT and embeds nothing
+    while still exiting 0 (audit CA-3)."""
+    import time as _time
+    from carta.embed import pipeline as pipeline_mod
+
+    _src, _sc = _write_md_with_pending_sidecar(tmp_path)
+
+    def _slow_embed(*a, **kw):
+        _time.sleep(0.2)  # outlives a join(0) so the bug would flag it timed-out
+        return 1, {"status": "embedded", "chunk_count": 1}
+
+    monkeypatch.setattr(pipeline_mod, "_embed_one_file", _slow_embed)
+    cfg = {**_NO_HEADER_CFG, "embed": {**_NO_HEADER_CFG["embed"], "file_timeout_s": 0}}
+    with patch("carta.embed.pipeline.QdrantClient", return_value=MagicMock()):
+        result = run_embed(tmp_path, cfg)
+
+    assert result["timed_out"] == [], "0 must not instantly time out every file"
+    assert result["embedded"] == 1
+
+
 # ---------------------------------------------------------------------------
 # embed.py — upsert_chunks batching (PIPE-01)
 # ---------------------------------------------------------------------------

--- a/carta/embed/tests/test_lock.py
+++ b/carta/embed/tests/test_lock.py
@@ -1,0 +1,54 @@
+"""Tests for the shared single-writer embed lock (audit Group F: CA-2/5/12)."""
+
+import os
+
+import pytest
+
+from carta.embed.lock import acquire, embed_lock, EmbedLockHeld
+
+
+def test_acquire_creates_lock_with_our_pid(tmp_path):
+    lp = tmp_path / "embed.lock"
+    acquire(lp)
+    assert lp.exists()
+    assert lp.read_text().strip() == str(os.getpid())
+
+
+def test_acquire_raises_when_held_by_live_pid(tmp_path):
+    """A second acquirer must not silently take a lock another live process holds —
+    that is exactly how concurrent embeds delete each other's points."""
+    lp = tmp_path / "embed.lock"
+    lp.write_text(str(os.getpid()))  # this (alive) process "holds" it
+    with pytest.raises(EmbedLockHeld) as exc:
+        acquire(lp)
+    assert exc.value.pid == os.getpid()
+
+
+def test_acquire_reclaims_stale_lock_from_dead_pid(tmp_path):
+    lp = tmp_path / "embed.lock"
+    lp.write_text("999999999")  # not a live PID — stale lock
+    acquire(lp)
+    assert lp.read_text().strip() == str(os.getpid())
+
+
+def test_embed_lock_releases_on_exit(tmp_path):
+    lp = tmp_path / "embed.lock"
+    with embed_lock(lp):
+        assert lp.exists()
+    assert not lp.exists()
+
+
+def test_embed_lock_releases_on_exception(tmp_path):
+    lp = tmp_path / "embed.lock"
+    with pytest.raises(ValueError):
+        with embed_lock(lp):
+            raise ValueError("boom")
+    assert not lp.exists()
+
+
+def test_embed_lock_raises_when_held(tmp_path):
+    lp = tmp_path / "embed.lock"
+    lp.write_text(str(os.getpid()))
+    with pytest.raises(EmbedLockHeld):
+        with embed_lock(lp):
+            pass

--- a/carta/eval/harness.py
+++ b/carta/eval/harness.py
@@ -28,8 +28,18 @@ class EvalQuery:
 def load_eval_set(path: Path) -> list[EvalQuery]:
     data = yaml.safe_load(Path(path).read_text()) or {}
     out: list[EvalQuery] = []
-    for row in data.get("queries", []):
-        out.append(EvalQuery(q=str(row["q"]), expect=[str(e) for e in row.get("expect", [])]))
+    for i, row in enumerate(data.get("queries", [])):
+        # Drop blank expectations: an empty string is a substring of every file_path
+        # (guaranteed HIT) and an empty list is a guaranteed MISS — both silently
+        # corrupt recall/MRR (audit CA-26). A query with no usable expectation can
+        # never be scored meaningfully, so fail loudly rather than fake a number.
+        expect = [s for e in row.get("expect", []) if (s := str(e).strip())]
+        if not expect:
+            raise ValueError(
+                f"eval query #{i + 1} ({row.get('q', '?')!r}) has no usable 'expect' "
+                f"entries after dropping blanks — it can never be scored meaningfully."
+            )
+        out.append(EvalQuery(q=str(row["q"]), expect=expect))
     return out
 
 

--- a/carta/eval/tests/test_harness.py
+++ b/carta/eval/tests/test_harness.py
@@ -18,6 +18,29 @@ def test_load_eval_set(tmp_path):
                               expect=["serial-bridge", "CLAUDE.md"])
 
 
+def test_load_eval_set_rejects_blank_expectations(tmp_path):
+    """An empty-string expect is a substring of every path (guaranteed HIT) and an
+    empty expect list is a guaranteed MISS — both silently corrupt recall/MRR, so
+    load_eval_set must reject them loudly (audit CA-26)."""
+    import yaml
+    p = tmp_path / "set.yaml"
+    p.write_text(yaml.dump({"queries": [{"q": "x", "expect": [""]}]}))
+    with pytest.raises(ValueError):
+        load_eval_set(p)
+    p.write_text(yaml.dump({"queries": [{"q": "y", "expect": []}]}))
+    with pytest.raises(ValueError):
+        load_eval_set(p)
+
+
+def test_load_eval_set_strips_blank_but_keeps_real_expectations(tmp_path):
+    """A blank entry mixed with a real one is dropped, not fatal."""
+    import yaml
+    p = tmp_path / "set.yaml"
+    p.write_text(yaml.dump({"queries": [{"q": "x", "expect": ["  ", "real.md"]}]}))
+    qs = load_eval_set(p)
+    assert qs[0].expect == ["real.md"]
+
+
 def test_compute_metrics_hit_and_miss():
     eval_queries = [
         EvalQuery(q="A", expect=["alpha"]),

--- a/carta/install/bootstrap.py
+++ b/carta/install/bootstrap.py
@@ -354,19 +354,41 @@ def _remove_plugin_cache() -> bool:
 
 
 def _create_qdrant_collections(project_name: str, qdrant_url: str, vector_size: int = 768) -> bool:
-    """Create Qdrant collections. Returns True if all succeeded."""
+    """Create Qdrant collections with the schema the embed pipeline expects.
+
+    Routes through carta.embed.embed.ensure_collection — the SAME code path
+    `carta embed` uses — so init and embed can never create divergent schemas.
+    (Init previously PUT a raw unnamed-dense collection via HTTP; embed creates a
+    named hybrid dense+bm25 collection. Because ensure_collection skips existing
+    collections, an init-before-embed project was permanently stuck on dense-only
+    retrieval with BM25+RRF hybrid silently off — audit CA-10.)
+
+    An existing collection with a legacy (non-hybrid) schema is left untouched but
+    flagged loudly rather than silently rubber-stamped (audit CA-27).
+
+    Returns True if all collections are present with no hard failure.
+    """
+    from qdrant_client import QdrantClient
+    from carta.embed.embed import ensure_collection, collection_is_hybrid
+
+    try:
+        client = QdrantClient(url=qdrant_url, timeout=10)
+    except Exception as e:
+        print(f"  Error: could not connect to Qdrant at {qdrant_url}: {e}")
+        return False
+
     failures = 0
     for type_ in ["doc", "session", "notes"]:
         collection = f"{project_name}_{type_}"
         try:
-            r = requests.put(
-                f"{qdrant_url}/collections/{collection}",
-                json={"vectors": {"size": VECTOR_DIMENSIONS.get(type_, vector_size), "distance": "Cosine"}},
-                timeout=5,
-            )
-            if r.status_code not in (200, 409):
-                print(f"  Error: Qdrant returned {r.status_code} for collection {collection}: {r.text}")
-                failures += 1
+            existed = client.collection_exists(collection)
+            ensure_collection(client, collection)
+            if existed and not collection_is_hybrid(client, collection):
+                print(
+                    f"  Warning: existing collection {collection} uses a legacy "
+                    f"non-hybrid schema — BM25+RRF hybrid retrieval is OFF for it. "
+                    f"Drop it and re-embed to enable hybrid."
+                )
         except Exception as e:
             print(f"  Error: could not create collection {collection}: {e}")
             failures += 1

--- a/carta/install/tests/test_bootstrap.py
+++ b/carta/install/tests/test_bootstrap.py
@@ -109,14 +109,48 @@ def test_bootstrap_creates_namespaced_collections(tmp_path):
     assert isinstance(project_name, str) and len(project_name) > 0
 
 def test_create_qdrant_collections_uses_namespaced_names():
+    from unittest.mock import MagicMock
     from carta.install.bootstrap import _create_qdrant_collections
-    with patch("carta.install.bootstrap.requests") as mock_req:
-        mock_req.put.return_value.status_code = 200
+    client = MagicMock()
+    client.collection_exists.return_value = False
+    with patch("qdrant_client.QdrantClient", return_value=client):
         _create_qdrant_collections("my-project", "http://localhost:6333")
-    called_urls = [call.args[0] for call in mock_req.put.call_args_list]
-    assert any("my-project_doc" in url for url in called_urls)
-    assert any("my-project_session" in url for url in called_urls)
-    assert any("my-project_notes" in url for url in called_urls)
+    created = [c.kwargs["collection_name"] for c in client.create_collection.call_args_list]
+    assert "my-project_doc" in created
+    assert "my-project_session" in created
+    assert "my-project_notes" in created
+
+
+def test_create_qdrant_collections_creates_hybrid_schema():
+    """Init creates the named dense + bm25 sparse hybrid schema (CA-10) so an
+    init-before-embed project is not silently stuck on dense-only retrieval."""
+    from unittest.mock import MagicMock
+    from carta.install.bootstrap import _create_qdrant_collections
+    client = MagicMock()
+    client.collection_exists.return_value = False
+    with patch("qdrant_client.QdrantClient", return_value=client):
+        ok = _create_qdrant_collections("p", "http://localhost:6333")
+    assert ok
+    assert client.create_collection.call_args_list, "should create collections"
+    for c in client.create_collection.call_args_list:
+        assert "dense" in c.kwargs["vectors_config"]
+        assert "bm25" in c.kwargs["sparse_vectors_config"]
+
+
+def test_create_qdrant_collections_warns_on_legacy_existing_schema(capsys):
+    """Re-init over an existing NON-hybrid collection must warn, not silently
+    rubber-stamp it (audit CA-27)."""
+    from unittest.mock import MagicMock
+    from carta.install.bootstrap import _create_qdrant_collections
+    client = MagicMock()
+    client.collection_exists.return_value = True  # already exists
+    with patch("qdrant_client.QdrantClient", return_value=client), \
+         patch("carta.embed.embed.collection_is_hybrid", return_value=False):
+        ok = _create_qdrant_collections("p", "http://localhost:6333")
+    assert ok  # not a hard failure
+    out = capsys.readouterr().out.lower()
+    assert "legacy" in out or "hybrid" in out
+    client.create_collection.assert_not_called()  # existing collection left untouched
 
 def test_bootstrap_continues_if_qdrant_unavailable(tmp_path):
     """bootstrap should warn and continue (not exit) when Qdrant is unreachable but not critically failing."""

--- a/carta/install/tests/test_bootstrap.py
+++ b/carta/install/tests/test_bootstrap.py
@@ -128,7 +128,10 @@ def test_create_qdrant_collections_creates_hybrid_schema():
     from carta.install.bootstrap import _create_qdrant_collections
     client = MagicMock()
     client.collection_exists.return_value = False
-    with patch("qdrant_client.QdrantClient", return_value=client):
+    # Pin the hybrid path: ensure_collection builds the named dense+bm25 schema only
+    # when fastembed is importable (an optional extra absent from the base CI install).
+    with patch("qdrant_client.QdrantClient", return_value=client), \
+         patch("carta.embed.embed._fastembed_available", return_value=True):
         ok = _create_qdrant_collections("p", "http://localhost:6333")
     assert ok
     assert client.create_collection.call_args_list, "should create collections"

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -17,6 +17,7 @@ from typing import Literal, Optional, Union
 
 from carta.config import find_config, load_config, ConfigError
 from carta.embed.pipeline import run_search, run_embed_file, discover_stale_files, run_embed, FILE_TIMEOUT_S
+from carta.embed.lock import embed_lock, EmbedLockHeld
 from carta.scanner.scanner import check_embed_induction_needed, check_embed_drift
 from carta.search.scoped import get_search_collections
 
@@ -319,6 +320,25 @@ def carta_embed(
         path = scope
         scope = "file"
 
+    # Single-writer lock (audit CA-5/12): carta_embed mutates the same Qdrant
+    # collections as the CLI. Without the lock, an agent embedding here while the
+    # maintainer runs `carta embed` (the ET-embed scenario) — or two MCP calls —
+    # would race their cleanup-deletes and drop freshly-written points. Hold the
+    # shared .carta/embed.lock and refuse with a busy error rather than corrupt data.
+    try:
+        repo_root = _repo_root_from_cfg()
+    except (FileNotFoundError, ConfigError) as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+    lock_path = repo_root / ".carta" / "embed.lock"
+    try:
+        with embed_lock(lock_path):
+            return _carta_embed_run(scope, path, force, cfg)
+    except EmbedLockHeld as e:
+        return {"error": "busy", "detail": f"another embed is already running (PID {e.pid}); retry shortly"}
+
+
+def _carta_embed_run(scope, path, force, cfg) -> dict:
+    """Run the scope-specific embed. The caller holds the single-writer embed lock."""
     # scope='file' path
     if scope == "file":
         if path is None:

--- a/carta/mcp/tests/test_server.py
+++ b/carta/mcp/tests/test_server.py
@@ -692,3 +692,24 @@ def test_load_image_as_base64_returns_empty_on_missing_file():
     from carta.mcp.server import _load_image_as_base64
     result = _load_image_as_base64(Path("/nonexistent/path.png"))
     assert result == ""
+
+
+def test_carta_embed_returns_busy_when_lock_held(tmp_path):
+    """carta_embed must refuse with a busy error (not race the cleanup-delete) when
+    another live writer holds the embed lock — e.g. a CLI ET-embed (audit CA-5/12)."""
+    import os
+    from unittest.mock import patch
+    server = _get_server_module()
+
+    # Lock held by THIS (live) process.
+    lock = tmp_path / ".carta" / "embed.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text(str(os.getpid()))
+
+    with patch.object(server, "_load_cfg", return_value=_TEST_CFG), \
+         patch.object(server, "_repo_root_from_cfg", return_value=tmp_path), \
+         patch.object(server, "run_embed") as mock_run_embed:
+        result = server.carta_embed("all")
+
+    assert result.get("error") == "busy"
+    mock_run_embed.assert_not_called()  # must NOT write while another holds the lock

--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -16,7 +16,13 @@ import yaml
 
 def parse_frontmatter(doc_path: Path) -> Optional[dict]:
     """Return parsed YAML frontmatter dict, or None if none present."""
-    text = doc_path.read_text(encoding="utf-8")
+    try:
+        # utf-8-sig strips a BOM (which would defeat the leading '---' check);
+        # errors="replace" stops a stray non-UTF8 byte from crashing the whole
+        # scan + graph build, which call this unguarded over every doc.
+        text = doc_path.read_text(encoding="utf-8-sig", errors="replace")
+    except OSError:
+        return None
     if not text.startswith("---"):
         return None
     end = text.find("\n---", 3)

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -65,6 +65,21 @@ def test_parse_frontmatter_no_frontmatter(tmp_path):
     assert parse_frontmatter(doc) is None
 
 
+def test_parse_frontmatter_tolerates_non_utf8(tmp_path):
+    """A non-UTF8 byte must not crash parse_frontmatter — it is called unguarded in
+    a tight loop over every doc during scan + graph build (audit Group C: CA-22)."""
+    md = tmp_path / "bad.md"
+    md.write_bytes(b"---\ntitle: x\n---\n\nbody \xff\xfe end\n")  # invalid utf-8 in body
+    assert parse_frontmatter(md) == {"title": "x"}  # must not raise
+
+
+def test_parse_frontmatter_strips_utf8_bom(tmp_path):
+    """A UTF-8 BOM must not defeat the leading '---' frontmatter check."""
+    md = tmp_path / "bom.md"
+    md.write_bytes("﻿---\ntitle: y\n---\n\nbody\n".encode("utf-8"))
+    assert parse_frontmatter(md) == {"title": "y"}
+
+
 def test_parse_frontmatter_empty_related(tmp_path):
     doc = write_doc(tmp_path, "test.md", """\
         ---

--- a/carta/tests/test_bootstrap.py
+++ b/carta/tests/test_bootstrap.py
@@ -177,7 +177,10 @@ def test_bootstrap_creates_notes_not_quirk():
 
     client = MagicMock()
     client.collection_exists.return_value = False
-    with patch("qdrant_client.QdrantClient", return_value=client):
+    # Pin the hybrid path: ensure_collection builds the named dense+bm25 schema only
+    # when fastembed is importable (an optional extra absent from the base CI install).
+    with patch("qdrant_client.QdrantClient", return_value=client), \
+         patch("carta.embed.embed._fastembed_available", return_value=True):
         ok = bs._create_qdrant_collections("p", "http://localhost:6333")
     assert ok
     created = [c.kwargs["collection_name"] for c in client.create_collection.call_args_list]

--- a/carta/tests/test_bootstrap.py
+++ b/carta/tests/test_bootstrap.py
@@ -169,23 +169,23 @@ def test_bootstrap_continues_when_qdrant_unreachable(tmp_path):
             raise AssertionError(f"bootstrap exited with code {e.code} when Qdrant was unreachable") from e
 
 
-def test_bootstrap_creates_notes_not_quirk(monkeypatch):
-    """Init must create {project}_notes (what routing/search use), not legacy _quirk."""
-    from unittest.mock import MagicMock
+def test_bootstrap_creates_notes_not_quirk():
+    """Init must create {project}_notes (what routing/search use), not legacy _quirk,
+    with the hybrid named-dense + bm25 sparse schema the embed path expects (CA-10)."""
+    from unittest.mock import MagicMock, patch
     from carta.install import bootstrap as bs
 
-    calls = []
-
-    def fake_put(url, json=None, timeout=None):
-        calls.append(url)
-        r = MagicMock()
-        r.status_code = 200
-        return r
-
-    monkeypatch.setattr(bs.requests, "put", fake_put)
-    ok = bs._create_qdrant_collections("p", "http://localhost:6333")
+    client = MagicMock()
+    client.collection_exists.return_value = False
+    with patch("qdrant_client.QdrantClient", return_value=client):
+        ok = bs._create_qdrant_collections("p", "http://localhost:6333")
     assert ok
-    assert any(u.endswith("/collections/p_notes") for u in calls)
-    assert any(u.endswith("/collections/p_doc") for u in calls)
-    assert any(u.endswith("/collections/p_session") for u in calls)
-    assert not any(u.endswith("/collections/p_quirk") for u in calls)
+    created = [c.kwargs["collection_name"] for c in client.create_collection.call_args_list]
+    assert "p_notes" in created
+    assert "p_doc" in created
+    assert "p_session" in created
+    assert "p_quirk" not in created
+    # Hybrid schema: a named 'dense' vector + a 'bm25' sparse vector on each collection.
+    for c in client.create_collection.call_args_list:
+        assert "dense" in c.kwargs["vectors_config"]
+        assert "bm25" in c.kwargs["sparse_vectors_config"]

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -895,3 +895,31 @@ def test_cmd_hook_check_diff_no_findings_exits_zero(tmp_path, monkeypatch):
     with pytest.raises(SystemExit) as exc:
         cli.cmd_hook(args)
     assert exc.value.code == 0
+
+
+def test_cmd_embed_exits_nonzero_on_failed_or_partial(tmp_path):
+    """A bulk embed that reports failed/partial files must warn and exit non-zero
+    so an ET-embed run can never report false-green (audit CA-1/4/7)."""
+    from unittest.mock import patch
+    from carta import cli
+
+    cfg_file = tmp_path / ".carta" / "config.yaml"
+    cfg_file.parent.mkdir()
+    cfg_file.write_text("project_name: test\nqdrant_url: http://localhost:6333\n")
+
+    cfg = {"project_name": "test", "qdrant_url": "http://localhost:6333",
+           "modules": {"doc_embed": True}, "embed": {}}
+    summary = {"embedded": 2, "skipped": 0, "extraction_failed": 0,
+               "failed": ["bad.md"], "partial": [], "errors": [], "timed_out": []}
+    args = type("A", (), {"repair": False, "visual": False, "files": None,
+                          "timeout": None, "no_tune": True})()
+
+    with patch("carta.cli.find_config", return_value=cfg_file), \
+         patch("carta.config.load_config", return_value=cfg), \
+         patch("carta.registry.register_project"), \
+         patch("carta.cli._maybe_tune_workers", side_effect=lambda c, skip=False: c), \
+         patch("carta.embed.pipeline.run_embed", return_value=summary), \
+         patch("carta.cli._notify_if_update"):
+        with pytest.raises(SystemExit) as exc:
+            cli.cmd_embed(args)
+    assert exc.value.code == 1

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -259,6 +259,15 @@ class TestCmdEvalRerankAssertion:
         assert code is None
         assert "rerank: applied on 1/2 queries" in captured.out
 
+    def test_partial_applied_warns_on_stderr(self, tmp_path, capsys):
+        """Partial reranker fail-open must surface a loud stderr warning so a
+        partially-reranked score can't be mistaken for a clean run (audit CA-20)."""
+        code = self._run(tmp_path, rerank_enabled=True, applied_per_query=[True, False])
+        captured = capsys.readouterr()
+        assert code is None  # still passes (don't change go/no-go), but it warns
+        err = captured.err.lower()
+        assert "partial" in err or "failed open" in err
+
     def test_all_applied_reports_count(self, tmp_path, capsys):
         code = self._run(tmp_path, rerank_enabled=True, applied_per_query=[True, True])
         captured = capsys.readouterr()

--- a/carta/tests/test_embed_targeted.py
+++ b/carta/tests/test_embed_targeted.py
@@ -15,9 +15,10 @@ def _make_args(files):
 
 @patch("carta.embed.pipeline.run_embed_file")
 @patch("carta.config.load_config")
-@patch("carta.config.find_config")
+@patch("carta.cli.find_config")
 def test_targeted_calls_run_embed_file(mock_find_config, mock_load_config, mock_run_embed_file, tmp_path):
-    """When files are passed, run_embed_file is called for each, lock is skipped."""
+    """When files are passed, run_embed_file is called for each; targeted embed now
+    also holds the single-writer lock (audit CA-2)."""
     from carta.cli import cmd_embed
 
     cfg_path = tmp_path / ".carta" / "config.yaml"
@@ -34,7 +35,7 @@ def test_targeted_calls_run_embed_file(mock_find_config, mock_load_config, mock_
     pdf = tmp_path / "test.pdf"
     pdf.touch()
 
-    with patch("carta.cli._acquire_embed_lock") as mock_lock, \
+    with patch("carta.embed.lock.acquire") as mock_lock, \
          patch("carta.ui.Progress") as MockProgress:
         mock_progress = MagicMock()
         mock_progress.__enter__ = MagicMock(return_value=mock_progress)
@@ -45,8 +46,8 @@ def test_targeted_calls_run_embed_file(mock_find_config, mock_load_config, mock_
             cmd_embed(_make_args([str(pdf)]))
 
         assert exc_info.value.code == 0
-        # Lock must NOT be acquired for targeted embed
-        mock_lock.assert_not_called()
+        # Targeted embed now holds the single-writer lock too (audit CA-2).
+        mock_lock.assert_called_once()
         # run_embed_file called with force=True
         mock_run_embed_file.assert_called_once_with(
             Path(str(pdf)), mock_load_config.return_value, force=True, progress=mock_progress
@@ -55,7 +56,7 @@ def test_targeted_calls_run_embed_file(mock_find_config, mock_load_config, mock_
 
 @patch("carta.embed.pipeline.run_embed_file")
 @patch("carta.config.load_config")
-@patch("carta.config.find_config")
+@patch("carta.cli.find_config")
 def test_targeted_missing_file_exits_1(mock_find_config, mock_load_config, mock_run_embed_file, tmp_path):
     """FileNotFoundError from run_embed_file causes exit(1)."""
     from carta.cli import cmd_embed
@@ -85,7 +86,7 @@ def test_targeted_missing_file_exits_1(mock_find_config, mock_load_config, mock_
 
 @patch("carta.embed.pipeline.run_embed_file")
 @patch("carta.config.load_config")
-@patch("carta.config.find_config")
+@patch("carta.cli.find_config")
 def test_targeted_multiple_files_all_processed(mock_find_config, mock_load_config, mock_run_embed_file, tmp_path):
     """All files are processed even if one errors; exit 1 if any errors."""
     from carta.cli import cmd_embed

--- a/carta/tests/test_integrity.py
+++ b/carta/tests/test_integrity.py
@@ -164,6 +164,26 @@ class TestScanCorpusIntegrity:
         report = scan_corpus_integrity(CFG, tmp_path, client=_client_with_points(pts))
         assert report["count_mismatches"] == {"docs/a.md": {"sidecar": 5, "qdrant": 2}}
 
+    def test_note_sidecar_counted_against_notes_not_doc(self, tmp_path):
+        """Notes route to {project}_notes; their chunk_count must be compared against
+        _notes, not _doc — else every embedded note is a false count-mismatch that
+        --repair needlessly re-embeds (audit CA-15)."""
+        from carta.embed.induct import sidecar_path
+        cfg = {"project_name": "p", "qdrant_url": "x"}
+        by_coll = {
+            "p_doc": [],
+            "p_notes": [_point("docs/quirks/q.md", "q", 0, "note body")],
+        }
+        sc = sidecar_path(tmp_path / "docs/quirks/q.md", tmp_path)
+        sc.parent.mkdir(parents=True, exist_ok=True)
+        sc.write_text(yaml.dump({
+            "current_path": "docs/quirks/q.md", "doc_type": "quirk",
+            "chunk_count": 1, "status": "embedded", "file_hash": "h",
+        }))
+        report = scan_corpus_integrity(cfg, tmp_path, client=_client_with_collections(by_coll))
+        assert "docs/quirks/q.md" not in report["count_mismatches"]
+        assert "docs/quirks/q.md" not in report["affected_files"]
+
     def test_detects_stuck_stale(self, tmp_path):
         # File on disk whose hash MATCHES the sidecar → stuck stale
         src_match = tmp_path / "docs" / "match.md"

--- a/carta/tests/test_lifecycle.py
+++ b/carta/tests/test_lifecycle.py
@@ -325,3 +325,19 @@ class TestDeleteOtherPoints:
         client = MagicMock()
         delete_other_points(client, "proj_doc", "x.md", keep_ids=[])
         client.delete.assert_called_once()
+
+    def test_retries_transient_delete_error(self):
+        """A transient delete failure must be retried — else old-generation points
+        survive and resurface in search until `carta embed --repair` (audit CA-14)."""
+        client = MagicMock()
+        calls = {"n": 0}
+
+        def flaky(**kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient 503")
+            return None
+
+        client.delete.side_effect = flaky
+        delete_other_points(client, "proj_doc", "x.md", keep_ids=["id-x"])  # no raise
+        assert calls["n"] >= 2

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -525,9 +525,12 @@ class TestVisionIntegration:
 
         with patch("carta.embed.pipeline.QdrantClient") as mock_client_cls:
             with patch("carta.embed.pipeline.extract_pdf_text", return_value=[{"page": 1, "text": "Text content"}]):
-                with patch("carta.embed.pipeline.chunk_text", return_value=[{"text": "Chunk", "page": 1}]):
+                with patch("carta.embed.pipeline.chunk_text", return_value=[{"text": "Chunk", "page": 1, "chunk_index": 0}]):
                     with patch("carta.vision.router.extract_image_descriptions_intelligent") as mock_vision:
-                        with patch("carta.embed.pipeline.upsert_chunks", return_value=0):
+                        # 1 text chunk persisted (chunk_text yields 1) so text embedding
+                        # genuinely succeeds — the point of this test is vision fail-open,
+                        # not a persistence failure (which is now its own status).
+                        with patch("carta.embed.pipeline.upsert_chunks", return_value=1):
                             with patch("carta.embed.pipeline.write_sidecar"):
                                 # Vision model unavailable: returns empty (fail-open)
                                 mock_vision.return_value = []

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1178,3 +1178,34 @@ class TestRunEmbedExtractionFailedSummary:
 
         assert summary["extraction_failed"] == 1
         assert summary["embedded"] == 0
+
+
+def test_run_search_passes_repo_root_not_dotcarta_to_graph_expansion(tmp_path):
+    """run_search must compute repo_root as the dir CONTAINING .carta (parent.parent
+    of the config), not the .carta dir itself — else graph expansion globs an empty
+    .carta dir and silently promotes nothing (audit CA-23)."""
+    from unittest.mock import patch, MagicMock
+    from carta.embed import pipeline
+
+    cfg_path = tmp_path / ".carta" / "config.yaml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text("")
+    cfg = {
+        "project_name": "t", "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "u", "ollama_model": "m"},
+        "search": {"top_n": 5, "graph": {"enabled": True}},
+    }
+
+    captured = {}
+
+    def fake_graph(results, cfg_, repo_root):
+        captured["repo_root"] = repo_root
+        return results
+
+    with patch("carta.embed.pipeline.find_config", return_value=str(cfg_path)), \
+         patch("carta.embed.pipeline.QdrantClient", return_value=MagicMock()), \
+         patch("carta.search.scoped.get_search_collections", return_value=[]), \
+         patch("carta.embed.pipeline._apply_graph_expansion", side_effect=fake_graph):
+        pipeline.run_search("q", cfg)
+
+    assert captured["repo_root"] == tmp_path  # repo root, NOT tmp_path/.carta

--- a/docs/audits/2026-06-16-pre-reembed-code-audit.md
+++ b/docs/audits/2026-06-16-pre-reembed-code-audit.md
@@ -149,3 +149,31 @@ These cause **silent data loss, wrong retrieval, or broken verification during/a
 6. **Group J/CA-3**, then **F (lock)**, **G (MCP search)**, **H (hook)**, **I (visual)**.
 
 Each fix follows the project's Superpowers TDD flow (failing test → fix → green), grouped into focused PRs by root cause.
+
+---
+
+## Disposition — fix session 2026-06-16
+
+Branch `audit/2026-06-16-comprehensive`, one commit per root-cause group, TDD throughout. Suite **982 → 1009 passing, 1 skipped** (+27 tests). All work landed green.
+
+| Group | Findings | Status | Commit |
+|-------|----------|--------|--------|
+| A — honest success accounting | CA-1, CA-4, CA-6, CA-7 | ✅ fixed | `050400c` |
+| C — encoding robustness | CA-13, CA-22 (+BOM) | ✅ fixed | `2a3c028` |
+| D — init hybrid schema | CA-10, CA-27 | ✅ fixed | `8730eb1` |
+| B — cleanup / notes | CA-15, CA-14 | ✅ fixed | `395af1f` |
+| B — deleted-source orphans | **CA-16** | ⏸️ **deferred** | — |
+| E — verification tooling | CA-17, CA-20, CA-23, CA-26 | ✅ fixed | `5bd05a3` |
+| J — timeout footgun | CA-3 | ✅ fixed | `2600d70` |
+| F — single-writer lock | CA-2, CA-5, CA-12 | ✅ fixed | `e5d1b0d` |
+| F — lock PID-reuse identity | **CA-25** | ⏸️ **deferred** | — |
+
+**Deferred (within the agreed blocker set), with rationale:**
+- **CA-16** (purge deleted-source points on a normal run): adding source-existence orphan detection to `integrity.py` false-positives across many existing integrity tests that assert on `_doc` points without creating real source files. Best done as a focused change that also updates those fixtures. Mitigation today: `delete_other_points` retry (CA-14) + the existing `--repair` path.
+- **CA-25** (PID-reuse makes a stale lock look alive): low-probability; the lock self-heals stale locks from dead PIDs and prints a remediation hint. A start-time identity check is the follow-up.
+
+**Out of scope this session** (the "Everything" tier, not part of the chosen blocker set — recommended next):
+- **Group G** — MCP `carta_search` bypasses `run_search` (raw-score merge lets visual swamp text): CA-11, CA-18.
+- **Group H** — hook output contract may be a runtime no-op + no latency budget: CA-8 (verify against current Claude Code docs first), CA-9.
+- **Group I** — visual drain marks pages done with no vector + dead `visual_timeout_s`: CA-19, CA-24.
+- The 48 medium/low items remain triaged in the table above.

--- a/docs/audits/2026-06-16-pre-reembed-code-audit.md
+++ b/docs/audits/2026-06-16-pre-reembed-code-audit.md
@@ -1,0 +1,151 @@
+# Carta Pre-Re-Embed Code Audit — 2026-06-16
+
+**Goal:** surface and fix issues before a full re-embed of real corpora (ET-embed).
+**Audit target:** branch `audit/2026-06-16-comprehensive` cut from `origin/main` @ `9b08b17` (includes merged PRs #54–#68). Test baseline: **982 passed, 1 skipped — green.**
+**Method:** 40-agent fan-out across 12 subsystems → independent adversarial verification of every high/critical finding → maintainer re-verified the embed/data path by hand. 76 raw findings → **27 confirmed high/critical, 48 medium/low, 1 refuted.**
+
+> Scope note: this is a **code/correctness** audit, distinct from the doc-structure audit in `AUDIT_REPORT.md` (AUDIT-001..019).
+
+---
+
+## Executive summary
+
+The codebase is well-engineered in the small (RRF math, chunking, point-ID scheme, LLM-rerank parsing, default visual-lane isolation are all solid and tested). The risk is concentrated in **integration seams and failure-accounting**, and one root cause dominates:
+
+> **The embed pipeline derives "success" from *reaching the end of the function*, not from *persisting what it expected*. Ollama and Qdrant errors are swallowed (caught + printed, `return 0`) instead of surfaced.** A file is stamped `status:"embedded"` (and counted in the green summary, and its `file_hash` recorded) **before** the pipeline knows whether any vectors landed.
+
+Consequences during a long ET-embed run against a real corpus:
+- A transient Ollama blip zeroes out **whole files** → marked embedded, never retried ([CA-1]).
+- A transient Qdrant blip drops **32-chunk batches** → marked embedded, never retried ([CA-4]).
+- A non-768 embedding model → **every batch silently fails**, reported as success ([CA-6]).
+- A partial upsert → file frozen **half-old/half-new**, never re-picked ([CA-7]).
+- Because the write-path Qdrant client uses `timeout=5` (the shortest in the codebase; reads use 30) and there is **no retry anywhere** in the write path, these blips are *likely*, not theoretical, under the load a full re-embed puts on Qdrant/Ollama.
+
+Secondary cross-cutting themes:
+- **Re-embed cleanup is non-atomic with no safety net** — superseded points survive any cleanup hiccup and `run_search` applies **no generation/stale filter**, so stale chunks resurface ([CA-14, CA-16]). Integrity tooling is **blind to `_notes`** ([CA-15]).
+- **Init creates the wrong collection schema** — `carta init` then `carta embed` permanently disables BM25+RRF hybrid retrieval ([CA-10]).
+- **Verification tooling you'll use to trust the run is itself broken** — `carta audit` caps at the first 1000 points ([CA-17]); eval can silently report partially-degraded numbers ([CA-20, CA-26]); graph expansion is a dead no-op ([CA-23]).
+- **No single-writer guarantee** across `--repair`/`--visual`/targeted/MCP embed paths → concurrent writers delete each other's points ([CA-2/5/12]).
+- **MCP `carta_search` (the agent-facing surface) bypasses `run_search`** — no RRF/rerank/graph, merges by raw score so visual swamps text ([CA-11/18]).
+- **The proactive-recall hook may be a runtime no-op** — emits `{"context":...}` where Claude Code expects `hookSpecificOutput.additionalContext` ([CA-8]); and it has no latency budget ([CA-9]).
+
+---
+
+## MUST-FIX before ET-embed (blockers)
+
+These cause **silent data loss, wrong retrieval, or broken verification during/after the re-embed itself**.
+
+### Group A — Embed pipeline: honest success accounting  *(the core blocker)*
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-1 | **CRITICAL** | Total Ollama failure → file stamped `embedded` with 0 vectors; `file_hash` recorded so it's never re-picked by pending/stale discovery | `pipeline.py:569-578,599-660,1452-1455`; `embed.py:283-313` |
+| CA-4 | HIGH | Whole 32-chunk batch lost on any Qdrant upsert error; `flush()` swallows it, returns 0, not in summary | `embed.py:267-275` |
+| CA-6 | HIGH | `VECTOR_DIM=768` hardcoded, no `len(vec)` check; non-768 model → every batch silently rejected, reported success | `embed.py:25,98-129,230-265` |
+| CA-7 | HIGH | Partial upsert leaves `status:"embedded"`; missing chunks never re-picked | `pipeline.py:653-658` vs `569-578` |
+| (med) | MED | Non-overflow Ollama errors (5xx/timeout/reset) get **no retry** | `embed.py:86-95` |
+| (med) | MED | Dense lane truncates oversized input; BM25 sparse lane does not → the two vectors of one point describe different text | `embed.py:72-95` vs `254-256` |
+
+**Root fix:** derive success from *persisted == expected*; add `summary['failed']`/`'partial']` and a re-pickable sidecar status (e.g. `embed_failed`); raise the write-path Qdrant `timeout` well above 5s; add bounded retry on transient Ollama/Qdrant errors; assert `len(vec)==expected` and reconcile collection dim with the live model.
+
+### Group B — Re-embed cleanup / stale duplicates
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-14 | HIGH | Old-gen chunks become **permanent searchable duplicates** if `delete_other_points` hiccups — no query-time generation filter, nothing ever sets `orphaned_at`, so no background sweep | `lifecycle.py:171-189`; `pipeline.py:644-658,1768-1773` |
+| CA-15 | HIGH | Integrity scan + `--repair` **blind to `_notes`** → every embedded note shows false count-mismatch (needless re-embed churn); deleted/duplicate note points never cleaned | `integrity.py:57`; `repair.py:39` |
+| CA-16 | HIGH | Deleted source files keep all vectors in `_doc` on a normal re-embed (only warned, never purged) | `pipeline.py:1309-1317` |
+| (med) | MED | `_visual` points never cleaned and IDs not generation-versioned → reclassified pages orphan | `embed.py:174-177` |
+
+**Root fix:** make supersede recoverable — stamp existing points `orphaned_at=now` before re-upsert (so `cleanup_expired_orphans` is a real backstop) **and/or** add a `doc_generation` filter to `run_search`; purge orphaned/deleted-file points on the normal run; extend integrity+repair to `_notes`.
+
+### Group C — Encoding robustness (real corpora have stray encodings)
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-13 | HIGH | Non-UTF8 markdown → `UnicodeDecodeError` → file silently dropped, **no `extraction_failed` bookkeeping**, retried-and-fails forever, invisible in status | `parse.py:177`; `pipeline.py:1394-1441` |
+| CA-22 | MED | `parse_frontmatter` crashes the **whole scan + graph/embed** on one non-UTF8 `.md` | `scanner.py:19` |
+| (med) | MED | UTF-8 BOM defeats frontmatter strip + H1 title detection | `parse.py:177` |
+
+**Root fix:** defensive decode (`utf-8-sig`, `errors="replace"`); write a durable `extraction_failed` sidecar on decode error.
+
+### Group D — Init creates the wrong schema (degrades ALL retrieval)
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-10 | HIGH | `carta init` creates **unnamed-dense** collections via raw HTTP; embed expects **named hybrid** (dense+bm25). `ensure_collection` early-returns on existing, so init-before-embed → hybrid BM25+RRF silently **off forever**. A re-embed faithfully fills the wrong schema. | `bootstrap.py:356-373` vs `embed.py:98-129` |
+| CA-27 | LOW | Re-`init` rubber-stamps a pre-existing wrong/incompatible schema as success (200/409) | `bootstrap.py:362-369` |
+
+**Root fix:** bootstrap should call `ensure_collection`/`ensure_visual_collection` (single source of truth) or replicate the named hybrid schema; GET-and-validate existing collections.
+
+### Group E — Post-re-embed verification tooling (so you can trust the run)
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-17 | HIGH | `audit.py` scroll pagination broken (`offset=len(points)`=1000 against UUID-keyed points) → audit **caps at first 1000 chunks**; >1000-point corpora get false orphan/disconnected/mismatch results | `audit.py:82-110` |
+| CA-23 | MED | Graph expansion is a **silent no-op** in `run_search` (`repo_root` = `.carta` dir, not repo root) → "graph neutral" eval conclusion is unreliable | `pipeline.py:1647` |
+| CA-20 | MED | Eval hard-fail gate catches only **total** rerank fail-open, not partial → a 0.8B reranker degrading on N/62 queries reports a trusted-looking "reranked" score | `cli.py:660-667` |
+| CA-26 | LOW | Empty / empty-string `expect` silently forces guaranteed MISS / guaranteed HIT → deflates/inflates recall | `harness.py:36-42` |
+
+**Root fix:** mirror `integrity._scroll_all` paging; fix `repo_root` to `parent.parent`; warn/exit on partial rerank; validate eval expectations.
+
+### Group J — CLI footgun
+| ID | Sev | Finding | Location |
+|----|-----|---------|----------|
+| CA-3 | HIGH | `--timeout 0` / `file_timeout_s 0` → `join(0)` flags **every** file TIMEOUT, embeds nothing, **exits 0** (docs imply 0 = unbounded) | `cli.py:199-201`; `pipeline.py:1401-1426` |
+
+**Root fix:** treat `<=0` as unbounded (match `visual_timeout_s`); exit non-zero when `embedded==0 and timed_out>0`.
+
+---
+
+## HIGH — fix soon (concurrency, MCP, hook, visual)
+
+### Group F — Single-writer / locking
+- **CA-2 / CA-5 / CA-12 [HIGH]** — embed lock covers only `cmd_embed`'s full-pipeline branch; `--repair`, `--visual`, targeted `--files`, and **all MCP `carta_embed`** paths are lockless → concurrent writers' `delete_other_points` removes each other's just-written points. (`cli.py:262`; `mcp/server.py:350-384`; `repair.py:32`)
+- **CA-21 [MED]** — MCP tools are sync `def` run on the event loop; a long `carta_embed(scope=all)` blocks all other JSON-RPC → client timeout, no progress/cancel. (`mcp/server.py:295-384`)
+- **CA-25 [LOW]** — bare-PID lock + OS PID reuse can permanently block future re-embeds after a hard kill. (`cli.py:105-149`)
+
+**Root fix:** one shared lock helper acquired by every mutating embed entry point; MCP returns `{"error":"busy"}` instead of racing; store PID+start-time or use `fcntl.flock`.
+
+### Group G — MCP search parity
+- **CA-11 / CA-18 [HIGH]** — `carta_search` imports but never calls `run_search`; it does per-collection dense-only queries and **sorts by raw score**, so once a `_visual` collection exists, ColPali MaxSim (~10–40) swamps text cosine (~0–1) for every query; no RRF/rerank/graph/visual-cap. The agent-facing surface diverges hard from CLI/hook. (`mcp/server.py:79-137`)
+
+**Root fix:** route `carta_search` through `run_search` (extend it to accept scope), or at minimum reuse `_rrf_merge_collections` with `visual_max_ratio`.
+
+### Group H — Hook
+- **CA-8 [HIGH]** — `_inject()` emits `{"context": ...}`; Claude Code's `UserPromptSubmit` contract for added context is `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}` (or plain stdout). If correct, **the entire proactive-recall feature is a runtime no-op** while unit tests pass (they assert the hook's own dict, not what CC consumes). The project's own research doc flagged this exact risk. **⚠ Verify against current Claude Code docs before changing.** (`hook.py:223-225`)
+- **CA-9 [HIGH]** — no latency budget around `run_search`; query-embed (`timeout=60`, ×4 attempts) + Qdrant (`timeout=10`) can block prompt submission ~60s, especially while ET-embed saturates Ollama. (`hook.py:92-96`)
+
+**Root fix:** emit the documented shape (after verification); wrap search+judge in a total hook budget (2–4s) and fail open on timeout.
+
+### Group I — Visual drain
+- **CA-19 [HIGH]** — a page is marked `visual_done` even when ColPali wrote **no vector** (`embed_pdf_pages` swallows a per-batch failure and returns `[]`); never re-queued → silent visual loss. (`pipeline.py:949-971`)
+- **CA-24 [MED]** — `visual_timeout_s` is **dead config** (never read); the `--visual` drain has no watchdog and can hang forever on one wedged page. (`pipeline.py:974-1074`)
+
+**Root fix:** assert a vector was produced before `move_to_done`; wire `visual_timeout_s` into a per-page daemon-thread watchdog like `file_timeout_s`.
+
+---
+
+## Medium / Low backlog (48 findings, by theme)
+
+- **Config/CLI:** list-replacing deep-merge drops default `excluded_paths` when user sets it; `CARTA_*_URL` honored only at init not runtime; no numeric/url type checks.
+- **Embed/parse:** sparse generation serial in main thread (defeats workers); BOM/H1/code-fence title edge cases; `vision/chunking.py` table-preserving module + `preserve_tables` are **dead code** (OCR tables flattened/split mid-row); `sections_from_markdown` ignores H1 boundaries.
+- **Re-embed:** plain `carta embed` re-run does **not** re-embed content-changed files (staleness only alerted, no bulk force path); sidecar status drift `"embedded"` vs plan's `"current"`.
+- **Search/eval:** rerank nullifies visual lane (placeholder excerpt); `_parse_order` coerces JSON bool/float to ranks; "recall@k" is really hit-rate@k; malformed eval YAML crashes; non-positive `-k` → all-MISS.
+- **Scanner/audit:** `detect_disconnected_files` exclusion never matches dir patterns; `get_changed_since_hash` silently returns `[]` on unreachable prev hash; orphaned-doc false positives on raw-vs-canonical `related:` keys.
+- **MCP/install:** dead scope-coercion branch; `carta init` hard-aborts if a stale plugin-cache dir can't be removed; vector-dim truth duplicated across 3 sites; version-compare mishandles ragged/`v`-prefixed tuples.
+- **Docs:** doc-audit report split-brain (`docs/AUDIT_REPORT.md` vs root); packaged `carta/skills/` diverged from `skills/`; CLAUDE.md retains v0.2/GSD framing (AUDIT-006 still open); bootstrap AGENTS.md documents only 3 commands; `config.yaml.example` omits `build/`,`temp/`; `carta hook` absent from README.
+- **Hook:** empty/whitespace query still searched; gray-zone judge doc says "fail-open" but is fail-closed.
+- **Visual:** MPS path lacks the segfault/dtype guard; test configs use non-`-hf` model IDs.
+
+(Full per-finding detail with reproduction + fix is in the workflow result; IDs map to the verified findings list.)
+
+## Refuted (1)
+- **CRLF markdown breaks frontmatter stripping** — refuted: `extract_markdown_text`/hash path LF-normalizes before the regex runs, so the isolated regex's CRLF-intolerance is not reachable via the real call path.
+
+---
+
+## Recommended fix sequence
+1. **Group A** (honest success accounting) — highest leverage; neutralizes the whole silent-loss family. TDD: simulate Ollama-all-fail, Qdrant-batch-fail, dim-mismatch, partial-upsert → assert re-pickable status + non-zero accounting.
+2. **Group C** (encoding) — small, removes silent file drops.
+3. **Group D/CA-10** (init hybrid schema) — ensures the re-embed actually populates hybrid.
+4. **Group B** (cleanup/dupes/notes) — correctness of the re-embedded corpus over time.
+5. **Group E** (audit/eval/graph verification) — so the post-embed checks are trustworthy.
+6. **Group J/CA-3**, then **F (lock)**, **G (MCP search)**, **H (hook)**, **I (visual)**.
+
+Each fix follows the project's Superpowers TDD flow (failing test → fix → green), grouped into focused PRs by root cause.


### PR DESCRIPTION
## Summary

A comprehensive pre-re-embed audit of Carta (40-agent fan-out across 12 subsystems + adversarial verification + hand-verification of the data path) surfaced **27 confirmed high/critical + 48 medium/low** issues. This PR fixes the **full blocker set** as focused, TDD'd, per-root-cause commits and rolls the CHANGELOG to **0.12.0**.

Full report + per-finding disposition: `docs/audits/2026-06-16-pre-reembed-code-audit.md`.

**Tests: 982 → 1009 passing, 1 skipped** — green at every commit.

## Headline

The embed pipeline marked files `status:"embedded"` from *reaching the end of the run*, not from *confirming vectors persisted* — Ollama/Qdrant errors were swallowed (`return 0`). During a large re-embed a transient blip could silently zero out whole files / 32-chunk batches with a green summary, never retried. Amplified by a write-path Qdrant `timeout=5` (reads use 30) and no retry in the write path.

## Fixes (commit per root cause)

| Group | Findings | What it stops |
|---|---|---|
| A — honest success accounting | CA-1/4/6/7 | silent file/batch loss; re-pickable `embed_failed`/`partial`, retry, timeout 5→30s, dim guard, non-zero exit |
| C — encoding robustness | CA-13/22 | BOM/non-UTF8 markdown dropped or crashing the scan |
| D — init hybrid schema | CA-10/27 | `carta init` permanently disabling BM25+RRF hybrid |
| B — integrity/cleanup | CA-14/15 | false `_notes` count-mismatch flood; un-retried stale cleanup |
| E — verification tooling | CA-17/20/23/26 | `carta audit` capped at 1000 pts; eval/graph trust |
| J — timeout footgun | CA-3 | `--timeout 0` embedding nothing yet exiting 0 |
| F — single-writer lock | CA-2/5/12 | concurrent CLI/MCP writers deleting each other's points |

## Deferred (in-scope, noted in commits + report)
- **CA-16** (purge deleted-source orphans on a normal run) — needs broader integrity-test fixture changes; mitigated by CA-14 retry + `--repair`.
- **CA-25** (lock PID-reuse identity) — low severity; lock self-heals dead-PID stale locks.

## Out of scope (recommended next, not in this PR)
- **Group H** — hook output contract may be a runtime no-op (CA-8, verify vs current Claude Code docs first) + no latency budget (CA-9).
- **Group G** — MCP `carta_search` raw-score merge lets visual swamp text (CA-11/18).
- **Group I** — visual drain marks pages done with no vector + dead `visual_timeout_s` (CA-19/24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)