### PR TITLE
fix(search): de-duplicate run_search results by doc (recall@5 0.952→0.984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to **carta-cc** are documented here. The format is loosely b
 
 ## [Unreleased]
 
+### Fixed
+- **`carta search` returned duplicate-chunk results, burying distinct docs.** `run_search` truncated the fused candidate pool to `top_n` without de-duplicating, so several high-ranked chunks of the same document — or the same visual page repeated — could fill the shown results (e.g. 3 of the top-5 being one spec doc), even when a relevant document sat just below at the 5th *distinct* position. `run_search` now fetches a deeper candidate pool, de-duplicates by source, and applies the visual-share cap (#36) against the final `top_n`. On the ET-embed eval, recall@5 **0.952 → 0.984** / MRR 0.855 → 0.875 with **zero regressions** — it recovered both the RJ45/CTS-harness and FSM-gain-scheduler docs that duplicate chunks had been crowding out (the lone remaining miss is a patent not yet OCR'd into the index). Provably non-decreasing at the doc level. Gated by `search.dedupe_results` (default on).
+
 ## [0.12.3] — 2026-06-17
 
 ### Fixed

--- a/carta/config.py
+++ b/carta/config.py
@@ -43,6 +43,7 @@ DEFAULTS = {
     },
     "search": {
         "top_n": 5,
+        "dedupe_results": True,
         "hybrid": {
             "enabled": True,
             "bm25_model": "Qdrant/bm25",

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1807,11 +1807,16 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     graph_enabled = graph_cfg.get("enabled", False)
     candidate_depth = graph_cfg.get("candidate_depth", 50)
     # Fetch deep enough for the rerank pool AND graph promotion (whichever is wider).
+    dedupe_results = cfg.get("search", {}).get("dedupe_results", True)
     fetch_limit = top_n
     if rerank_enabled:
         fetch_limit = max(fetch_limit, candidate_pool)
     if graph_enabled:
         fetch_limit = max(fetch_limit, candidate_depth)
+    if dedupe_results:
+        # Dedup collapses duplicate chunks/visual pages; fetch a real pool so the
+        # top_n SHOWN results are distinct docs, not 2-3 docs' worth of dup chunks.
+        fetch_limit = max(fetch_limit, _RESULT_POOL_FLOOR)
 
     # Get all collections to search
     try:
@@ -1952,8 +1957,11 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     # visual_max_ratio caps the visual lane's share so text questions keep their depth.
     fusion_cfg = cfg.get("search", {}).get("fusion", {})
     visual_max_ratio = fusion_cfg.get("visual_max_ratio", 1.0)
+    # When deduping, defer the visual cap to the final stage (applied against top_n
+    # after dedup) so the deepened pool can't let visual over-inject. 1.0 = no cap.
+    merge_ratio = 1.0 if dedupe_results else visual_max_ratio
     all_results = _rrf_merge_collections(
-        per_collection, fetch_limit, visual_max_ratio=visual_max_ratio
+        per_collection, fetch_limit, visual_max_ratio=merge_ratio
     )
 
     # Graph-aware expansion: promote related:-adjacent docs into the pool the reranker
@@ -1961,6 +1969,11 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     # candidate_depth (default 50) widens the Qdrant fetch to seed the walk.
     if graph_enabled:
         all_results = _apply_graph_expansion(all_results, cfg, repo_root)
+
+    # De-duplicate by source so the reranker ranks distinct docs and the shown
+    # top_n covers distinct docs (not duplicate chunks of the same one).
+    if dedupe_results:
+        all_results = _dedupe_by_source(all_results)
 
     # Optional second-stage cross-encoder reranking (opt-in via search.rerank.enabled)
     rerank_applied = False
@@ -1990,5 +2003,10 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
     if stats is not None:
         stats["rerank_requested"] = rerank_enabled
         stats["rerank_applied"] = rerank_applied
+
+    # Cap the visual lane's share of the SHOWN results (relative to top_n, not the
+    # deepened fetch pool), preserving the #36 balance after dedup.
+    if dedupe_results:
+        all_results = _apply_visual_cap(all_results, top_n, visual_max_ratio)
 
     return all_results[:top_n]

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -90,6 +90,10 @@ def _iter_inductable_files(docs_root: Path) -> Iterator[Path]:
 # Maximum seconds to allow a single file's embed processing to run
 FILE_TIMEOUT_S = 300
 
+# Minimum candidate pool fetched before de-duplication, so the top_n SHOWN results
+# can be top_n DISTINCT docs even when several high-ranked chunks share a doc.
+_RESULT_POOL_FLOOR = 30
+
 # Env var that, when set, points run_embed at a JSONL log it appends one row
 # to per processed file. Useful for profiling long batch runs.
 _PERF_LOG_ENV = "CARTA_PERF_LOG"
@@ -1647,6 +1651,35 @@ def _visual_collection_ready(client, coll_name: str) -> bool:
     return bool(count and count > 0)
 
 
+def _apply_visual_cap(ordered: list[dict], limit: int, visual_max_ratio: float = 1.0) -> list[dict]:
+    """Admit up to ``limit`` hits from an already-ordered list, capping the visual share.
+
+    Caps ``type == "visual"`` hits at ``round(visual_max_ratio * limit)``; overflow
+    visual is diverted and the freed slots are backfilled with deeper non-visual hits,
+    input order preserved among everything admitted. ``visual_max_ratio >= 1.0`` disables
+    the cap. Returns a list of length <= limit.
+    """
+    visual_cap = round(visual_max_ratio * limit)
+    result: list[dict] = []
+    overflow: list[dict] = []
+    visual_admitted = 0
+    for hit in ordered:
+        if len(result) >= limit:
+            break
+        if hit.get("type") == "visual":
+            if visual_admitted < visual_cap:
+                result.append(hit)
+                visual_admitted += 1
+            else:
+                overflow.append(hit)
+        else:
+            result.append(hit)
+    # Text too shallow to fill the pool: restore diverted visual, still in order.
+    if len(result) < limit and overflow:
+        result.extend(overflow[: limit - len(result)])
+    return result
+
+
 def _rrf_merge_collections(
     per_collection: list[list[dict]],
     top_n: int,
@@ -1689,28 +1722,8 @@ def _rrf_merge_collections(
     # -rrf: higher fused score first. coll_index/rank: deterministic, text-first ties.
     scored.sort(key=lambda t: (-t[0], t[1], t[2]))
 
-    # Cap the visual lane's share of the pool. No-op when no hit is visual or when
-    # visual_cap >= top_n (i.e. visual_max_ratio >= 1.0): the visual branch never
-    # diverts, so the walk reproduces scored[:top_n] exactly.
-    visual_cap = round(visual_max_ratio * top_n)
-    result: list[dict] = []
-    overflow: list[dict] = []
-    visual_admitted = 0
-    for _, _, _, hit in scored:
-        if len(result) >= top_n:
-            break
-        if hit.get("type") == "visual":
-            if visual_admitted < visual_cap:
-                result.append(hit)
-                visual_admitted += 1
-            else:
-                overflow.append(hit)
-        else:
-            result.append(hit)
-    # Text too shallow to fill the pool: restore diverted visual, still RRF order.
-    if len(result) < top_n and overflow:
-        result.extend(overflow[: top_n - len(result)])
-    return result
+    ordered = [hit for _, _, _, hit in scored]
+    return _apply_visual_cap(ordered, top_n, visual_max_ratio)
 
 
 def _apply_graph_expansion(results: list[dict], cfg: dict, repo_root) -> list[dict]:

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1680,6 +1680,26 @@ def _apply_visual_cap(ordered: list[dict], limit: int, visual_max_ratio: float =
     return result
 
 
+def _dedupe_by_source(results: list[dict]) -> list[dict]:
+    """Keep the first (best-ranked) occurrence of each distinct ``source``, drop the rest.
+
+    Order preserved. Hits without a ``source`` are passed through (treated as distinct),
+    so a missing key never collapses unrelated results.
+    """
+    seen: set = set()
+    out: list[dict] = []
+    for hit in results:
+        src = hit.get("source")
+        if src is None:
+            out.append(hit)
+            continue
+        if src in seen:
+            continue
+        seen.add(src)
+        out.append(hit)
+    return out
+
+
 def _rrf_merge_collections(
     per_collection: list[list[dict]],
     top_n: int,

--- a/carta/embed/tests/test_embed.py
+++ b/carta/embed/tests/test_embed.py
@@ -845,8 +845,9 @@ def test_run_search_returns_hits(mock_qdrant_cls, mock_embed, mock_find_config):
     mock_client.query_points.return_value = mock_response
 
     results = run_search("what is the voltage rating", MINIMAL_CFG)
-    # Search now returns results from all collections (doc, notes, session)
-    assert len(results) == 3
+    # The doc/notes/session collections all return the same docs/spec.pdf hit in this
+    # mock; dedupe_results collapses identical-source hits to one distinct result.
+    assert len(results) == 1
     assert results[0]["score"] == pytest.approx(0.92)
     assert results[0]["source"] == "docs/spec.pdf"
     assert results[0]["excerpt"] == "relevant excerpt"

--- a/carta/embed/tests/test_hybrid_query.py
+++ b/carta/embed/tests/test_hybrid_query.py
@@ -31,7 +31,7 @@ def test_hybrid_query_uses_prefetch_and_rrf(monkeypatch):
 # ---------------------------------------------------------------------------
 
 def _make_run_search_cfg(*, top_n=5, rerank_enabled=False, candidate_pool=30,
-                          hybrid_enabled=False):
+                          hybrid_enabled=False, dedupe_results=False):
     """Return a minimal carta config dict for run_search tests."""
     return {
         "project_name": "test_proj",
@@ -43,6 +43,7 @@ def _make_run_search_cfg(*, top_n=5, rerank_enabled=False, candidate_pool=30,
         },
         "search": {
             "top_n": top_n,
+            "dedupe_results": dedupe_results,
             "hybrid": {"enabled": hybrid_enabled, "prefetch_limit": 40,
                        "bm25_model": "Qdrant/bm25"},
             "rerank": {"enabled": rerank_enabled, "candidate_pool": candidate_pool,
@@ -140,7 +141,7 @@ def test_run_search_overfetch_when_rerank_enabled(monkeypatch):
 
 
 def test_run_search_no_overfetch_when_rerank_disabled(monkeypatch):
-    """With rerank disabled, retrieval should use limit=top_n (5) — no change."""
+    """With rerank AND dedup disabled, retrieval uses limit=top_n (5) — no overfetch."""
     captured_limits = []
     _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
                            n_points_per_collection=5, is_hybrid=False)
@@ -155,6 +156,23 @@ def test_run_search_no_overfetch_when_rerank_disabled(monkeypatch):
         )
 
     assert len(results) <= 5
+
+
+def test_run_search_deepens_fetch_for_dedup_when_enabled(monkeypatch):
+    """With dedup on, fetch is deepened to the pool floor (30) even when rerank is
+    off, so dedup has headroom to backfill top_n distinct docs."""
+    captured_limits = []
+    _patch_run_search_deps(monkeypatch, captured_limits=captured_limits,
+                           n_points_per_collection=30, is_hybrid=False)
+
+    cfg = _make_run_search_cfg(top_n=5, rerank_enabled=False, dedupe_results=True)
+    pipeline.run_search("serial bridge baud", cfg)
+
+    assert captured_limits, "No query_points calls were captured"
+    for lim in captured_limits:
+        assert lim == 30, (
+            f"Expected deepened fetch 30 (pool floor) with dedup on, got {lim}"
+        )
 
 
 def test_run_search_hybrid_overfetch_when_rerank_enabled(monkeypatch):

--- a/carta/embed/tests/test_result_dedup.py
+++ b/carta/embed/tests/test_result_dedup.py
@@ -1,0 +1,31 @@
+"""Result de-duplication: distinct docs in the shown top_n (spec 2026-06-17)."""
+from carta.embed.pipeline import _dedupe_by_source
+
+
+def test_dedupe_keeps_first_occurrence_and_order():
+    results = [
+        {"source": "a.md", "excerpt": "1"},
+        {"source": "b.md", "excerpt": "2"},
+        {"source": "a.md", "excerpt": "3"},   # dup of a.md
+        {"source": "c.md", "excerpt": "4"},
+        {"source": "b.md", "excerpt": "5"},   # dup of b.md
+    ]
+    out = _dedupe_by_source(results)
+    assert [h["source"] for h in out] == ["a.md", "b.md", "c.md"]
+    assert out[0]["excerpt"] == "1"  # best-ranked occurrence kept
+
+
+def test_dedupe_keeps_distinct_visual_pages():
+    results = [
+        {"source": "ds.pdf (page 20)"},
+        {"source": "ds.pdf (page 20)"},   # exact dup
+        {"source": "ds.pdf (page 31)"},   # different page = distinct result
+    ]
+    out = _dedupe_by_source(results)
+    assert [h["source"] for h in out] == ["ds.pdf (page 20)", "ds.pdf (page 31)"]
+
+
+def test_dedupe_passes_through_missing_source():
+    results = [{"excerpt": "x"}, {"excerpt": "y"}]  # no source key
+    out = _dedupe_by_source(results)
+    assert len(out) == 2

--- a/carta/embed/tests/test_result_dedup.py
+++ b/carta/embed/tests/test_result_dedup.py
@@ -29,3 +29,65 @@ def test_dedupe_passes_through_missing_source():
     results = [{"excerpt": "x"}, {"excerpt": "y"}]  # no source key
     out = _dedupe_by_source(results)
     assert len(out) == 2
+
+
+from unittest.mock import MagicMock
+
+
+def _run_search_with_merge(monkeypatch, tmp_path, merged, cfg):
+    """Drive run_search with _rrf_merge_collections stubbed to return `merged`."""
+    import carta.embed.pipeline as pipeline
+    monkeypatch.setattr(pipeline, "_rrf_merge_collections", lambda *a, **k: list(merged))
+    monkeypatch.setattr(pipeline, "QdrantClient", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(pipeline, "find_config", lambda: str(tmp_path / ".carta" / "config.yaml"))
+    monkeypatch.setattr("carta.search.scoped.get_search_collections", lambda cfg, scope: [])
+    return pipeline.run_search("query", cfg)
+
+
+_BASE_CFG = {
+    "project_name": "proj",
+    "qdrant_url": "http://localhost:6333",
+    "embed": {"ollama_url": "http://localhost:11434", "ollama_model": "nomic-embed-text"},
+}
+
+
+def test_run_search_dedupes_results_by_source(monkeypatch, tmp_path):
+    merged = [
+        {"source": "design.md", "type": "text", "excerpt": "1"},
+        {"source": "design.md", "type": "text", "excerpt": "2"},
+        {"source": "design.md", "type": "text", "excerpt": "3"},
+        {"source": "cts-control.md", "type": "text", "excerpt": "4"},
+        {"source": "other.md", "type": "text", "excerpt": "5"},
+    ]
+    cfg = {**_BASE_CFG, "search": {"top_n": 5, "dedupe_results": True,
+                                   "fusion": {"visual_max_ratio": 0.2}}}
+    out = _run_search_with_merge(monkeypatch, tmp_path, merged, cfg)
+    assert [h["source"] for h in out] == ["design.md", "cts-control.md", "other.md"]
+
+
+def test_run_search_dedupe_off_preserves_duplicates(monkeypatch, tmp_path):
+    merged = [
+        {"source": "a.md", "type": "text"},
+        {"source": "a.md", "type": "text"},
+        {"source": "b.md", "type": "text"},
+    ]
+    cfg = {**_BASE_CFG, "search": {"top_n": 5, "dedupe_results": False,
+                                   "fusion": {"visual_max_ratio": 0.2}}}
+    out = _run_search_with_merge(monkeypatch, tmp_path, merged, cfg)
+    assert [h["source"] for h in out] == ["a.md", "a.md", "b.md"]
+
+
+def test_run_search_caps_visual_against_top_n_after_dedup(monkeypatch, tmp_path):
+    merged = [
+        {"source": "v0", "type": "visual"},
+        {"source": "v1", "type": "visual"},
+        {"source": "t0", "type": "text"},
+        {"source": "t1", "type": "text"},
+        {"source": "t2", "type": "text"},
+        {"source": "t3", "type": "text"},
+    ]
+    cfg = {**_BASE_CFG, "search": {"top_n": 5, "dedupe_results": True,
+                                   "fusion": {"visual_max_ratio": 0.2}}}  # cap = 1
+    out = _run_search_with_merge(monkeypatch, tmp_path, merged, cfg)
+    assert sum(1 for h in out if h["type"] == "visual") == 1
+    assert len(out) == 5

--- a/carta/embed/tests/test_visual_search_merge.py
+++ b/carta/embed/tests/test_visual_search_merge.py
@@ -111,16 +111,18 @@ def test_ratio_zero_excludes_visual_when_text_fills_pool():
 
 
 def test_run_search_forwards_configured_visual_max_ratio(monkeypatch, tmp_path):
-    # The configured search.fusion.visual_max_ratio must reach _rrf_merge_collections.
+    # With dedupe on (default) the configured ratio is applied at the FINAL visual
+    # cap (the merge runs uncapped, deferring the cap to after dedup).
     import carta.embed.pipeline as pipeline
 
     captured = {}
+    monkeypatch.setattr(pipeline, "_rrf_merge_collections", lambda *a, **k: [])
 
-    def fake_merge(per_collection, top_n, k=60, visual_max_ratio=1.0):
+    def fake_cap(ordered, limit, visual_max_ratio=1.0):
         captured["ratio"] = visual_max_ratio
-        return []
+        return list(ordered)[:limit]
 
-    monkeypatch.setattr(pipeline, "_rrf_merge_collections", fake_merge)
+    monkeypatch.setattr(pipeline, "_apply_visual_cap", fake_cap)
     monkeypatch.setattr(pipeline, "QdrantClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr(pipeline, "find_config", lambda: str(tmp_path / ".carta" / "config.yaml"))
     # No collections -> the per-collection loop is skipped and the merge is still called.

--- a/carta/tests/test_config.py
+++ b/carta/tests/test_config.py
@@ -154,3 +154,7 @@ def test_ollama_keep_alive_default_and_env_override(monkeypatch):
     assert ollama_keep_alive() == "10m"
     monkeypatch.setenv("CARTA_OLLAMA_KEEP_ALIVE", "-1")
     assert ollama_keep_alive() == "-1"
+
+
+def test_search_dedupe_results_default_on():
+    assert DEFAULTS["search"]["dedupe_results"] is True

--- a/docs/superpowers/specs/2026-06-17-search-result-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-17-search-result-dedup-design.md
@@ -1,0 +1,193 @@
+# Search result de-duplication — design
+
+- **Date:** 2026-06-17
+- **Status:** approved (pending spec review)
+- **Issue:** follow-up from the #19 first-stage-recall investigation
+- **Scope owner:** Ian
+
+## Context
+
+The #19 investigation (improve first-stage recall) ran a per-lane depth check and a
+full-pipeline simulation on the rebuilt 0.952 ET-embed corpus. The conclusion
+overturned the premise: **first-stage recall is healthy** — the gold docs are
+well-covered and well-embedded. The three residual eval "misses" turned out to be
+three unrelated causes, only one of which is a retrieval bug:
+
+| Miss | Real cause | Disposition |
+|------|------------|-------------|
+| `cts-control` (RJ45 pinout) | Duplicate chunks + duplicate visual pages crowd the returned top-5 | **This spec** |
+| `FSM_GAIN_SCHEDULER` | Relevant design/plan docs surface but cannot match the `expect` string (underscore vs hyphen); the matching firmware doc is outranked | Eval-correctness debt — out of scope |
+| `US-11965795` (kingpin patent) | Patent PDF has 0 chunks (never OCR'd) | #38 data gap — out of scope |
+
+### The bug
+
+`run_search` (`carta/embed/pipeline.py`) fuses per-collection candidate lists, then
+returns `all_results[:top_n]` **with no de-duplication**. When `rerank` and `graph`
+are disabled (the default, and what the proactive-recall hook uses), the per-collection
+fetch depth is `fetch_limit = top_n`, so the fused pool is shallow. Observed top-8 for
+the cts-control query:
+
+```
+1,3,5,7. .../specs/2026-04-16-cts-subsystem-vcu-interface-design.md   ← same doc ×4
+2,4.     .../Yuchai ... Electric Drive Unit ... .pdf (page 20)         ← same visual page ×2
+6,8.     docs/reference/datasheets/tcan1044-q1.pdf (page 26)           ← same visual page ×2
+```
+
+Three of the top-5 slots are the same `.md`; the genuinely-relevant `cts-control.md`
+is pushed below the cut. This wastes the slot budget on **every** query — the returned
+"5 results" routinely cover only 2–3 distinct documents — and it is what buries the
+RJ45 gold.
+
+## Goal
+
+Return `top_n` **distinct, non-redundant** documents from `run_search`, recovering the
+cts-control/RJ45 miss and improving result quality on every query.
+
+### Non-goals
+
+- First-stage recall / chunking / embedding changes (the investigation showed these are
+  already healthy — no re-embed).
+- The FSM eval-expectation artifact (separate eval-correctness work).
+- Patent OCR coverage / `US-11965795` (#38).
+- De-duplicating the underlying corpus or the `_visual` collection's duplicate points
+  (a real but separate data-hygiene item — noted under Follow-ups).
+
+## Acceptance bar (strict no-regression)
+
+On the ET-embed 62-query eval (`carta eval .carta/eval/et-embed.yaml -k 5`, the default
+rerank-off configuration):
+
+- recall@5 **recovers `cts-control`** (the RJ45 query), and
+- **zero regressions** — every query that passes today still passes, and
+- recall@5 **≥ 0.952** (current), targeting **0.968** (60/62; the FSM artifact and the
+  #38 patent remain out of scope and will still "miss").
+
+Measured by A/B: run the eval with `search.dedupe_results` off (baseline) vs on.
+
+## Mechanism
+
+All changes live in `run_search` plus two small helpers in `carta/embed/pipeline.py`.
+The dedup path is gated by a config flag so it is reversible and A/B-measurable; with the
+flag **off**, `run_search` behaves exactly as it does today.
+
+### New data flow (flag on, the default)
+
+1. **Fetch a real pool.** Floor the per-collection fetch depth to `_RESULT_POOL_FLOOR`
+   (30) even when rerank/graph are off, so dedup has headroom to backfill `top_n`
+   *distinct* results. (The `_doc` hybrid query already prefetches 40 per lane, so
+   returning ~30 fused candidates adds no extra Qdrant round-trips and negligible cost;
+   the `_visual` lane fetches ~30 ColPali hits instead of `top_n`.)
+2. **Merge without the visual cap.** Call `_rrf_merge_collections(per_collection,
+   pool_limit, visual_max_ratio=1.0)` — pure RRF order, cap deferred to the final stage
+   (`1.0` already means "no cap" per its contract).
+3. **Graph expansion** (if enabled) — unchanged, operates on the deep ordered pool.
+4. **Rerank** (if enabled) — returns the deep reranked pool (`top_n=pool_limit`) rather
+   than pre-truncating to `top_n`, so the final stage can dedup + cap + truncate
+   uniformly.
+5. **De-duplicate by source** — `_dedupe_by_source(all_results)` keeps the first
+   (best-ranked) occurrence of each distinct `source` string, preserving order.
+6. **Apply the visual cap relative to `top_n`** — `_apply_visual_cap(all_results, top_n,
+   visual_max_ratio)` caps visual hits at `round(visual_max_ratio * top_n)` (= 1 at the
+   0.2 default), diverting excess visual and backfilling with deeper text, RRF order
+   preserved.
+7. **Truncate to `top_n`** and return.
+
+### Dedup granularity (decided)
+
+De-dup by **exact `source` string** — `file_path` for text hits, `"{file_path} (page N)"`
+for visual hits. This collapses the observed redundancy (same `.md` repeated; the same
+`(page N)` repeated) while keeping *different* pages of one PDF as distinct results,
+preserving page-level visual diversity. Rejected alternative: collapsing all pages of a
+PDF to one slot (max doc diversity, but a multi-page datasheet could surface only once).
+
+## Components & interfaces
+
+### `_dedupe_by_source(results: list[dict]) -> list[dict]` (new, pure)
+
+Returns a new list with later duplicates of each `source` removed, first occurrence and
+order preserved. Hits without a `source` key (defensive) are passed through untouched
+(treated as distinct). No I/O; trivially unit-testable.
+
+### `_apply_visual_cap(ordered: list[dict], limit: int, visual_max_ratio: float) -> list[dict]` (extracted)
+
+Extracted verbatim from the existing cap+backfill block inside `_rrf_merge_collections`
+(currently lines ~1692–1713): given an already-ordered hit list, admit up to `limit`
+hits, capping `type == "visual"` hits at `round(visual_max_ratio * limit)`, diverting
+overflow visual and backfilling with deeper non-visual hits, order preserved. Returns a
+list of length ≤ `limit`.
+
+After extraction, `_rrf_merge_collections` calls `_apply_visual_cap` internally (no
+behavior change to existing callers), and `run_search` calls it again at the final stage
+against `top_n`. The logic exists once, used in two places.
+
+### `run_search` changes
+
+- Compute `pool_limit = max(fetch_limit, _RESULT_POOL_FLOOR)` when `dedupe_results` is on.
+- Merge with `visual_max_ratio=1.0` (defer cap); rerank with `top_n=pool_limit`.
+- Final stage: `_dedupe_by_source` → `_apply_visual_cap(..., top_n, ...)` → `[:top_n]`.
+- When `dedupe_results` is off: unchanged from today (shallow fetch, cap during merge,
+  no dedup) — exact baseline for A/B.
+
+## No-regression argument (default rerank-off configuration)
+
+Doc-level recall@`top_n` cannot drop a doc the old path returned:
+
+- **Visual count is unchanged.** Old path caps visual at `round(ratio * fetch_limit)`
+  with `fetch_limit = top_n` → 1 (at defaults). New path caps at `round(ratio * top_n)`
+  → 1. Same single highest-RRF visual is admitted in both (dedup keeps the first/best
+  occurrence), so the visual slot is identical.
+- **Text docs are a superset.** The merged RRF order's prefix is identical between old
+  (shallow) and new (deep) — deepening only appends a tail. The old top-`top_n` chunks
+  cover the first *k ≤ top_n* distinct docs of that order; the new path returns the first
+  `top_n` distinct docs of the same order. The former is a prefix-subset of the latter,
+  so every doc shown by the old path is still shown.
+
+Therefore the new path's distinct-doc set ⊇ the old path's, and recall is monotonically
+non-decreasing. The guarantee is also verified empirically by the eval A/B (the strict
+acceptance bar). The guarantee is stated for the default rerank-off path; the rerank-on
+path (opt-in, hook-disabled) changes — for the better, feeding the reranker distinct docs
+— and is validated separately if/when rerank is enabled.
+
+## Error handling
+
+- Both helpers are pure and total; no new I/O, no new failure modes.
+- The existing per-collection fetch error handling (skip-on-404, raise-on-transport) is
+  unchanged. Fail-open posture preserved.
+
+## Config & defaults
+
+- `search.dedupe_results: true` — new key in `DEFAULTS` (`carta/config.py`). Default on
+  (it is a bug fix); off restores prior behavior for A/B and rollback.
+- `_RESULT_POOL_FLOOR = 30` — module constant in `pipeline.py` (not config; internal
+  headroom). Promote to config only if a future need to tune it appears (YAGNI).
+
+## Testing (TDD)
+
+1. `_dedupe_by_source` — unit: collapses repeated sources to first occurrence; preserves
+   order; keeps distinct sources (incl. different `(page N)` of one PDF); passes through
+   hits lacking `source`.
+2. `_apply_visual_cap` — unit: caps visual at `round(ratio*limit)`; backfills text when
+   text is shallow; `ratio=1.0` is a no-op; order preserved. (Characterization tests so
+   the extraction is provably behavior-preserving for `_rrf_merge_collections`.)
+3. `run_search` — integration (mocked Qdrant): a dup-heavy fused list yields `top_n`
+   **distinct** sources; visual stays ≤ `round(ratio*top_n)`; flag off reproduces current
+   output.
+4. Acceptance — ET-embed eval A/B: recovers `cts-control`, recall@5 ≥ 0.952 → ~0.968,
+   **zero regressions**.
+
+## Risk & rollback
+
+- **Risk:** the cap-extraction subtly changes `_rrf_merge_collections` output.
+  *Mitigation:* characterization tests pin its current behavior before extraction.
+- **Risk:** deeper `_visual` fetch adds latency. *Mitigation:* ColPali query embed is
+  per-query (one model load); fetching 30 vs 5 points from Qdrant is negligible. The hook
+  disables visual/rerank anyway.
+- **Rollback:** `search.dedupe_results: false` restores prior behavior with no redeploy.
+
+## Out of scope / follow-ups (tracked, not in this spec)
+
+- **Eval-correctness pass** — FSM underscore/hyphen expectation; patent-only golds where
+  relevant markdown exists; re-verify the other 59. Makes the metric trustworthy.
+- **#38** — OCR-drain scanned patents so `US-11965795` enters the index.
+- **Duplicate `_visual` points** — the same page appearing twice (`(page 20) ×2`) hints
+  at stale visual points from re-drains; a `_visual` data-hygiene/repair item.


### PR DESCRIPTION
## Summary
`run_search` returned `top_n` fused **chunks** with no doc-level de-duplication, so several high-ranked chunks of one document (or the same visual page repeated) could fill the shown top-5 — burying distinct relevant docs that were already top-5 *documents*. This wasted the result-slot budget on every query and was the real cause of the residual ET-embed eval misses (a #19 first-stage-recall follow-up — recall itself turned out to be healthy).

**Fix:** `run_search` now fetches a deeper candidate pool (`_RESULT_POOL_FLOOR`), merges uncapped, de-duplicates by `source`, then applies the visual-share cap (#36) against the final `top_n` and truncates. Gated by `search.dedupe_results` (default on); flag off reproduces the legacy path. Provably non-decreasing at the doc level (dedup only adds distinct docs, never removes one already shown).

- `_dedupe_by_source` — new pure helper (exact `source` string; keeps distinct visual pages of a PDF).
- `_apply_visual_cap` — extracted from `_rrf_merge_collections` so the cap can apply after dedup, against the shown `top_n` (the 11 existing merge tests guard the extraction).

## Validation
- **ET-embed eval A/B (rerank off, same corpus):** recall@5 **0.952 → 0.984** (59→61/62), MRR 0.855 → 0.875, **zero regressions** (treatment miss set ⊂ baseline). Recovered both RJ45/`cts-control` (@3) and `FSM_GAIN_SCHEDULER` (@4); the lone remaining miss is a patent never OCR'd into the index (#38, out of scope).
- **Full unit suite: 1035 passed, 2 skipped.**

## Test Plan
- [x] Unit: `_dedupe_by_source`, `run_search` dedup integration (on/off + visual cap vs top_n)
- [x] Fetch-deepen + identical-hit-collapse behavior tests updated
- [x] Full suite green (1035 passed)
- [x] ET-embed eval A/B: +2 recovered, 0 regressions
- [ ] CI: 3.10 / 3.11 / 3.12 + validate-plugin

Spec: `docs/superpowers/specs/2026-06-17-search-result-dedup-design.md`
Plan: `docs/superpowers/plans/2026-06-17-search-result-dedup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)