### PR TITLE
fix: queue-side visual scope, canonical sidecar walk, case-insensitive PDF induction (0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **carta-cc** are documented here. The format is loosely b
 
 ## [Unreleased]
 
+## [0.12.3] — 2026-06-17
+
+### Fixed
+Three follow-ups surfaced during the 0.12.2 ET-embed closeout.
+- **Two-pass visual *queueing* ignored `colpali_scoped_paths`.** 0.12.2 fixed the `--visual` *drain* to skip out-of-scope sources, but pass-1 queueing still marked their image-heavy pages `visual_pending` — so out-of-scope docs (e.g. patents) re-queued on every `carta embed` and inflated the "N pages await visual" count with pages the drain would never process. Queueing now honors `colpali_scoped_paths` (the same check the inline ColPali path already applied), so out-of-scope files get pass-1 text only, no phantom pending pages. The zero-extractable-text OCR-rescue path stays ungated, preserving scanned docs' only route to any indexed text.
+- **Scanner emitted phantom `sidecar_path_drift` for nested junk sidecar copies.** `_iter_sidecar_files` walked every `*.embed-meta.yaml` under `.carta/sidecars/`, including stray sidecar trees replicated into `.carta/sidecars/.worktrees/<wt>/.carta/sidecars/…` by worktree checkouts or imports; each copy's `current_path` was resolved against the real repo, producing false `sidecar_path_drift` / `sidecar_broken_related` findings for sources it didn't own. The walk now skips non-canonical copies (a sidecar's location under `sidecars/` must equal where its `current_path` maps), mirroring `induct.iter_canonical_sidecars`. Removes the dead `_SIDECAR_SKIP_DIRS` constant this supersedes.
+- **`carta embed` auto-induction missed uppercase `.PDF`.** New-file discovery globbed `*.pdf` / `*.md` case-sensitively, so an uppercase-extension file was perpetually flagged `embed_induction_needed` by the scanner (which lowercases suffixes) yet never auto-inducted — embeddable only via an explicit `carta embed <file>`. Discovery now matches supported extensions case-insensitively.
+
 ## [0.12.2] — 2026-06-17
 
 ### Fixed

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -9,7 +9,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
-from typing import Optional
+from typing import Iterator, Optional
 
 import yaml
 from qdrant_client import QdrantClient
@@ -41,18 +41,27 @@ from carta.vision.classifier import PageClass, PageAnalyzer
 _IMAGE_HEAVY = {PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED}
 
 
-def _mark_or_collect_visual_pages(page_classes: list, cfg: dict) -> dict:
+def _mark_or_collect_visual_pages(page_classes: list, cfg: dict, rel_path: str = "") -> dict:
     """Return sidecar updates queuing 1-indexed image-heavy pages when two_pass_visual is on.
 
     Args:
         page_classes: List of PageClass values, one per page (0-indexed position = page-1).
-        cfg: Carta config dict. Reads embed.two_pass_visual.
+        cfg: Carta config dict. Reads embed.two_pass_visual and embed.colpali_scoped_paths.
+        rel_path: Repo-relative path of the source file, used to honor
+            colpali_scoped_paths. Out-of-scope sources are not queued — the visual
+            drain skips them anyway (``_filter_visual_pending_in_scope``), so queuing
+            them only strands phantom pages in visual_pending that re-queue every embed
+            and inflate the "N pages await visual" count. Empty/absent scopes = no
+            restriction (backward compatible).
 
     Returns:
         Dict with VISUAL_PENDING_KEY → sorted list of 1-indexed page numbers, or {} when
-        two_pass_visual is off or no image-heavy pages exist.
+        two_pass_visual is off, the source is out of scope, or no image-heavy pages exist.
     """
     if not cfg.get("embed", {}).get("two_pass_visual", True):
+        return {}
+    scopes = (cfg.get("embed", {}) or {}).get("colpali_scoped_paths", []) or []
+    if scopes and not _colpali_path_in_scope(rel_path, scopes):
         return {}
     pending = [i + 1 for i, pc in enumerate(page_classes) if pc in _IMAGE_HEAVY]
     updates: dict = {}
@@ -62,6 +71,21 @@ def _mark_or_collect_visual_pages(page_classes: list, cfg: dict) -> dict:
 
 
 _SUPPORTED_EXTENSIONS = [".pdf", ".md"]
+_SUPPORTED_EXTENSIONS_SET = frozenset(_SUPPORTED_EXTENSIONS)
+
+
+def _iter_inductable_files(docs_root: Path) -> Iterator[Path]:
+    """Yield supported source files under docs_root, matching extensions
+    case-insensitively so uppercase ``.PDF`` (and ``.MD``) are found like ``.pdf``.
+
+    The scanner's induction check already lowercases suffixes
+    (``check_embed_induction_needed``), so a case-sensitive ``rglob("*.pdf")`` here
+    left uppercase-extension files perpetually flagged "needs induction" yet never
+    auto-inducted — embeddable only via an explicit ``carta embed <file>``.
+    """
+    for p in docs_root.rglob("*"):
+        if p.is_file() and p.suffix.lower() in _SUPPORTED_EXTENSIONS_SET:
+            yield p
 
 # Maximum seconds to allow a single file's embed processing to run
 FILE_TIMEOUT_S = 300
@@ -440,7 +464,17 @@ def _embed_one_file(
         _skip_inline_vision = False
 
         if two_pass_visual and _page_classes_from_extraction is not None:
-            _visual_queue_updates = _mark_or_collect_visual_pages(_page_classes_from_extraction, cfg)
+            # Pass the repo-relative path so queueing honors colpali_scoped_paths,
+            # exactly like the drain (_filter_visual_pending_in_scope) and the inline
+            # ColPali scope check below. _skip_inline_vision stays True regardless, so
+            # an out-of-scope file gets pass-1 text only — no queue, no inline vision.
+            _rel_for_scope = (
+                str(file_path.relative_to(repo_root))
+                if file_path.is_relative_to(repo_root) else str(file_path)
+            )
+            _visual_queue_updates = _mark_or_collect_visual_pages(
+                _page_classes_from_extraction, cfg, _rel_for_scope
+            )
             _skip_inline_vision = True  # two-pass queued; inline path not needed
         elif two_pass_visual and _page_classes_from_extraction is None:
             # Classification error was already logged during extraction; fail closed.
@@ -1380,17 +1414,17 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
             file=sys.stderr, flush=True,
         )
 
-    # Auto-induct any supported files that lack a sidecar (e.g. after sidecar deletion)
+    # Auto-induct any supported files that lack a sidecar (e.g. after sidecar deletion).
+    # Extension matching is case-insensitive so uppercase .PDF is inducted like .pdf.
     docs_root_path = repo_root / cfg.get("docs_root", "docs/")
     if docs_root_path.is_dir():
-        for ext in _SUPPORTED_EXTENSIONS:
-            for file_path in docs_root_path.rglob(f"*{ext}"):
-                sc_path = sidecar_path(file_path, repo_root)
-                if not sc_path.exists():
-                    stub = generate_sidecar_stub(file_path, repo_root, cfg)
-                    write_sidecar(file_path, stub, repo_root)
-                    if verbose:
-                        print(f"  inducted: {file_path.relative_to(repo_root)}", flush=True)
+        for file_path in _iter_inductable_files(docs_root_path):
+            sc_path = sidecar_path(file_path, repo_root)
+            if not sc_path.exists():
+                stub = generate_sidecar_stub(file_path, repo_root, cfg)
+                write_sidecar(file_path, stub, repo_root)
+                if verbose:
+                    print(f"  inducted: {file_path.relative_to(repo_root)}", flush=True)
 
     chunking = cfg.get("embed", {}).get("chunking", {})
     max_tokens = chunking.get("max_tokens", 400)

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -640,6 +640,26 @@ def test_run_embed_qdrant_unreachable(mock_qdrant_cls, tmp_path):
     assert "Qdrant" in result["errors"][0]
 
 
+# Auto-induct discovery must match supported extensions case-insensitively, so an
+# uppercase `.PDF` is inducted like `.pdf` (the scanner already flags it via
+# `f.suffix.lower()`, so case-sensitive discovery left those files perpetually
+# "needs induction" but never embeddable without an explicit path).
+
+def test_iter_inductable_files_matches_extensions_case_insensitively(tmp_path):
+    from carta.embed.pipeline import _iter_inductable_files
+
+    docs = tmp_path / "docs"
+    (docs / "sub").mkdir(parents=True)
+    (docs / "a.pdf").write_bytes(b"%PDF")
+    (docs / "b.PDF").write_bytes(b"%PDF")
+    (docs / "sub" / "c.md").write_text("# c")
+    (docs / "sub" / "d.MD").write_text("# d")
+    (docs / "e.txt").write_text("nope")  # unsupported extension
+
+    found = {p.name for p in _iter_inductable_files(docs)}
+    assert found == {"a.pdf", "b.PDF", "c.md", "d.MD"}
+
+
 # ---------------------------------------------------------------------------
 # parse.py — encoding robustness (audit Group C: CA-13, BOM)
 # ---------------------------------------------------------------------------

--- a/carta/embed/tests/test_pass1_marking.py
+++ b/carta/embed/tests/test_pass1_marking.py
@@ -21,3 +21,41 @@ def test_mark_noop_when_no_image_heavy_pages():
     cfg = {"embed": {"two_pass_visual": True}}
     page_classes = [PageClass.PURE_TEXT, PageClass.STRUCTURED_TEXT]
     assert pipeline._mark_or_collect_visual_pages(page_classes, cfg) == {}
+
+
+# Queue-side scope (bug: queueing ignored colpali_scoped_paths; only the drain
+# skipped out-of-scope sources, so patents re-queued every embed and inflated the
+# misleading "N pages await visual" count). Queueing must honor scope like the drain.
+
+_SCOPED_CFG = {
+    "embed": {
+        "two_pass_visual": True,
+        "colpali_scoped_paths": ["docs/reference/datasheets/"],
+    }
+}
+
+
+def test_mark_skips_out_of_scope_source_when_scopes_set():
+    page_classes = [PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED]
+    updates = pipeline._mark_or_collect_visual_pages(
+        page_classes, _SCOPED_CFG, "docs/reference/patents/US123.pdf"
+    )
+    assert updates == {}  # out of scope → not queued (drain would skip it anyway)
+
+
+def test_mark_queues_in_scope_source_when_scopes_set():
+    page_classes = [PageClass.TEXT_WITH_IMAGES, PageClass.FLATTENED]
+    updates = pipeline._mark_or_collect_visual_pages(
+        page_classes, _SCOPED_CFG, "docs/reference/datasheets/part.pdf"
+    )
+    assert updates[VISUAL_PENDING_KEY] == [1, 2]
+
+
+def test_mark_no_scopes_queues_regardless_of_path():
+    """Empty/absent colpali_scoped_paths = no restriction (backward compatible)."""
+    cfg = {"embed": {"two_pass_visual": True}}
+    page_classes = [PageClass.TEXT_WITH_IMAGES]
+    updates = pipeline._mark_or_collect_visual_pages(
+        page_classes, cfg, "anywhere/patents/US999.pdf"
+    )
+    assert updates[VISUAL_PENDING_KEY] == [1]

--- a/carta/scanner/scanner.py
+++ b/carta/scanner/scanner.py
@@ -545,9 +545,6 @@ def check_nested_docs_folders(repo_root: Path, cfg: dict = None) -> list:
 # Sidecar (.embed-meta.yaml) support
 # ---------------------------------------------------------------------------
 
-_SIDECAR_SKIP_DIRS = frozenset([".git", ".pio", "node_modules", "build", "install", "__pycache__"])
-
-
 def _iter_sidecar_files(repo_root: Path, cfg: dict):
     """Yield .embed-meta.yaml files under .carta/sidecars/ whose source isn't excluded.
 
@@ -556,6 +553,14 @@ def _iter_sidecar_files(repo_root: Path, cfg: dict):
     entry of '.carta/' (common in user configs predating the sidecar relocation)
     would silently filter every sidecar. Sidecars without current_path
     (pre-lifecycle) are yielded unconditionally.
+
+    Non-canonical copies are skipped: a sidecar carrying a current_path whose
+    location under sidecars_root does not equal where that current_path maps to is
+    a stray duplicate — e.g. a whole sidecar tree replicated into
+    ``.carta/sidecars/.worktrees/<wt>/.carta/sidecars/...`` by a worktree checkout
+    or import. Scanning such a copy emits phantom sidecar_path_drift /
+    broken_related findings for a source it does not own. (Mirrors the canonical
+    check in ``carta.embed.induct.iter_canonical_sidecars``.)
     """
     sidecars_root = repo_root / ".carta" / "sidecars"
     if not sidecars_root.exists():
@@ -563,8 +568,16 @@ def _iter_sidecar_files(repo_root: Path, cfg: dict):
     for p in sidecars_root.rglob("*.embed-meta.yaml"):
         data = parse_sidecar(p)
         current_path = data.get("current_path") if data else None
-        if current_path and is_excluded(repo_root / current_path, cfg, repo_root):
-            continue
+        if current_path:
+            if is_excluded(repo_root / current_path, cfg, repo_root):
+                continue
+            expected_rel = Path(current_path).with_suffix(".embed-meta.yaml")
+            try:
+                actual_rel = p.relative_to(sidecars_root)
+            except ValueError:
+                continue
+            if actual_rel != expected_rel:
+                continue  # stray/nested junk copy, not this source's canonical sidecar
         yield p
 
 

--- a/carta/scanner/tests/test_scanner.py
+++ b/carta/scanner/tests/test_scanner.py
@@ -1077,3 +1077,23 @@ def test_iter_sidecar_files_yields_pre_lifecycle_sidecars(tmp_path):
     cfg = _minimal_cfg(tmp_path, excluded_paths=["docs/"])
     yielded = list(_iter_sidecar_files(tmp_path, cfg))
     assert len(yielded) == 1
+
+
+def test_iter_sidecar_files_skips_noncanonical_nested_copies(tmp_path):
+    """A junk sidecar copy nested under a worktree tree (not at the canonical
+    location its current_path maps to) must be skipped — else it emits phantom
+    sidecar_path_drift findings for a source it does not own."""
+    # Canonical sidecar for a real file — must be yielded.
+    _write_sidecar(tmp_path, "docs/foo.embed-meta.yaml", "docs/foo.md")
+    (tmp_path / "docs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "docs" / "foo.md").write_text("# foo")
+    # Junk copy: a whole sidecar tree replicated under a worktree checkout, sitting
+    # far from where its current_path (docs/bar.md) would canonically place it.
+    _write_sidecar(
+        tmp_path,
+        ".worktrees/wt/.carta/sidecars/docs/bar.embed-meta.yaml",
+        "docs/bar.md",
+    )
+    cfg = _minimal_cfg(tmp_path)
+    yielded = [p.name for p in _iter_sidecar_files(tmp_path, cfg)]
+    assert yielded == ["foo.embed-meta.yaml"]


### PR DESCRIPTION
Three follow-ups surfaced during the ET-embed 0.12.2 closeout. None touch retrieval — the 62-query ET-embed eval on the current corpus is **0.952 recall@5 / 0.865 MRR** (hybrid-alone), a new high, independent of these fixes.

## Fixes

**1. Two-pass visual *queueing* ignored `colpali_scoped_paths`.**
0.12.2 fixed the `--visual` *drain* to skip out-of-scope sources, but pass-1 queueing still marked their image-heavy pages `visual_pending` — so out-of-scope docs (e.g. patents) re-queued on every `carta embed` and inflated the "N pages await visual" count with pages the drain would never process. `_mark_or_collect_visual_pages` now takes a `rel_path` and honors `colpali_scoped_paths` (the same check the inline ColPali path already applied). The zero-extractable-text OCR-rescue path stays ungated, preserving scanned docs' only route to any indexed text.

**2. Scanner emitted phantom `sidecar_path_drift` for nested junk sidecar copies.**
`_iter_sidecar_files` walked every `*.embed-meta.yaml` under `.carta/sidecars/`, including stray sidecar trees replicated into `.carta/sidecars/.worktrees/<wt>/.carta/sidecars/…` by worktree checkouts or imports; each copy's `current_path` was resolved against the real repo, producing false `sidecar_path_drift` / `sidecar_broken_related` findings for sources it didn't own. The walk now skips non-canonical copies (location under `sidecars/` must equal where `current_path` maps), mirroring `induct.iter_canonical_sidecars`. Removes the dead `_SIDECAR_SKIP_DIRS` constant this supersedes.

**3. `carta embed` auto-induction missed uppercase `.PDF`.**
New-file discovery globbed `*.pdf` / `*.md` case-sensitively, so an uppercase-extension file was perpetually flagged `embed_induction_needed` by the scanner (which lowercases suffixes) yet never auto-inducted — embeddable only via an explicit `carta embed <file>`. Discovery now matches supported extensions case-insensitively (`_iter_inductable_files`).

## Tests
TDD: 5 new tests (RED→GREEN). Full suite **1027 passed, 2 skipped** (torch-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)