### PR TITLE
fix(scanner): exclude vendored/scratch dirs + exempt READMEs from orphan check (0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to **carta-cc** are documented here. The format is loosely b
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-06-16
+
+### Fixed — scanner false positives
+Follow-up to the 0.12.0 audit, cutting `carta scan` noise so the real doc-hygiene signal isn't buried. On the ET-embed corpus these two fixes removed 19 false findings (`homeless_doc` 34→18, `orphaned_doc` 6→3) with no real finding lost.
+- **Exclude vendored / virtualenv / scratch dirs.** `_ALWAYS_EXCLUDED_DIRS` covered only `.claude/worktrees/`, `build/`, `temp/`, so commonly-gitignored machine dirs were still walked and reported — e.g. 15 `tmp/` scratch docs and a `.pixi/.../site-packages/` vendored file flagged as `homeless_doc`. Added `tmp/`, `dist/`, `node_modules/`, `.venv/`, `venv/`, `.pixi/`, `site-packages/`, `.tox/` (matched as a path substring, so envs nested under a subproject are caught too). These live in `_ALWAYS_EXCLUDED_DIRS` rather than `DEFAULTS["excluded_paths"]` because an existing `config.yaml` replaces `excluded_paths` wholesale, so defaults never reach installed repos.
+- **Exempt READMEs from the `orphaned_doc` check.** A directory README is a navigational index discoverable by structure, not islanded knowledge — so having no inbound `related:` links is expected, not a problem (mirrors the existing homeless-check README skip). Sole-README section indexes are no longer false-flagged as orphans.
+
 ## [0.12.0] — 2026-06-16
 
 ### Fixed — pre-ET-embed reliability & correctness audit (CA-1..CA-27)

--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -490,7 +490,15 @@ def suggest_related_for_all(
 def check_orphaned_doc(
     doc_path: Path, frontmatter, inverted_index: dict, repo_root: Path
 ) -> Optional[dict]:
-    """Flag docs not referenced by any other doc's related: AND with no folder siblings."""
+    """Flag docs not referenced by any other doc's related: AND with no folder siblings.
+
+    READMEs are exempt: a directory README is a navigational index / front-door,
+    discoverable by structure rather than by graph edges, so having no inbound
+    related: links is expected, not a problem (parallels check_homeless_docs'
+    README skip). Without this, sole-README section indexes get false-flagged.
+    """
+    if doc_path.name == "README.md":
+        return None
     rel = str(doc_path.relative_to(repo_root))
     if rel in inverted_index:
         return None

--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -49,9 +49,18 @@ def parse_frontmatter(doc_path: Path) -> Optional[dict]:
 # Machine/tooling dirs that are never valid scan targets — excluded regardless
 # of user config, like .git (skipped in _iter_md_files). Existing repos carry a
 # config.yaml whose excluded_paths replaces DEFAULTS wholesale (_deep_merge does
-# not merge lists), so DEFAULTS alone would never reach them. `.claude/worktrees/`
-# holds full-repo worktree copies; `build/` holds packaging mirrors; `temp/` is scratch.
-_ALWAYS_EXCLUDED_DIRS = (".claude/worktrees/", "build/", "temp/")
+# not merge lists), so DEFAULTS alone would never reach them — these must live
+# here to reach existing installs. `.claude/worktrees/` holds full-repo worktree
+# copies; `build/`/`dist/` hold packaging mirrors; `temp/`/`tmp/` are scratch; the
+# rest are vendored deps / virtualenvs / tooling caches whose markdown (READMEs,
+# vendored docs, site-packages) is never project knowledge. Patterns are matched
+# as a path substring (see is_excluded), so envs nested under a subproject — e.g.
+# analysis/**/.pixi/.../site-packages/ — are caught too. All are commonly
+# gitignored yet were still being walked and reported as doc-hygiene issues.
+_ALWAYS_EXCLUDED_DIRS = (
+    ".claude/worktrees/", "build/", "dist/", "temp/", "tmp/",
+    "node_modules/", ".venv/", "venv/", ".pixi/", "site-packages/", ".tox/",
+)
 
 
 def is_excluded(file_path: Path, cfg: dict, repo_root: Path) -> bool:

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -539,6 +539,21 @@ def test_orphaned_doc_not_flagged_if_has_siblings(tmp_path):
     assert check_orphaned_doc(doc, {}, idx, tmp_path) is None
 
 
+def test_orphaned_doc_exempts_readme(tmp_path):
+    """A directory README is a navigational index/front-door, discoverable by
+    structure rather than graph edges — so "nothing links to it" is expected, not
+    a problem. It must not be orphan-flagged even alone in its folder with no
+    inbound links (parallels check_homeless_docs' README skip). A non-README doc in
+    the same situation is still an orphan."""
+    _make_tree(tmp_path, ["docs/reference/suppliers/Goldgun/README.md"])
+    readme = tmp_path / "docs/reference/suppliers/Goldgun/README.md"
+    assert check_orphaned_doc(readme, {}, {}, tmp_path) is None
+    # control: a non-README alone in its folder with no inbound links IS flagged
+    _make_tree(tmp_path, ["docs/reference/suppliers/Acme/catalogue.md"])
+    other = tmp_path / "docs/reference/suppliers/Acme/catalogue.md"
+    assert check_orphaned_doc(other, {}, {}, tmp_path)["type"] == "orphaned_doc"
+
+
 # ---------------------------------------------------------------------------
 # get_current_git_hash / get_changed_since_hash
 # ---------------------------------------------------------------------------

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -251,6 +251,55 @@ def test_structural_dirs_excluded_regardless_of_config(tmp_path):
     assert is_excluded(tmp_path / "docs" / "X.md", cfg, tmp_path) is False
 
 
+def test_default_excludes_vendored_and_scratch_dirs(tmp_path):
+    """Vendored deps, virtualenvs, build/test output, and scratch dirs are
+    machine artifacts — never valid scan targets — so they must be excluded even
+    when a pre-existing config.yaml's excluded_paths omits them (#49 follow-up).
+    These are commonly gitignored (e.g. ET-embed's tmp/ and analysis/**/.pixi/),
+    yet the scanner walked them and reported their contents as doc-hygiene issues.
+    """
+    cfg = {"excluded_paths": []}  # existing install whose config omits these
+    # scratch dirs — DEFAULTS had `*.tmp` (files) but never `tmp/` (the dir)
+    assert is_excluded(tmp_path / "tmp" / "franks-notes.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / "tmp" / "dempsey" / "EXPORT.md", cfg, tmp_path) is True
+    # pixi env nested under a subproject — must match by substring, not just prefix
+    nested_pixi = (tmp_path / "analysis" / "dyn" / ".pixi" / "envs" / "default"
+                   / "lib" / "python3.14" / "site-packages" / "pyparsing" / "ai"
+                   / "best_practices.md")
+    assert is_excluded(nested_pixi, cfg, tmp_path) is True
+    # vendored deps / virtualenvs — robust for existing installs, not just new ones
+    assert is_excluded(tmp_path / "frontend" / "node_modules" / "p" / "guide.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / ".venv" / "lib" / "x" / "doc.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / "venv" / "x.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / "pkgs" / "site-packages" / "p" / "doc.md", cfg, tmp_path) is True
+    # build / test output
+    assert is_excluded(tmp_path / "dist" / "x.md", cfg, tmp_path) is True
+    assert is_excluded(tmp_path / ".tox" / "py311" / "x.md", cfg, tmp_path) is True
+    # Guard against over-matching: 'attempts/' must NOT be caught by 'tmp/'.
+    assert is_excluded(tmp_path / "docs" / "attempts" / "x.md", cfg, tmp_path) is False
+    assert is_excluded(tmp_path / "docs" / "X.md", cfg, tmp_path) is False
+
+
+def test_homeless_skips_tmp_and_vendored(tmp_path):
+    """check_homeless_docs must not flag scratch/vendored markdown — the bulk of
+    ET-embed's homeless_doc noise was tmp/ scratch plus a .pixi site-packages
+    file — while still flagging a genuinely homeless doc."""
+    _make_tree(tmp_path, [
+        "docs/real.md",
+        "tmp/franks-notes.md",
+        "analysis/dyn/.pixi/envs/default/lib/site-packages/pyparsing/ai/best_practices.md",
+        "frontend/node_modules/pkg/guide.md",
+        "stray-notes.md",  # genuinely homeless — should still be flagged
+    ])
+    cfg = _minimal_cfg(tmp_path)
+    issues = check_homeless_docs(tmp_path, cfg)
+    doc_paths = [i["doc"] for i in issues]
+    assert "tmp/franks-notes.md" not in doc_paths
+    assert "analysis/dyn/.pixi/envs/default/lib/site-packages/pyparsing/ai/best_practices.md" not in doc_paths
+    assert "frontend/node_modules/pkg/guide.md" not in doc_paths
+    assert "stray-notes.md" in doc_paths
+
+
 def test_homeless_skips_skills_dirs(tmp_path):
     """SKILL.md files under skills/ and carta/skills/ are intentional homes (#52)."""
     _make_tree(tmp_path, [


### PR DESCRIPTION
## Summary
Two `carta scan` false-positive fixes (**0.12.1**), follow-up to the 0.12.0 pre-re-embed audit. Cuts scan noise so the real doc-hygiene signal isn't buried.

- **Exclude vendored/virtualenv/scratch dirs** (`0dce61b`): `_ALWAYS_EXCLUDED_DIRS` only had `.claude/worktrees/`, `build/`, `temp/`, so commonly-gitignored machine dirs were still walked and reported. Added `tmp/`, `dist/`, `node_modules/`, `.venv/`, `venv/`, `.pixi/`, `site-packages/`, `.tox/` (matched as a path substring, so envs nested under a subproject are caught). Placed in `_ALWAYS_EXCLUDED_DIRS` (not `DEFAULTS["excluded_paths"]`) because an existing `config.yaml` replaces `excluded_paths` wholesale — so defaults never reach installed repos.
- **Exempt READMEs from `orphaned_doc`** (`77019ab`): a directory README is a navigational index discoverable by structure, not islanded knowledge; having no inbound `related:` links is expected, not a problem. Mirrors the existing homeless-check README skip.

## Validation (ET-embed, ~3,700 docs)
- `homeless_doc` 34 → 18 (15 `tmp/` scratch + 1 `.pixi/.../site-packages/` removed)
- `orphaned_doc` 6 → 3 (3 README false-positives gone; the 3 remaining are real islanded docs)
- No real finding lost; no other scan category affected by the scanner changes.

## Tests (TDD)
- `is_excluded` matrix for the new dirs incl. nested `.pixi/site-packages` + an `attempts/` vs `tmp/` over-match guard; a `check_homeless_docs` integration test.
- README-exempt orphan test with a non-README control (still flagged).
- Full scanner suite green (70 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)