### PR TITLE
perf+fix: visual-drain scope, MPS productionization, Ollama keep_alive, hook/json fixes (0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to **carta-cc** are documented here. The format is loosely b
 
 ## [Unreleased]
 
+## [0.12.2] — 2026-06-17
+
+### Fixed
+- **Visual drain ignored `colpali_scoped_paths`.** Only the inline ColPali path enforced scope; the two-pass `--visual` drain processed every queued page, so out-of-scope docs (e.g. patents) got ColPali-embedded anyway — on ET-embed ~2126 of 2252 pages, burning the slow OCR+ColPali pass on excluded docs and polluting the `_visual` collection with low-value figures. `run_visual_embed` now skips out-of-scope sources.
+- **Hook judge inner timeout exceeded its outer budget.** `_call_ollama_judge` hardcoded a 4s Ollama timeout while the worker-thread budget is the configured `judge_timeout_s` (default 3s); since the executor waits for the thread on exit, the hook could block ~4s despite a 3s budget. The inner now tracks the outer budget.
+- **`carta doctor --json` / `audit --json` output was corrupted** when a newer version was available: the update-available notice printed to stdout. It now goes to stderr, keeping machine-readable stdout clean.
+
+### Changed — performance
+- **MPS productionized.** `colpali_device` now defaults to `"auto"` (MPS > CUDA > CPU); `CARTA_COLPALI_DEVICE` overrides at run time; a load-time guard falls back to CPU if the GPU device can't run the model instead of failing every page. ColPali no longer runs on CPU-by-default on Apple Silicon.
+- **Ollama `keep_alive`** is now set on every request (embed, rerank, hook judge, query extraction), configurable via `CARTA_OLLAMA_KEEP_ALIVE` (default `"10m"`; `"-1"` keeps models resident). Stops models reloading across idle gaps — chiefly the prompt-submit hook.
+
 ## [0.12.1] — 2026-06-16
 
 ### Fixed — scanner false positives

--- a/carta/config.py
+++ b/carta/config.py
@@ -109,7 +109,7 @@ DEFAULTS = {
         # False = hard opt-out. Auto never loads ColPali unless there's something to search.
         "colpali_enabled": None,
         "colpali_model": "vidore/colqwen2-v1.0-hf",  # or vidore/colpali-v1.3-hf
-        "colpali_device": "cpu",  # "cpu", "cuda", "mps"
+        "colpali_device": "auto",  # "auto" (MPS>CUDA>CPU), "cpu", "cuda", "mps"; CARTA_COLPALI_DEVICE env overrides
         "colpali_batch_size": 1,  # pages per batch (1 for CPU)
         "colpali_sidecar_path": ".carta/visual_cache/",  # where to store page PNGs
         "colpali_scoped_paths": [],  # restrict ColPali to these repo-relative globs/dirs; [] = all PDFs

--- a/carta/config.py
+++ b/carta/config.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 from typing import Optional
+import os
 import yaml
+
+
+def ollama_keep_alive() -> str:
+    """How long Ollama keeps a model resident after a request (its ``keep_alive``).
+
+    Default ``"10m"`` (Ollama's own default is 5m), overridable via
+    ``CARTA_OLLAMA_KEEP_ALIVE``. ``"-1"`` keeps models loaded indefinitely; ``"0"``
+    unloads immediately. Applied to every carta Ollama request (embed, rerank, hook
+    judge) so a model doesn't reload across idle gaps — notably the prompt-submit
+    hook, whose calls can be minutes apart.
+    """
+    return os.environ.get("CARTA_OLLAMA_KEEP_ALIVE", "10m")
 
 REQUIRED_FIELDS = ["project_name", "qdrant_url"]
 

--- a/carta/embed/colpali.py
+++ b/carta/embed/colpali.py
@@ -16,6 +16,7 @@ Supported checkpoints (HF-native, no PEFT adapters):
 """
 
 import io
+import os
 import sys
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -63,6 +64,31 @@ VECTOR_DIM = 128
 class ColPaliError(Exception):
     """Raised when ColPali operations fail."""
     pass
+
+
+def _load_with_fallback(load_fn, device: str):
+    """Call ``load_fn(device)``; on failure with a non-CPU device, warn and retry on
+    CPU. Returns ``(model, processor, final_device)``.
+
+    This is the GPU safety guard the visual pipeline previously lacked: ColQwen2 /
+    ColPali can hit an unsupported op or a dtype mismatch on MPS, and without a
+    fallback the whole drain would fail every page. A CPU failure is genuine and is
+    re-raised. (A hard segfault can't be caught here — only exceptions.)
+    """
+    try:
+        model, processor = load_fn(device)
+        return model, processor, device
+    except Exception as exc:  # noqa: BLE001 — any GPU load failure → retry on CPU
+        if device == "cpu":
+            raise
+        print(
+            f"Warning: ColPali failed on {device} ({type(exc).__name__}: {exc}); "
+            "falling back to CPU",
+            file=sys.stderr,
+            flush=True,
+        )
+        model, processor = load_fn("cpu")
+        return model, processor, "cpu"
 
 
 class ColPaliEmbedder:
@@ -123,16 +149,31 @@ class ColPaliEmbedder:
         self._is_colqwen = "qwen" in model_name.lower()
 
     def _resolve_device(self, device: str) -> str:
-        """Resolve device string to available device.
+        """Resolve a device string to an available device.
 
-        Falls back to CPU if requested device is unavailable.
+        Resolution order:
+        1. The ``CARTA_COLPALI_DEVICE`` env var overrides the configured device
+           (a run-time switch without editing config.yaml).
+        2. ``"auto"`` (or empty) auto-detects: MPS (Apple Silicon) > CUDA > CPU.
+        3. An explicit ``"cuda"``/``"mps"`` that isn't available falls back to CPU.
 
         Args:
-            device: Requested device ("cpu", "cuda", "mps")
+            device: Requested device ("auto", "cpu", "cuda", "mps")
 
         Returns:
             Available device string.
         """
+        env_device = os.environ.get("CARTA_COLPALI_DEVICE")
+        if env_device:
+            device = env_device.strip().lower()
+
+        if device in ("auto", ""):
+            if torch is not None and torch.backends.mps.is_available():
+                return "mps"
+            if torch is not None and torch.cuda.is_available():
+                return "cuda"
+            return "cpu"
+
         if device == "cuda" and torch is not None:
             if not torch.cuda.is_available():
                 print(
@@ -163,22 +204,10 @@ class ColPaliEmbedder:
 
         print(f"Loading ColPali model: {self.model_name}...", flush=True)
 
-        dtype = torch.bfloat16 if self.device in ("cuda", "mps") else torch.float32
-
-        if self._is_colqwen:
-            model = ColQwen2ForRetrieval.from_pretrained(
-                self.model_name,
-                torch_dtype=dtype,
-                device_map=self.device,
-            ).eval()
-            processor = ColQwen2Processor.from_pretrained(self.model_name)
-        else:
-            model = ColPaliForRetrieval.from_pretrained(
-                self.model_name,
-                torch_dtype=dtype,
-                device_map=self.device,
-            ).eval()
-            processor = ColPaliProcessor.from_pretrained(self.model_name)
+        # Wrapped so a non-CPU device that can't run the model (unsupported MPS op,
+        # dtype mismatch) degrades to CPU instead of failing every page.
+        model, processor, final_device = _load_with_fallback(self._load_on_device, self.device)
+        self.device = final_device
 
         # Cache for reuse
         self._MODEL_CACHE[self.model_name] = (model, processor)
@@ -186,6 +215,25 @@ class ColPaliEmbedder:
         self._processor = processor
 
         print(f"Model loaded on {self.device}", flush=True)
+        return model, processor
+
+    def _load_on_device(self, device: str) -> Tuple:
+        """Load model + processor on a specific device (the raw load, no fallback)."""
+        dtype = torch.bfloat16 if device in ("cuda", "mps") else torch.float32
+        if self._is_colqwen:
+            model = ColQwen2ForRetrieval.from_pretrained(
+                self.model_name,
+                torch_dtype=dtype,
+                device_map=device,
+            ).eval()
+            processor = ColQwen2Processor.from_pretrained(self.model_name)
+        else:
+            model = ColPaliForRetrieval.from_pretrained(
+                self.model_name,
+                torch_dtype=dtype,
+                device_map=device,
+            ).eval()
+            processor = ColPaliProcessor.from_pretrained(self.model_name)
         return model, processor
 
     def embed_page(self, image: "Image.Image") -> "np.ndarray":

--- a/carta/embed/embed.py
+++ b/carta/embed/embed.py
@@ -19,7 +19,7 @@ from qdrant_client.models import (
     VectorParams,
 )
 
-from carta.config import collection_name, collection_for_doc_type
+from carta.config import collection_name, collection_for_doc_type, ollama_keep_alive
 
 # nomic-embed-text produces 768-dimensional vectors
 VECTOR_DIM = 768
@@ -89,7 +89,7 @@ def get_embedding(
     for attempt in range(4):
         resp = requests.post(
             f"{ollama_url}/api/embeddings",
-            json={"model": model, "prompt": f"{prefix}{attempt_text}"},
+            json={"model": model, "prompt": f"{prefix}{attempt_text}", "keep_alive": ollama_keep_alive()},
             timeout=60,
         )
         if resp.status_code == 200:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -853,6 +853,27 @@ def _discover_visual_pending(repo_root: Path) -> list[tuple]:
     return out
 
 
+def _filter_visual_pending_in_scope(queued: list[tuple], scopes: list) -> list[tuple]:
+    """Drop (sidecar_path, sidecar) pairs whose source (``current_path``) is out of
+    ``colpali_scoped_paths``.
+
+    The two-pass visual drain must honor ``colpali_scoped_paths`` exactly like the
+    inline ColPali path (``_colpali_path_in_scope`` in ``_embed_one_file``).
+    Otherwise out-of-scope docs (e.g. patents) queued as ``visual_pending`` get
+    drained anyway — burning the expensive ColPali + OCR pass on docs the user
+    excluded and polluting the ``_visual`` collection with low-value figures.
+
+    Empty ``scopes`` means no restriction (backward compatible).
+    """
+    if not scopes:
+        return queued
+    return [
+        (sc_path, sc)
+        for (sc_path, sc) in queued
+        if _colpali_path_in_scope(sc.get("current_path") or "", scopes)
+    ]
+
+
 def _visual_chunk_index_pass2(page: int, i: int) -> str:
     """Return the chunk_index token used for pass-2 visual/OCR text chunks.
 
@@ -1029,6 +1050,20 @@ def run_visual_embed(
 
     client = QdrantClient(url=cfg["qdrant_url"], timeout=UPSERT_CLIENT_TIMEOUT_S)
     queued = _discover_visual_pending(repo_root)
+    # Honor colpali_scoped_paths in the two-pass drain too (not just the inline path):
+    # skip out-of-scope sources (e.g. patents) that were queued as visual_pending,
+    # else the expensive ColPali pass burns on excluded docs and pollutes _visual.
+    _scopes = (cfg.get("embed", {}) or {}).get("colpali_scoped_paths", []) or []
+    if _scopes:
+        _before = len(queued)
+        queued = _filter_visual_pending_in_scope(queued, _scopes)
+        _skipped = _before - len(queued)
+        if _skipped:
+            print(
+                f"    visual drain: skipping {_skipped} out-of-scope source(s) "
+                f"(not in colpali_scoped_paths)",
+                flush=True,
+            )
     summary["files"] = len(queued)
     total_pages = sum(len(sc.get(VISUAL_PENDING_KEY, []) or []) for _, sc in queued)
 

--- a/carta/embed/tests/test_colpali.py
+++ b/carta/embed/tests/test_colpali.py
@@ -1,5 +1,6 @@
 """Tests for carta.embed.colpali module."""
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch, Mock
@@ -214,3 +215,92 @@ class TestEmbedQuery:
         
         with pytest.raises(ColPaliError):
             embedder.embed_query("test query")
+
+
+class TestMPSProductionization:
+    """Auto-detect, CARTA_COLPALI_DEVICE override, and the device-load safety guard."""
+
+    @patch.dict("os.environ", {}, clear=False)
+    @patch("carta.embed.colpali._COLPALI_AVAILABLE", True)
+    @patch("carta.embed.colpali.np", MagicMock())
+    @patch("carta.embed.colpali.Image", MagicMock())
+    @patch("carta.embed.colpali.torch")
+    def test_auto_detects_mps_on_apple_silicon(self, mock_torch):
+        """device='auto' picks MPS when Apple Silicon Metal is available."""
+        from carta.embed.colpali import ColPaliEmbedder
+
+        os.environ.pop("CARTA_COLPALI_DEVICE", None)
+        mock_torch.backends.mps.is_available.return_value = True
+        with patch.object(Path, "mkdir"):
+            e = ColPaliEmbedder(device="auto")
+        assert e.device == "mps"
+
+    @patch.dict("os.environ", {}, clear=False)
+    @patch("carta.embed.colpali._COLPALI_AVAILABLE", True)
+    @patch("carta.embed.colpali.np", MagicMock())
+    @patch("carta.embed.colpali.Image", MagicMock())
+    @patch("carta.embed.colpali.torch")
+    def test_auto_falls_back_to_cpu_without_gpu(self, mock_torch):
+        """device='auto' resolves to CPU when neither MPS nor CUDA is available."""
+        from carta.embed.colpali import ColPaliEmbedder
+
+        os.environ.pop("CARTA_COLPALI_DEVICE", None)
+        mock_torch.backends.mps.is_available.return_value = False
+        mock_torch.cuda.is_available.return_value = False
+        with patch.object(Path, "mkdir"):
+            e = ColPaliEmbedder(device="auto")
+        assert e.device == "cpu"
+
+    @patch("carta.embed.colpali._COLPALI_AVAILABLE", True)
+    @patch("carta.embed.colpali.np", MagicMock())
+    @patch("carta.embed.colpali.Image", MagicMock())
+    @patch("carta.embed.colpali.torch")
+    def test_env_var_overrides_configured_device(self, mock_torch):
+        """CARTA_COLPALI_DEVICE overrides the configured device (run-time switch)."""
+        from carta.embed.colpali import ColPaliEmbedder
+
+        mock_torch.backends.mps.is_available.return_value = True
+        with patch.dict("os.environ", {"CARTA_COLPALI_DEVICE": "mps"}), patch.object(Path, "mkdir"):
+            e = ColPaliEmbedder(device="cpu")  # config says cpu; env wins
+        assert e.device == "mps"
+
+    def test_load_with_fallback_recovers_on_cpu(self):
+        """A GPU load failure (e.g. an unsupported MPS op) falls back to CPU."""
+        from carta.embed.colpali import _load_with_fallback
+
+        calls = []
+
+        def fake_load(dev):
+            calls.append(dev)
+            if dev != "cpu":
+                raise RuntimeError("MPS op 'aten::foo' not implemented")
+            return ("model", "proc")
+
+        model, proc, final = _load_with_fallback(fake_load, "mps")
+        assert final == "cpu"
+        assert (model, proc) == ("model", "proc")
+        assert calls == ["mps", "cpu"]
+
+    def test_load_with_fallback_reraises_cpu_failure(self):
+        """A genuine CPU load failure is real — re-raise, don't loop."""
+        from carta.embed.colpali import _load_with_fallback
+
+        def fake_load(dev):
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            _load_with_fallback(fake_load, "cpu")
+
+    def test_load_with_fallback_noop_when_device_works(self):
+        """When the requested device loads fine, no fallback occurs."""
+        from carta.embed.colpali import _load_with_fallback
+
+        calls = []
+
+        def fake_load(dev):
+            calls.append(dev)
+            return ("m", "p")
+
+        _, _, final = _load_with_fallback(fake_load, "mps")
+        assert final == "mps"
+        assert calls == ["mps"]

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -298,6 +298,19 @@ def test_get_embedding_raises_on_non_200(mock_requests):
         get_embedding("test text")
 
 
+@patch("carta.embed.embed.requests")
+def test_get_embedding_sends_keep_alive(mock_requests):
+    """Every Ollama embedding request carries keep_alive so the model stays resident
+    across idle gaps instead of reloading."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"embedding": [0.0] * 768}
+    mock_requests.post.return_value = mock_resp
+    get_embedding("hello world")
+    payload = mock_requests.post.call_args.kwargs["json"]
+    assert "keep_alive" in payload
+
+
 # ---------------------------------------------------------------------------
 # embed.py — ensure_collection create vs skip
 # ---------------------------------------------------------------------------

--- a/carta/embed/tests/test_visual_drainer.py
+++ b/carta/embed/tests/test_visual_drainer.py
@@ -186,3 +186,26 @@ def test_pass2_point_ids_disjoint_from_pass1():
     assert pass1_ids.isdisjoint(pass2_ids), (
         "Pass-1 and pass-2 point IDs collide — namespace isolation is broken"
     )
+
+
+def test_drainer_filters_out_of_scope_pages():
+    """The --visual drain must honor colpali_scoped_paths: out-of-scope sources
+    (e.g. patents, not in [datasheets, manuals, suppliers]) that were queued as
+    visual_pending must be skipped — otherwise the expensive ColPali pass burns on
+    docs the user excluded and pollutes the _visual collection with low-value
+    figures. The inline path enforced scope; the two-pass drain did not (the bug)."""
+    scopes = ["docs/reference/datasheets/", "docs/reference/manuals/"]
+    queued = [
+        ("a.yaml", {"current_path": "docs/reference/datasheets/murata.pdf", VISUAL_PENDING_KEY: [1]}),
+        ("b.yaml", {"current_path": "docs/reference/patents/prior-art/US123.pdf", VISUAL_PENDING_KEY: [1, 2]}),
+    ]
+    out = pipeline._filter_visual_pending_in_scope(queued, scopes)
+    paths = [sc["current_path"] for _, sc in out]
+    assert "docs/reference/datasheets/murata.pdf" in paths
+    assert "docs/reference/patents/prior-art/US123.pdf" not in paths
+
+
+def test_drainer_no_scope_keeps_all_pages():
+    """Empty colpali_scoped_paths means no restriction (backward compatible)."""
+    queued = [("b.yaml", {"current_path": "docs/reference/patents/x.pdf", VISUAL_PENDING_KEY: [1]})]
+    assert pipeline._filter_visual_pending_in_scope(queued, []) == queued

--- a/carta/hook/hook.py
+++ b/carta/hook/hook.py
@@ -157,9 +157,14 @@ def _extract_query(prompt: str, cfg: dict) -> str:
 # Ollama judge (D-15 through D-18)
 # ---------------------------------------------------------------------------
 
-def _call_ollama_judge(prompt: str, hits: list[dict], cfg: dict) -> bool:
+def _call_ollama_judge(prompt: str, hits: list[dict], cfg: dict, timeout_s: float = 4) -> bool:
     """Judge whether the documentation candidates are relevant. Returns True only
-    on a 'yes'; any error or non-yes answer returns False (fail-open)."""
+    on a 'yes'; any error or non-yes answer returns False (fail-open).
+
+    ``timeout_s`` is the Ollama call budget; _judge_with_timeout passes the same
+    value it enforces on the worker thread so the inner timeout never exceeds the
+    outer one. An inner > outer let the hook block past judge_timeout_s, since
+    ThreadPoolExecutor.__exit__ waits for the abandoned thread to finish."""
     from carta.hook.judge import ollama_yesno
 
     ollama_url = cfg["embed"]["ollama_url"]
@@ -174,7 +179,7 @@ def _call_ollama_judge(prompt: str, hits: list[dict], cfg: dict) -> bool:
         "You decide if documentation is relevant to a coding prompt. "
         "Answer only 'yes' or 'no'."
     )
-    return bool(ollama_yesno(ollama_url, model, system, user_msg, timeout_s=4))
+    return bool(ollama_yesno(ollama_url, model, system, user_msg, timeout_s=timeout_s))
 
 
 def _judge_with_timeout(
@@ -188,7 +193,7 @@ def _judge_with_timeout(
     proceeds unblocked — it just stays silent.
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(_call_ollama_judge, prompt, hits, cfg)
+        future = executor.submit(_call_ollama_judge, prompt, hits, cfg, timeout_s)
         try:
             return future.result(timeout=timeout_s)
         except concurrent.futures.TimeoutError:

--- a/carta/hook/hook.py
+++ b/carta/hook/hook.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import requests
 
-from carta.config import find_config, load_config, NOTE_DOC_TYPES
+from carta.config import find_config, load_config, NOTE_DOC_TYPES, ollama_keep_alive
 from carta.embed.pipeline import run_search
 
 
@@ -143,6 +143,7 @@ def _extract_query(prompt: str, cfg: dict) -> str:
                     {"role": "user", "content": prompt[:1000]},
                 ],
                 "stream": False,
+                "keep_alive": ollama_keep_alive(),
             },
             timeout=4,
         )

--- a/carta/hook/judge.py
+++ b/carta/hook/judge.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import requests
 
+from carta.config import ollama_keep_alive
+
 
 def ollama_yesno(
     ollama_url: str,
@@ -28,6 +30,7 @@ def ollama_yesno(
                     {"role": "user", "content": user},
                 ],
                 "stream": False,
+                "keep_alive": ollama_keep_alive(),
             },
             timeout=timeout_s,
         )

--- a/carta/hook/tests/test_hook.py
+++ b/carta/hook/tests/test_hook.py
@@ -455,6 +455,39 @@ def test_call_ollama_judge_sends_correct_format():
     assert "my prompt" in user_msgs[0]["content"] or "Some excerpt" in user_msgs[0]["content"]
 
 
+def test_call_ollama_judge_uses_given_timeout():
+    """The inner Ollama timeout must track the caller's budget, not a hardcoded 4s.
+    A hardcoded inner > the outer thread budget lets the hook block past the
+    configured judge_timeout_s (ThreadPoolExecutor.__exit__ waits for the thread)."""
+    from carta.hook.hook import _call_ollama_judge
+    cfg = _make_cfg()
+    hits = [_make_hit(0.75)]
+    captured = {}
+
+    def fake_yesno(url, model, system, user, *, timeout_s):
+        captured["timeout_s"] = timeout_s
+        return True
+
+    with patch("carta.hook.judge.ollama_yesno", fake_yesno):
+        _call_ollama_judge("p", hits, cfg, timeout_s=2)
+    assert captured["timeout_s"] == 2
+
+
+def test_judge_with_timeout_passes_budget_to_inner():
+    """_judge_with_timeout forwards its budget to the inner judge so inner <= outer."""
+    from carta.hook.hook import _judge_with_timeout
+    cfg = _make_cfg()
+    captured = {}
+
+    def fake_call(prompt, hits, cfg, timeout_s):
+        captured["timeout_s"] = timeout_s
+        return False
+
+    with patch("carta.hook.hook._call_ollama_judge", fake_call):
+        _judge_with_timeout("p", [], cfg, timeout_s=2)
+    assert captured["timeout_s"] == 2
+
+
 def test_call_ollama_judge_parses_yes():
     """'yes' response returns True (D-17)."""
     from carta.hook.hook import _call_ollama_judge

--- a/carta/search/llm_rerank.py
+++ b/carta/search/llm_rerank.py
@@ -11,6 +11,8 @@ import re
 import sys
 import requests
 
+from carta.config import ollama_keep_alive
+
 _SYSTEM = (
     "You rank document passages by relevance to a search query. "
     "Return ONLY a JSON array of passage numbers, most relevant first. "
@@ -84,6 +86,7 @@ def llm_rerank_hits(query: str, hits: list[dict], *, model: str, ollama_url: str
                 # reranker silently fails open. A listwise reranker never needs to think.
                 "think": False,
                 "options": {"temperature": 0},
+                "keep_alive": ollama_keep_alive(),
             },
             timeout=timeout_s,
         )

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -144,3 +144,13 @@ def test_fusion_defaults_present():
     # Eval-swept optimum: maximizes ET-embed 62q text recall (0.839->0.887) while
     # holding the 14q visual eval flat at 0.857 (see RESULTS.md 2026-06-13).
     assert fusion["visual_max_ratio"] == 0.2
+
+
+def test_ollama_keep_alive_default_and_env_override(monkeypatch):
+    """keep_alive defaults to 10m (Ollama's own default is 5m) and is overridable
+    via CARTA_OLLAMA_KEEP_ALIVE (e.g. '-1' = keep resident indefinitely)."""
+    from carta.config import ollama_keep_alive
+    monkeypatch.delenv("CARTA_OLLAMA_KEEP_ALIVE", raising=False)
+    assert ollama_keep_alive() == "10m"
+    monkeypatch.setenv("CARTA_OLLAMA_KEEP_ALIVE", "-1")
+    assert ollama_keep_alive() == "-1"

--- a/carta/tests/test_update.py
+++ b/carta/tests/test_update.py
@@ -111,7 +111,9 @@ def test_maybe_notify_prints_when_update_available(tmp_path, capsys):
          patch("carta.update.checker._fetch_latest", return_value="0.4.0"):
         maybe_notify(carta_dir, {"update_check": True})
     captured = capsys.readouterr()
-    assert "0.4.0" in captured.out
+    # Notice goes to stderr so it never pollutes machine-readable stdout (--json).
+    assert "0.4.0" in captured.err
+    assert captured.out == ""
 
 
 def test_maybe_notify_silent_when_disabled(tmp_path, capsys):

--- a/carta/update/checker.py
+++ b/carta/update/checker.py
@@ -121,6 +121,8 @@ def maybe_notify(carta_dir: Optional[Path], cfg: dict) -> None:
         msg = check_for_update(carta_dir)
         if msg:
             sep = "─" * 51
-            print(f"\n{sep}\n{msg}\n{sep}")
+            # stderr, not stdout: the notice must never pollute machine-readable
+            # output (e.g. `carta doctor --json`, `carta audit --json`).
+            print(f"\n{sep}\n{msg}\n{sep}", file=sys.stderr)
     except Exception:
         pass


### PR DESCRIPTION
## Summary
**0.12.2** — performance + correctness follow-up surfaced while investigating the slow ET-embed visual drain.

### Fixes
- **Visual drain honors `colpali_scoped_paths`** (`5f234bf`): the two-pass `--visual` drain ignored scope and ColPali-embedded out-of-scope patents (~2126 of 2252 ET-embed pages) — ~18× wasted work + low-value figures polluting `_visual`. Now skips out-of-scope sources.
- **Hook judge inner timeout tracks the outer budget** (`d2d776b`): inner 4s > outer 3s let the hook block ~4s despite a 3s `judge_timeout_s` (the executor waits for the thread on exit).
- **`--json` output no longer corrupted by the update notice** (`3506249`): the "update available" banner printed to stdout, breaking `carta doctor --json` / `audit --json`. Now goes to stderr. (Fixes 3 pre-existing tests that only passed in CI because no newer version existed at the time.)

### Performance
- **MPS productionized** (`e1d5262`): `colpali_device` defaults to `"auto"` (MPS > CUDA > CPU); `CARTA_COLPALI_DEVICE` env override; a load-time guard falls back to CPU if the GPU can't run the model. Verified `auto → mps` on Apple Silicon. ColPali no longer defaults to CPU on Macs.
- **Ollama `keep_alive`** on every request (`89a1102`): embed, rerank, hook judge, query extraction. `CARTA_OLLAMA_KEEP_ALIVE` (default `10m`, `-1` = resident). Stops idle-gap reloads, chiefly the prompt-submit hook.

## Tests
TDD throughout. Full suite **1022 passed, 2 skipped**. New tests: scope filter (skip/keep + no-scope passthrough), MPS auto-detect / env override / load-fallback guard, keep_alive helper + payload, judge-timeout forwarding, update-notice→stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)