### PR TITLE
feat: carta focus — file-scoped deep retrieval (CLI + MCP)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ pip install -e .
 ## Project Structure
 
 - Python 3.10+ semantic memory sidecar for Claude Code (Qdrant vectors, Ollama embeddings)
-- **CLI** (`carta <cmd>`, or `python -m carta <cmd>`): `init`, `scan`, `embed` (`--visual` / `--repair`), `search`, `audit`, `doctor`, `eval`, `remember`, `status`, `statusline`, `export`, `import`, `update`
-- **MCP** (`carta-mcp`, stdio): `carta_search`, `carta_embed`, `carta_scan`, `carta_remember`
+- **CLI** (`carta <cmd>`, or `python -m carta <cmd>`): `init`, `scan`, `embed` (`--visual` / `--repair`), `search`, `focus`, `audit`, `doctor`, `eval`, `remember`, `status`, `statusline`, `export`, `import`, `update`
+- **MCP** (`carta-mcp`, stdio): `carta_search`, `carta_focus`, `carta_embed`, `carta_scan`, `carta_remember`
 - **Hook** (`carta-hook` + `carta/hooks/*.sh`): pre-prompt proactive recall, three-zone gate (high→inject, low→silent, gray→Ollama judge), fail-open
 - **Modules** (`carta/`): `embed/` `search/` `scanner/` `audit/` `eval/` `vision/` `mcp/` `hook/` `memory/` `install/` `update/` `ui/`
 - Tests in `carta/tests/` and `carta/*/tests/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Retrieval-quality changes are validated against the ET-embed eval corpus — see
 | `scan` | Structural doc scan → `.carta/scan-results.json` (no LLM) |
 | `embed` | Extract/chunk/embed pending docs → Qdrant. `--visual` drains image-heavy pages (two-pass); `--repair` re-embeds damaged points |
 | `search` | Hybrid (BM25 + dense, RRF) semantic search |
+| `focus` | Deep retrieval scoped to **one file**: page-anchored passages, an outline (omit query), and table/figure pages as images. Two-step partner to `search` (locate → go deep) |
 | `audit` | Embed-pipeline **data integrity** check → JSON |
 | `doctor` | Diagnose environment (Qdrant/Ollama/models); `--fix` auto-installs |
 | `eval` | Score retrieval quality against an eval set |
@@ -159,7 +160,7 @@ Retrieval-quality changes are validated against the ET-embed eval corpus — see
 
 ### MCP — `carta-mcp` (stdio, `carta/mcp/server.py`)
 
-Claude-initiated tools: `carta_search`, `carta_embed`, `carta_scan`, `carta_remember`.
+Claude-initiated tools: `carta_search`, `carta_focus`, `carta_embed`, `carta_scan`, `carta_remember`.
 
 ### Hook — `carta-hook` (+ `carta/hooks/*.sh`)
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ last_reviewed: 2026-03-20
 | `/doc-audit` | Structural + semantic audit, generates `docs/AUDIT_REPORT.md` |
 | `/doc-embed` | Ingest PDFs, manuals, and audio transcripts into Qdrant |
 | `/doc-search` | Natural language search over the embedded knowledge base |
+| `carta focus` / `carta_focus` | Deep retrieval scoped to one file: page-anchored passages, an outline (omit query), and table/figure pages as images. Two-step partner to `/doc-search` (locate → go deep) |
 | `carta remember` / `carta_remember` | Save a curated project note (quirk / bug-note / helpful-note) as a repo markdown file and embed it |
 
 ---

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -324,6 +324,52 @@ def cmd_search(args):
 
     _notify_if_update(cfg_path, cfg)
 
+def cmd_focus(args):
+    from carta.config import load_config
+    cfg_path = find_config()
+    cfg = load_config(cfg_path)
+    if not cfg["modules"].get("doc_search"):
+        print("doc_search module is disabled in config.", file=sys.stderr)
+        sys.exit(1)
+    from carta.embed.pipeline import run_focus
+    repo_root = cfg_path.parent.parent
+    query = " ".join(args.query) if args.query else ""
+    try:
+        results = run_focus(args.source, cfg, query=query, limit=args.limit)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not results:
+        print(f"No focus results for {args.source!r}. Is the file embedded? "
+              f"Use `carta search` to find the exact source path.")
+        return
+
+    if not query:
+        print(f"Outline of {args.source} ({len(results)} sections):")
+        for r in results:
+            page = r.get("page")
+            page_s = f"p.{page}" if page is not None else "p.?"
+            heading = r.get("section_heading") or "(no heading)"
+            print(f"  {page_s:>6}  {heading}")
+        return
+
+    cache_dir = repo_root / ".carta" / "cache" / "focus"
+    stem = Path(args.source).stem
+    for r in results:
+        page = r.get("page")
+        page_s = f"p.{page}" if page is not None else "p.?"
+        heading = r.get("section_heading") or ""
+        head_s = f" §{heading}" if heading else ""
+        print(f"[{r['score']:.2f}] {r['source']} {page_s}{head_s} — {r['excerpt']}")
+        if r.get("image_b64"):
+            import base64
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            img_path = cache_dir / f"{stem}-p{page}.png"
+            img_path.write_bytes(base64.b64decode(r["image_b64"]))
+            print(f"        ↳ page image: {img_path}")
+
+
 def cmd_update(args):
     """Check for and apply carta updates."""
     from carta.update.updater import run_update, print_check
@@ -945,6 +991,16 @@ def main():
         ),
     )
 
+    focus_p = sub.add_parser(
+        "focus",
+        help="Go deep in one file: page-anchored passages, or an outline (omit the query)")
+    focus_p.add_argument("query", nargs="*",
+                         help="Query to search within the file; omit for a section/page outline")
+    focus_p.add_argument("--source", required=True, metavar="PATH",
+                         help="Repo-relative file path (the 'source' from a carta search result)")
+    focus_p.add_argument("--limit", type=int, default=15,
+                         help="Max passages to return (default 15)")
+
     eval_p = sub.add_parser("eval", help="Score retrieval quality against an eval set")
     eval_p.add_argument("eval_path", help="Path to eval-set YAML (see carta/eval/datasets/example.yaml)")
     eval_p.add_argument("-k", type=int, default=5, help="top-k cutoff (default 5)")
@@ -1042,6 +1098,7 @@ def main():
         "scan": cmd_scan,
         "embed": cmd_embed,
         "search": cmd_search,
+        "focus": cmd_focus,
         "audit": cmd_audit,
         "doctor": cmd_doctor,
         "eval": cmd_eval,

--- a/carta/cli.py
+++ b/carta/cli.py
@@ -324,6 +324,7 @@ def cmd_search(args):
 
     _notify_if_update(cfg_path, cfg)
 
+
 def cmd_focus(args):
     from carta.config import load_config
     cfg_path = find_config()
@@ -343,6 +344,7 @@ def cmd_focus(args):
     if not results:
         print(f"No focus results for {args.source!r}. Is the file embedded? "
               f"Use `carta search` to find the exact source path.")
+        _notify_if_update(cfg_path, cfg)
         return
 
     if not query:
@@ -352,6 +354,7 @@ def cmd_focus(args):
             page_s = f"p.{page}" if page is not None else "p.?"
             heading = r.get("section_heading") or "(no heading)"
             print(f"  {page_s:>6}  {heading}")
+        _notify_if_update(cfg_path, cfg)
         return
 
     cache_dir = repo_root / ".carta" / "cache" / "focus"
@@ -368,6 +371,7 @@ def cmd_focus(args):
             img_path = cache_dir / f"{stem}-p{page}.png"
             img_path.write_bytes(base64.b64decode(r["image_b64"]))
             print(f"        ↳ page image: {img_path}")
+    _notify_if_update(cfg_path, cfg)
 
 
 def cmd_update(args):

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1886,6 +1886,8 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
                             "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
                             "type": "visual",
                             "doc_type": payload.get("doc_type", ""),
+                            "page": payload.get("page_num"),
+                            "section_heading": "",
                         })
                         
                 except Exception:
@@ -1935,6 +1937,8 @@ def run_search(query: str, cfg: dict, verbose: bool = False, stats: dict | None 
                         "excerpt": payload.get("text", ""),
                         "type": "text",
                         "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page"),
+                        "section_heading": payload.get("section_heading", ""),
                     })
 
             per_collection.append(coll_results)

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1608,7 +1608,7 @@ def run_embed(repo_root: Path, cfg: dict, verbose: bool = False, progress=None) 
 
 
 def _hybrid_query_collection(client, coll_name, query, dense_vec, top_n,
-                              prefetch_limit, bm25_model):
+                              prefetch_limit, bm25_model, query_filter=None):
     """Run a hybrid BM25+dense query with Qdrant RRF fusion.
 
     Fetches `prefetch_limit` candidates from each of the dense and sparse
@@ -1619,15 +1619,19 @@ def _hybrid_query_collection(client, coll_name, query, dense_vec, top_n,
     to return).  When reranking is enabled, callers should pass `fetch_limit`
     (= candidate_pool) here so that the reranker has a wide enough pool to
     promote lower-ranked relevant documents.
+
+    `query_filter` (optional) is applied to BOTH prefetch lanes so the filter
+    takes effect before fusion (used by run_focus to scope to one file).
     """
     sv = embed_sparse_query(query, model_name=bm25_model)
     return client.query_points(
         collection_name=coll_name,
         prefetch=[
-            qmodels.Prefetch(query=dense_vec, using=DENSE_VECTOR_NAME, limit=prefetch_limit),
+            qmodels.Prefetch(query=dense_vec, using=DENSE_VECTOR_NAME,
+                             limit=prefetch_limit, filter=query_filter),
             qmodels.Prefetch(
                 query=qmodels.SparseVector(indices=sv.indices, values=sv.values),
-                using=SPARSE_VECTOR_NAME, limit=prefetch_limit,
+                using=SPARSE_VECTOR_NAME, limit=prefetch_limit, filter=query_filter,
             ),
         ],
         query=qmodels.FusionQuery(fusion=qmodels.Fusion.RRF),

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1684,6 +1684,36 @@ def _apply_visual_cap(ordered: list[dict], limit: int, visual_max_ratio: float =
     return result
 
 
+_FOCUS_DEFAULT_LIMIT = 15  # passages returned by a deep focus query
+
+
+def _normalize_source(source: str) -> str:
+    """Strip a trailing ' (page N)' suffix (the visual-hit source form) to the bare file_path."""
+    return re.sub(r"\s*\(page\s+\S+\)\s*$", "", source).strip()
+
+
+def _file_filter(source: str) -> Filter:
+    """Qdrant filter matching points whose file_path payload equals `source`."""
+    return Filter(must=[qmodels.FieldCondition(
+        key="file_path", match=qmodels.MatchValue(value=source))])
+
+
+def _ensure_file_path_index(client, coll_name: str) -> None:
+    """Idempotently create a keyword payload index on file_path to speed the focus filter.
+
+    Fail-open: an existing index, a missing collection, or an older server all just mean
+    the filter runs unindexed (correct, slower) — never an error to the caller.
+    """
+    try:
+        client.create_payload_index(
+            collection_name=coll_name,
+            field_name="file_path",
+            field_schema=qmodels.PayloadSchemaType.KEYWORD,
+        )
+    except Exception:
+        pass
+
+
 def _dedupe_by_source(results: list[dict]) -> list[dict]:
     """Keep the first (best-ranked) occurrence of each distinct ``source``, drop the rest.
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1717,18 +1717,22 @@ def _ensure_file_path_index(client, coll_name: str) -> None:
 _FOCUS_RENDER_DPI = 150  # page-image resolution for focus visual hits
 
 
-def render_page_png(abs_file_path: Path, page: int, repo_root: Path) -> bytes | None:
+def render_page_png(abs_file_path: Path, page: int, repo_root: Path,
+                    embed_cfg: dict | None = None) -> bytes | None:
     """Return PNG bytes for a 1-indexed PDF page, or None if it can't be produced.
 
-    Fast path: a ColPali cache PNG at .carta/visual_cache/<stem>/page_NNNN.png.
+    Fast path: a ColPali cache PNG under the configured colpali_sidecar_path
+    (default .carta/visual_cache/), at <cache_dir>/<stem>/page_NNNN.png.
     Fallback: render on demand with PyMuPDF. Non-PDF, out-of-range page, or any
     failure returns None so the caller degrades to anchors-only for that hit.
     """
     try:
         if abs_file_path.suffix.lower() != ".pdf":
             return None
-        cached = (repo_root / ".carta" / "visual_cache" /
-                  abs_file_path.stem / f"page_{page:04d}.png")
+        cache_dir = Path((embed_cfg or {}).get("colpali_sidecar_path", ".carta/visual_cache/"))
+        if not cache_dir.is_absolute():
+            cache_dir = repo_root / cache_dir
+        cached = cache_dir / abs_file_path.stem / f"page_{page:04d}.png"
         if cached.is_file():
             return cached.read_bytes()
         import fitz  # PyMuPDF, imported lazily
@@ -1741,12 +1745,13 @@ def render_page_png(abs_file_path: Path, page: int, repo_root: Path) -> bytes | 
         return None
 
 
-def _attach_page_images(hits: list[dict], abs_source_path: Path, repo_root: Path) -> list[dict]:
+def _attach_page_images(hits: list[dict], abs_source_path: Path, repo_root: Path,
+                        embed_cfg: dict | None = None) -> list[dict]:
     """Attach a base64 page PNG to each visual hit that has a page number. Mutates + returns hits."""
     import base64
     for hit in hits:
         if hit.get("type") == "visual" and hit.get("page"):
-            png = render_page_png(abs_source_path, hit["page"], repo_root)
+            png = render_page_png(abs_source_path, hit["page"], repo_root, embed_cfg)
             if png is not None:
                 hit["image_b64"] = base64.b64encode(png).decode("ascii")
     return hits

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1685,6 +1685,7 @@ def _apply_visual_cap(ordered: list[dict], limit: int, visual_max_ratio: float =
 
 
 _FOCUS_DEFAULT_LIMIT = 15  # passages returned by a deep focus query
+_FOCUS_OUTLINE_SCROLL_LIMIT = 10_000  # raise the limit if any single file exceeds this chunk count
 
 
 def _normalize_source(source: str) -> str:
@@ -1770,9 +1771,17 @@ def _focus_outline(client, collections: list[str], ff: Filter, source: str) -> l
         try:
             points, _ = client.scroll(
                 collection_name=coll, scroll_filter=ff,
-                with_payload=True, limit=10_000,
+                with_payload=True, limit=_FOCUS_OUTLINE_SCROLL_LIMIT,
             )
-        except Exception:
+        except Exception as e:
+            err_str = str(e).lower()
+            if "404" in err_str or "not found" in err_str or "doesn't exist" in err_str:
+                continue
+            if any(kw in err_str for kw in ("connection refused", "connection error",
+                                            "network", "timeout", "unreachable")):
+                raise RuntimeError(
+                    f"Cannot reach Qdrant — is it running? "
+                    f"Start it with: carta doctor --fix\n(Detail: {e})") from e
             continue
         for p in points:
             payload = p.payload or {}

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1816,22 +1816,25 @@ def _focus_deep(client, collections: list[str], ff: Filter, query: str,
                     continue
                 if not _visual_collection_ready(client, coll_name):
                     continue
-                embedder = ColPaliEmbedder(
-                    model_name=embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf"),
-                    device=embed_cfg.get("colpali_device", "cpu"), batch_size=1)
-                qv = embedder.embed_query(query)
-                qv = qv.tolist() if hasattr(qv, "tolist") else list(qv)
-                response = client.query_points(
-                    collection_name=coll_name, query=qv, using="colpali",
-                    limit=limit, with_payload=True, query_filter=ff)
-                for r in response.points:
-                    payload = r.payload or {}
-                    coll_results.append({
-                        "score": r.score,
-                        "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
-                        "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
-                        "type": "visual", "doc_type": payload.get("doc_type", ""),
-                        "page": payload.get("page_num"), "section_heading": ""})
+                try:
+                    embedder = ColPaliEmbedder(
+                        model_name=embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf"),
+                        device=embed_cfg.get("colpali_device", "cpu"), batch_size=1)
+                    qv = embedder.embed_query(query)
+                    qv = qv.tolist() if hasattr(qv, "tolist") else list(qv)
+                    response = client.query_points(
+                        collection_name=coll_name, query=qv, using="colpali",
+                        limit=limit, with_payload=True, query_filter=ff)
+                    for r in response.points:
+                        payload = r.payload or {}
+                        coll_results.append({
+                            "score": r.score,
+                            "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
+                            "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
+                            "type": "visual", "doc_type": payload.get("doc_type", ""),
+                            "page": payload.get("page_num"), "section_heading": ""})
+                except Exception:
+                    pass  # visual lane is auxiliary — skip on any ColPali/query error, keep text results
             else:
                 ollama_url = cfg["embed"]["ollama_url"]
                 model = cfg["embed"]["ollama_model"]

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1799,6 +1799,125 @@ def _focus_outline(client, collections: list[str], ff: Filter, source: str) -> l
              "doc_type": ""} for _sort, page, heading in rows]
 
 
+def _focus_deep(client, collections: list[str], ff: Filter, query: str,
+                cfg: dict, repo_root: Path, source: str, limit: int) -> list[dict]:
+    """File-scoped deep retrieval: filtered per-collection queries, RRF fused, NO dedup,
+    NO visual cap, NO graph expansion; visual hits get a rendered page image."""
+    per_collection: list[list[dict]] = []
+    for coll_name in collections:
+        coll_results: list[dict] = []
+        try:
+            if coll_name.endswith("_visual"):
+                embed_cfg = cfg.get("embed", {})
+                if embed_cfg.get("colpali_enabled", None) is False:
+                    continue
+                from carta.embed.colpali import is_colpali_available, ColPaliEmbedder
+                if not is_colpali_available():
+                    continue
+                if not _visual_collection_ready(client, coll_name):
+                    continue
+                embedder = ColPaliEmbedder(
+                    model_name=embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf"),
+                    device=embed_cfg.get("colpali_device", "cpu"), batch_size=1)
+                qv = embedder.embed_query(query)
+                qv = qv.tolist() if hasattr(qv, "tolist") else list(qv)
+                response = client.query_points(
+                    collection_name=coll_name, query=qv, using="colpali",
+                    limit=limit, with_payload=True, query_filter=ff)
+                for r in response.points:
+                    payload = r.payload or {}
+                    coll_results.append({
+                        "score": r.score,
+                        "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
+                        "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
+                        "type": "visual", "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page_num"), "section_heading": ""})
+            else:
+                ollama_url = cfg["embed"]["ollama_url"]
+                model = cfg["embed"]["ollama_model"]
+                query_vec = get_embedding(query, ollama_url=ollama_url, model=model,
+                                          prefix="search_query: ")
+                hybrid_cfg = cfg.get("search", {}).get("hybrid", {})
+                is_hybrid = collection_is_hybrid(client, coll_name)
+                if hybrid_cfg.get("enabled", False) and is_hybrid:
+                    response = _hybrid_query_collection(
+                        client, coll_name, query, query_vec, limit,
+                        prefetch_limit=hybrid_cfg.get("prefetch_limit", 40),
+                        bm25_model=hybrid_cfg.get("bm25_model", "Qdrant/bm25"),
+                        query_filter=ff)
+                elif is_hybrid:
+                    response = client.query_points(
+                        collection_name=coll_name, query=query_vec, using=DENSE_VECTOR_NAME,
+                        limit=limit, with_payload=True, query_filter=ff)
+                else:
+                    response = client.query_points(
+                        collection_name=coll_name, query=query_vec,
+                        limit=limit, with_payload=True, query_filter=ff)
+                for r in response.points:
+                    payload = r.payload or {}
+                    coll_results.append({
+                        "score": r.score,
+                        "source": payload.get("file_path", payload.get("slug", "")),
+                        "excerpt": payload.get("text", ""), "type": "text",
+                        "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page"),
+                        "section_heading": payload.get("section_heading", "")})
+            per_collection.append(coll_results)
+        except Exception as e:
+            err_str = str(e).lower()
+            if "404" in err_str or "not found" in err_str or "doesn't exist" in err_str:
+                continue
+            if any(kw in err_str for kw in ("connection refused", "connection error",
+                                            "network", "timeout", "unreachable")):
+                raise RuntimeError(
+                    f"Cannot reach Qdrant — is it running? "
+                    f"Start it with: carta doctor --fix\n(Detail: {e})") from e
+            continue
+
+    # RRF fuse across lanes; visual_max_ratio=1.0 disables the cap (we WANT the file's pages).
+    fused = _rrf_merge_collections(per_collection, limit, visual_max_ratio=1.0)
+    # embed_cfg threaded so render_page_png honors a custom colpali_sidecar_path.
+    fused = _attach_page_images(fused, repo_root / source, repo_root, cfg.get("embed", {}))
+    return fused[:limit]
+
+
+def run_focus(source: str, cfg: dict, *, query: str = "",
+              limit: int = _FOCUS_DEFAULT_LIMIT) -> list[dict]:
+    """Deep, file-scoped retrieval over a single source file.
+
+    Modes:
+      - query == "" : outline — the file's distinct (section_heading, page) rows in page order.
+      - query set   : deep — up to `limit` page-anchored passages from the file (dedup off,
+                      no graph expansion, visual cap off); visual hits carry image_b64.
+
+    Returns list of dicts: {score, source, page, section_heading, excerpt, type, doc_type, image_b64?}.
+    Fail-open: an unknown/never-embedded file yields []. Raises RuntimeError only on Qdrant transport failure.
+    """
+    from carta.search.scoped import get_search_collections
+
+    source = _normalize_source(source)
+    repo_root = Path(find_config()).parent.parent
+    try:
+        client = QdrantClient(url=cfg["qdrant_url"], timeout=10)
+    except Exception as e:
+        raise RuntimeError(f"Cannot connect to Qdrant: {e}") from e
+
+    try:
+        collections = get_search_collections(cfg, "repo")
+    except ValueError:
+        collections = [collection_name(cfg, "doc")]
+        if cfg.get("embed", {}).get("colpali_enabled", None) is not False:
+            collections.append(f"{cfg['project_name']}_visual")
+
+    ff = _file_filter(source)
+    for coll in collections:
+        _ensure_file_path_index(client, coll)
+
+    if not query:
+        return _focus_outline(client, collections, ff, source)
+    return _focus_deep(client, collections, ff, query, cfg, repo_root, source, limit)
+
+
 def _dedupe_by_source(results: list[dict]) -> list[dict]:
     """Keep the first (best-ranked) occurrence of each distinct ``source``, drop the rest.
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1714,6 +1714,44 @@ def _ensure_file_path_index(client, coll_name: str) -> None:
         pass
 
 
+_FOCUS_RENDER_DPI = 150  # page-image resolution for focus visual hits
+
+
+def render_page_png(abs_file_path: Path, page: int, repo_root: Path) -> bytes | None:
+    """Return PNG bytes for a 1-indexed PDF page, or None if it can't be produced.
+
+    Fast path: a ColPali cache PNG at .carta/visual_cache/<stem>/page_NNNN.png.
+    Fallback: render on demand with PyMuPDF. Non-PDF, out-of-range page, or any
+    failure returns None so the caller degrades to anchors-only for that hit.
+    """
+    try:
+        if abs_file_path.suffix.lower() != ".pdf":
+            return None
+        cached = (repo_root / ".carta" / "visual_cache" /
+                  abs_file_path.stem / f"page_{page:04d}.png")
+        if cached.is_file():
+            return cached.read_bytes()
+        import fitz  # PyMuPDF, imported lazily
+        with fitz.open(str(abs_file_path)) as doc:
+            if page < 1 or page > len(doc):
+                return None
+            pix = doc[page - 1].get_pixmap(dpi=_FOCUS_RENDER_DPI)
+            return pix.tobytes("png")
+    except Exception:
+        return None
+
+
+def _attach_page_images(hits: list[dict], abs_source_path: Path, repo_root: Path) -> list[dict]:
+    """Attach a base64 page PNG to each visual hit that has a page number. Mutates + returns hits."""
+    import base64
+    for hit in hits:
+        if hit.get("type") == "visual" and hit.get("page"):
+            png = render_page_png(abs_source_path, hit["page"], repo_root)
+            if png is not None:
+                hit["image_b64"] = base64.b64encode(png).decode("ascii")
+    return hits
+
+
 def _dedupe_by_source(results: list[dict]) -> list[dict]:
     """Keep the first (best-ranked) occurrence of each distinct ``source``, drop the rest.
 

--- a/carta/embed/pipeline.py
+++ b/carta/embed/pipeline.py
@@ -1757,6 +1757,39 @@ def _attach_page_images(hits: list[dict], abs_source_path: Path, repo_root: Path
     return hits
 
 
+def _focus_outline(client, collections: list[str], ff: Filter, source: str) -> list[dict]:
+    """Return the file's distinct (section_heading, page) rows in page order — a synthetic TOC.
+
+    Scrolls text-collection payloads only (no embedding); pages with no number sort last.
+    """
+    seen: set = set()
+    rows: list[tuple] = []
+    for coll in collections:
+        if coll.endswith("_visual"):
+            continue
+        try:
+            points, _ = client.scroll(
+                collection_name=coll, scroll_filter=ff,
+                with_payload=True, limit=10_000,
+            )
+        except Exception:
+            continue
+        for p in points:
+            payload = p.payload or {}
+            page = payload.get("page")
+            heading = payload.get("section_heading", "")
+            key = (page, heading)
+            if key in seen:
+                continue
+            seen.add(key)
+            sort_page = page if isinstance(page, int) else 1_000_000
+            rows.append((sort_page, page, heading))
+    rows.sort(key=lambda r: r[0])
+    return [{"score": 0.0, "source": source, "page": page,
+             "section_heading": heading, "excerpt": "", "type": "outline",
+             "doc_type": ""} for _sort, page, heading in rows]
+
+
 def _dedupe_by_source(results: list[dict]) -> list[dict]:
     """Keep the first (best-ranked) occurrence of each distinct ``source``, drop the rest.
 

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -174,7 +174,7 @@ def carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict] | d
     for r in results:
         item = {
             "score": round(r.get("score", 0.0), 4),
-            "source": r["source"],
+            "source": r.get("source", ""),
             "page": r.get("page"),
             "section_heading": r.get("section_heading", ""),
             "excerpt": (r.get("excerpt") or "")[:300],

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -16,7 +16,7 @@ from mcp.server.fastmcp import FastMCP
 from typing import Literal, Optional, Union
 
 from carta.config import find_config, load_config, ConfigError
-from carta.embed.pipeline import run_search, run_embed_file, discover_stale_files, run_embed, FILE_TIMEOUT_S
+from carta.embed.pipeline import run_search, run_focus, run_embed_file, discover_stale_files, run_embed, FILE_TIMEOUT_S
 from carta.embed.lock import embed_lock, EmbedLockHeld
 from carta.scanner.scanner import check_embed_induction_needed, check_embed_drift
 from carta.search.scoped import get_search_collections
@@ -136,6 +136,57 @@ def carta_search(
         formatted.append(result)
     
     return formatted
+
+
+def carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict] | dict:
+    """Go deep in ONE already-located file: page-anchored passages, an outline, and
+    table/figure pages returned as images.
+
+    Use AFTER carta_search has identified the relevant file — pass that result's `source`
+    string here. With an EMPTY query, returns the file's section/page outline (a synthetic
+    table of contents) so you can choose where to read.
+
+    Args:
+        source: Repo-relative file path (the `source` from a carta_search result; a
+                trailing " (page N)" from a visual result is fine — it is stripped).
+        query: Natural-language query. Empty string => outline mode.
+        top_k: Maximum passages to return (default 15).
+
+    Returns:
+        List of dicts: {score, source, page, section_heading, excerpt, type, image_b64?}.
+        `image_b64` is present on visual (table/figure) hits. On failure:
+        {"error": "<type>", "detail": "<message>"}.
+    """
+    try:
+        cfg = _load_cfg()
+    except (ConfigError, FileNotFoundError) as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+
+    try:
+        results = run_focus(source, cfg, query=query, limit=top_k)
+    except RuntimeError as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+    except Exception as e:
+        _logger.warning("carta_focus unexpected error: %s", e)
+        return {"error": "service_unavailable", "detail": str(e)}
+
+    formatted = []
+    for r in results:
+        item = {
+            "score": round(r.get("score", 0.0), 4),
+            "source": r["source"],
+            "page": r.get("page"),
+            "section_heading": r.get("section_heading", ""),
+            "excerpt": (r.get("excerpt") or "")[:300],
+            "type": r.get("type", "text"),
+        }
+        if r.get("image_b64"):
+            item["image_b64"] = r["image_b64"]
+        formatted.append(item)
+    return formatted
+
+
+mcp_server.add_tool(carta_focus)
 
 
 def _run_search_collection(query: str, cfg: dict, collection_name: str, top_n: int) -> list[dict]:

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -186,6 +186,12 @@ def carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict] | d
     return formatted
 
 
+# Registered via add_tool() rather than the @mcp_server.tool() decorator the sibling
+# tools use. This is registration-equivalent (FastMCP's tool() decorator just calls
+# add_tool(fn) then returns fn), but it keeps carta_focus a plain, callable function in
+# this module's namespace. The test suite mocks out mcp.server.fastmcp, so the decorator
+# would replace carta_focus with a MagicMock and make it un-unit-testable. Do not "fix"
+# this back to the decorator without first making the carta_focus tests patch the mock.
 mcp_server.add_tool(carta_focus)
 
 

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -932,3 +932,42 @@ def test_cmd_embed_exits_nonzero_on_failed_or_partial(tmp_path):
         with pytest.raises(SystemExit) as exc:
             cli.cmd_embed(args)
     assert exc.value.code == 1
+
+
+class TestCmdFocus:
+    def _cfg(self, tmp_path):
+        return {"modules": {"doc_search": True}, "project_name": "p",
+                "qdrant_url": "http://localhost:6333", "embed": {}}
+
+    def test_outline_mode_prints_sections(self, tmp_path, capsys):
+        import argparse
+        from unittest.mock import patch
+        from carta import cli
+        outline = [{"score": 0.0, "source": "imu.pdf", "page": 1,
+                    "section_heading": "Cover", "excerpt": "", "type": "outline"}]
+        args = argparse.Namespace(source="imu.pdf", query=[], limit=15)
+        with patch("carta.cli.find_config", return_value=tmp_path / ".carta" / "config.yaml"), \
+             patch("carta.config.load_config", return_value=self._cfg(tmp_path)), \
+             patch("carta.embed.pipeline.run_focus", return_value=outline):
+            cli.cmd_focus(args)
+        out = capsys.readouterr().out
+        assert "Outline of imu.pdf" in out and "Cover" in out
+
+    def test_deep_mode_writes_image_and_prints_path(self, tmp_path, capsys):
+        import argparse, base64
+        from unittest.mock import patch
+        from carta import cli
+        (tmp_path / ".carta").mkdir()
+        hits = [{"score": 0.9, "source": "imu.pdf", "page": 47,
+                 "section_heading": "Gyro", "excerpt": "regs",
+                 "type": "visual", "image_b64": base64.b64encode(b"PNG").decode()}]
+        args = argparse.Namespace(source="imu.pdf", query=["gyro", "regs"], limit=15)
+        with patch("carta.cli.find_config", return_value=tmp_path / ".carta" / "config.yaml"), \
+             patch("carta.config.load_config", return_value=self._cfg(tmp_path)), \
+             patch("carta.embed.pipeline.run_focus", return_value=hits):
+            cli.cmd_focus(args)
+        out = capsys.readouterr().out
+        assert "p.47" in out and "Gyro" in out
+        img = tmp_path / ".carta" / "cache" / "focus" / "imu-p47.png"
+        assert img.is_file() and img.read_bytes() == b"PNG"
+        assert str(img) in out

--- a/carta/tests/test_mcp_server.py
+++ b/carta/tests/test_mcp_server.py
@@ -141,3 +141,35 @@ def test_remember_no_config_maps_to_service_unavailable():
     with patch.object(server, "_load_cfg", side_effect=ConfigError("no .carta")):
         out = server._remember("x")
     assert out["error"] == "service_unavailable"
+
+
+class TestCartaFocus:
+    def test_formats_results_and_passes_through_image(self):
+        from unittest.mock import patch
+        import carta.mcp.server as server
+
+        fake = [
+            {"score": 0.876543, "source": "docs/imu.pdf", "page": 47,
+             "section_heading": "6.3 Gyro", "excerpt": "x" * 400, "type": "text"},
+            {"score": 0.5, "source": "docs/imu.pdf (page 47)", "page": 47,
+             "section_heading": "", "excerpt": "[Visual]", "type": "visual",
+             "image_b64": "QkFTRTY0"},
+        ]
+        with patch.object(server, "_load_cfg", return_value={"x": 1}), \
+             patch.object(server, "run_focus", return_value=fake) as mock_focus:
+            out = server.carta_focus(source="docs/imu.pdf (page 47)", query="sensitivity", top_k=15)
+
+        mock_focus.assert_called_once_with("docs/imu.pdf (page 47)", {"x": 1},
+                                           query="sensitivity", limit=15)
+        assert out[0]["score"] == 0.8765          # rounded to 4dp
+        assert out[0]["page"] == 47
+        assert len(out[0]["excerpt"]) == 300       # truncated
+        assert out[1]["image_b64"] == "QkFTRTY0"   # passed through on visual hits
+
+    def test_returns_error_dict_on_config_failure(self):
+        from unittest.mock import patch
+        import carta.mcp.server as server
+        from carta.config import ConfigError
+        with patch.object(server, "_load_cfg", side_effect=ConfigError("no config")):
+            out = server.carta_focus(source="x.pdf")
+        assert out["error"] == "service_unavailable"

--- a/carta/tests/test_mcp_server.py
+++ b/carta/tests/test_mcp_server.py
@@ -173,3 +173,13 @@ class TestCartaFocus:
         with patch.object(server, "_load_cfg", side_effect=ConfigError("no config")):
             out = server.carta_focus(source="x.pdf")
         assert out["error"] == "service_unavailable"
+        assert "detail" in out and out["detail"]
+
+    def test_returns_error_dict_on_runtime_error(self):
+        from unittest.mock import patch
+        import carta.mcp.server as server
+        with patch.object(server, "_load_cfg", return_value={}), \
+             patch.object(server, "run_focus", side_effect=RuntimeError("Qdrant down")):
+            out = server.carta_focus(source="x.pdf")
+        assert out["error"] == "service_unavailable"
+        assert "Qdrant down" in out["detail"]

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1265,3 +1265,27 @@ class TestHybridQueryFilter:
         kwargs = client.query_points.call_args.kwargs
         prefetches = kwargs["prefetch"]
         assert all(p.filter is ff for p in prefetches), "filter must reach every prefetch lane"
+
+
+class TestFocusSourceHelpers:
+    def test_normalize_strips_visual_page_suffix(self):
+        from carta.embed.pipeline import _normalize_source
+        assert _normalize_source("docs/imu.pdf (page 12)") == "docs/imu.pdf"
+        assert _normalize_source("docs/imu.pdf") == "docs/imu.pdf"
+        assert _normalize_source("  a/b.md  ") == "a/b.md"
+
+    def test_file_filter_matches_file_path(self):
+        from carta.embed.pipeline import _file_filter
+        ff = _file_filter("docs/imu.pdf")
+        cond = ff.must[0]
+        assert cond.key == "file_path"
+        assert cond.match.value == "docs/imu.pdf"
+
+    def test_ensure_index_swallows_errors(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _ensure_file_path_index
+        client = MagicMock()
+        client.create_payload_index.side_effect = Exception("already exists")
+        # Must not raise.
+        _ensure_file_path_index(client, "test-project_doc")
+        client.create_payload_index.assert_called_once()

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1445,3 +1445,35 @@ class TestRunFocus:
         assert [r["type"] for r in results] == ["outline", "outline"]
         assert [r["page"] for r in results] == [1, 2]
         mock_embed.assert_not_called()  # outline does no embedding
+
+    def test_visual_lane_failure_degrades_to_text(self):
+        """A broken ColPali/visual lane must not fail the focus query — text results still return."""
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_focus
+
+        text_point = MagicMock(); text_point.score = 0.9
+        text_point.payload = {"file_path": "docs/imu.pdf", "text": "gyro regs",
+                              "page": 5, "section_heading": "Regs", "doc_type": ""}
+        text_resp = MagicMock(); text_resp.points = [text_point]
+        client = MagicMock(); client.query_points.return_value = text_resp
+
+        cfg = dict(self.BASE_CFG)
+        cfg["embed"] = {**self.BASE_CFG["embed"], "colpali_enabled": True}
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.embed.pipeline._ensure_file_path_index"), \
+             patch("carta.embed.pipeline._visual_collection_ready", return_value=True), \
+             patch("carta.embed.colpali.is_colpali_available", return_value=True), \
+             patch("carta.embed.colpali.ColPaliEmbedder",
+                   side_effect=Exception("colpali model load failed: timeout")), \
+             patch("carta.search.scoped.get_search_collections",
+                   return_value=["test-project_doc", "test-project_visual"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_focus("docs/imu.pdf", cfg, query="gyro")
+
+        # Visual lane raised with a 'timeout' message that WOULD trip the transport-error
+        # branch if it reached the outer handler. Focus must instead degrade to text.
+        assert [r["source"] for r in results] == ["docs/imu.pdf"]
+        assert results[0]["page"] == 5

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1289,3 +1289,43 @@ class TestFocusSourceHelpers:
         # Must not raise.
         _ensure_file_path_index(client, "test-project_doc")
         client.create_payload_index.assert_called_once()
+
+
+class TestRenderPageImages:
+    def test_non_pdf_returns_none(self, tmp_path):
+        from carta.embed.pipeline import render_page_png
+        md = tmp_path / "a.md"; md.write_text("hello")
+        assert render_page_png(md, 1, tmp_path) is None
+
+    def test_cache_hit_returns_cached_bytes(self, tmp_path):
+        from carta.embed.pipeline import render_page_png
+        pdf = tmp_path / "imu.pdf"; pdf.write_bytes(b"%PDF-1.4 fake")
+        cache = tmp_path / ".carta" / "visual_cache" / "imu"
+        cache.mkdir(parents=True)
+        (cache / "page_0007.png").write_bytes(b"CACHEDPNG")
+        assert render_page_png(pdf, 7, tmp_path) == b"CACHEDPNG"
+
+    def test_real_render_and_out_of_range(self, tmp_path):
+        import fitz
+        from carta.embed.pipeline import render_page_png
+        pdf = tmp_path / "doc.pdf"
+        doc = fitz.open()
+        doc.new_page(); doc.new_page()
+        doc.save(str(pdf)); doc.close()
+        png = render_page_png(pdf, 1, tmp_path)
+        assert png is not None and png[:8] == b"\x89PNG\r\n\x1a\n"
+        assert render_page_png(pdf, 99, tmp_path) is None  # out of range
+
+    def test_attach_images_only_to_visual_hits(self, tmp_path):
+        from unittest.mock import patch
+        from carta.embed.pipeline import _attach_page_images
+        hits = [
+            {"type": "text", "page": 3},
+            {"type": "visual", "page": 7},
+            {"type": "visual", "page": None},
+        ]
+        with patch("carta.embed.pipeline.render_page_png", return_value=b"PNGBYTES"):
+            out = _attach_page_images(hits, tmp_path / "imu.pdf", tmp_path)
+        assert "image_b64" not in out[0]            # text untouched
+        assert out[1]["image_b64"]                  # visual w/ page rendered
+        assert "image_b64" not in out[2]            # visual w/o page skipped

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1369,3 +1369,20 @@ class TestFocusOutline:
         client = MagicMock(); client.scroll.return_value = ([], None)
         _focus_outline(client, ["test-project_visual"], _file_filter("imu.pdf"), "imu.pdf")
         client.scroll.assert_not_called()  # visual collections are skipped
+
+    def test_outline_raises_on_transport_failure(self):
+        import pytest
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+        client = MagicMock()
+        client.scroll.side_effect = Exception("Connection refused")
+        with pytest.raises(RuntimeError, match="Qdrant"):
+            _focus_outline(client, ["test-project_doc"], _file_filter("imu.pdf"), "imu.pdf")
+
+    def test_outline_swallows_collection_not_found(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+        client = MagicMock()
+        client.scroll.side_effect = Exception("Collection not found: status_code=404")
+        rows = _focus_outline(client, ["test-project_doc"], _file_filter("imu.pdf"), "imu.pdf")
+        assert rows == []  # 404 is swallowed → empty outline, no raise

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1242,3 +1242,26 @@ def test_run_search_passes_repo_root_not_dotcarta_to_graph_expansion(tmp_path):
         pipeline.run_search("q", cfg)
 
     assert captured["repo_root"] == tmp_path  # repo root, NOT tmp_path/.carta
+
+
+class TestHybridQueryFilter:
+    """_hybrid_query_collection threads an optional Qdrant filter into each prefetch lane."""
+
+    def test_query_filter_applied_to_prefetch(self):
+        from unittest.mock import MagicMock, patch
+        from carta.embed.pipeline import _hybrid_query_collection
+        from qdrant_client.models import Filter, FieldCondition, MatchValue
+
+        client = MagicMock()
+        client.query_points.return_value = MagicMock(points=[])
+        ff = Filter(must=[FieldCondition(key="file_path", match=MatchValue(value="a.pdf"))])
+
+        with patch("carta.embed.pipeline.embed_sparse_query",
+                   return_value=MagicMock(indices=[1], values=[1.0])):
+            _hybrid_query_collection(client, "c", "q", [0.0] * 768, 10,
+                                     prefetch_limit=40, bm25_model="Qdrant/bm25",
+                                     query_filter=ff)
+
+        kwargs = client.query_points.call_args.kwargs
+        prefetches = kwargs["prefetch"]
+        assert all(p.filter is ff for p in prefetches), "filter must reach every prefetch lane"

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1386,3 +1386,62 @@ class TestFocusOutline:
         client.scroll.side_effect = Exception("Collection not found: status_code=404")
         rows = _focus_outline(client, ["test-project_doc"], _file_filter("imu.pdf"), "imu.pdf")
         assert rows == []  # 404 is swallowed → empty outline, no raise
+
+
+class TestRunFocus:
+    BASE_CFG = {
+        "project_name": "test-project",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://localhost:11434",
+                  "ollama_model": "nomic-embed-text", "colpali_enabled": False},
+        "search": {"top_n": 5},
+        "modules": {"doc_search": True},
+    }
+
+    def test_deep_filters_to_file_and_keeps_all_chunks(self):
+        """Deep mode applies the file filter and does NOT dedup (multiple chunks, one source)."""
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_focus
+
+        def mk(page):
+            p = MagicMock(); p.score = 1.0 / page
+            p.payload = {"file_path": "docs/imu.pdf", "text": f"chunk p{page}",
+                         "page": page, "section_heading": f"S{page}", "doc_type": ""}
+            return p
+        resp = MagicMock(); resp.points = [mk(10), mk(11), mk(12)]
+        client = MagicMock(); client.query_points.return_value = resp
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.embed.pipeline._ensure_file_path_index"), \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_focus("docs/imu.pdf (page 10)", self.BASE_CFG, query="sensitivity")
+
+        # All three chunks of the one file survive (dedup is off in focus).
+        assert len(results) == 3
+        assert {r["page"] for r in results} == {10, 11, 12}
+        assert all(r["source"] == "docs/imu.pdf" for r in results)
+        # Filter reached Qdrant (normalized — no '(page 10)' suffix).
+        ff = client.query_points.call_args.kwargs["query_filter"]
+        assert ff.must[0].match.value == "docs/imu.pdf"
+
+    def test_empty_query_returns_outline(self):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_focus
+
+        def mk(page, heading):
+            p = MagicMock(); p.payload = {"page": page, "section_heading": heading}; return p
+        client = MagicMock(); client.scroll.return_value = ([mk(1, "Cover"), mk(2, "Setup")], None)
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=client), \
+             patch("carta.embed.pipeline._ensure_file_path_index"), \
+             patch("carta.embed.pipeline.get_embedding") as mock_embed, \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_focus("docs/imu.pdf", self.BASE_CFG)  # no query
+
+        assert [r["type"] for r in results] == ["outline", "outline"]
+        assert [r["page"] for r in results] == [1, 2]
+        mock_embed.assert_not_called()  # outline does no embedding

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1340,3 +1340,32 @@ class TestRenderPageImages:
         assert render_page_png(pdf, 3, tmp_path,
                                {"colpali_sidecar_path": "custom_cache/"}) == b"CUSTOMPNG"
         assert render_page_png(pdf, 3, tmp_path) is None  # default path: no cache, fake PDF -> None
+
+
+class TestFocusOutline:
+    def test_outline_returns_distinct_sections_in_page_order(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+
+        def mk(page, heading):
+            p = MagicMock(); p.payload = {"page": page, "section_heading": heading}; return p
+
+        client = MagicMock()
+        # Unordered, with a duplicate (3,"Intro") that must collapse.
+        client.scroll.return_value = (
+            [mk(3, "Intro"), mk(1, "Cover"), mk(3, "Intro"), mk(2, "Setup")], None)
+
+        rows = _focus_outline(client, ["test-project_doc"], _file_filter("imu.pdf"), "imu.pdf")
+
+        assert [(r["page"], r["section_heading"]) for r in rows] == [
+            (1, "Cover"), (2, "Setup"), (3, "Intro")]
+        assert all(r["type"] == "outline" and r["source"] == "imu.pdf" for r in rows)
+        # Outline must not embed anything — it scrolls payloads only.
+        client.scroll.assert_called_once()
+
+    def test_outline_skips_visual_collections(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+        client = MagicMock(); client.scroll.return_value = ([], None)
+        _focus_outline(client, ["test-project_visual"], _file_filter("imu.pdf"), "imu.pdf")
+        client.scroll.assert_not_called()  # visual collections are skipped

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -611,6 +611,39 @@ class TestRunSearch:
 
         assert results == []
 
+    def test_results_carry_page_and_section_anchors(self):
+        """run_search surfaces page + section_heading from the payload on each hit."""
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_search
+
+        cfg = {
+            "project_name": "test-project",
+            "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://localhost:11434",
+                      "ollama_model": "nomic-embed-text", "colpali_enabled": False},
+            "search": {"top_n": 5},
+            "modules": {"doc_search": True},
+        }
+
+        point = MagicMock()
+        point.score = 0.91
+        point.payload = {"file_path": "docs/imu.pdf", "text": "sensitivity register",
+                         "page": 47, "section_heading": "6.3 Gyro Config", "doc_type": ""}
+        resp = MagicMock(); resp.points = [point]
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = resp
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=mock_client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_search("imu sensitivity", cfg)
+
+        assert results, "expected at least one hit"
+        assert results[0]["page"] == 47
+        assert results[0]["section_heading"] == "6.3 Gyro Config"
+
 
 class TestVisionProgressWiring:
     """Verify _vision_callback is passed and _vision_events are handled correctly."""

--- a/carta/tests/test_pipeline.py
+++ b/carta/tests/test_pipeline.py
@@ -1329,3 +1329,14 @@ class TestRenderPageImages:
         assert "image_b64" not in out[0]            # text untouched
         assert out[1]["image_b64"]                  # visual w/ page rendered
         assert "image_b64" not in out[2]            # visual w/o page skipped
+
+    def test_cache_hit_honors_custom_sidecar_path(self, tmp_path):
+        from carta.embed.pipeline import render_page_png
+        pdf = tmp_path / "imu.pdf"; pdf.write_bytes(b"%PDF-1.4 fake")
+        cache = tmp_path / "custom_cache" / "imu"
+        cache.mkdir(parents=True)
+        (cache / "page_0003.png").write_bytes(b"CUSTOMPNG")
+        # Default path would miss; the configured path must hit.
+        assert render_page_png(pdf, 3, tmp_path,
+                               {"colpali_sidecar_path": "custom_cache/"}) == b"CUSTOMPNG"
+        assert render_page_png(pdf, 3, tmp_path) is None  # default path: no cache, fake PDF -> None

--- a/docs/superpowers/plans/2026-06-18-carta-focus.md
+++ b/docs/superpowers/plans/2026-06-18-carta-focus.md
@@ -1,0 +1,1078 @@
+# Carta Focus (file-scoped retrieval) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `carta focus` (CLI) + `carta_focus` (MCP) capability that goes deep in one already-located file — page-anchored passages, an outline mode, and table/figure pages returned as images — plus surface `page`/`section_heading` on every search result.
+
+**Architecture:** A new `run_focus` engine in `carta/embed/pipeline.py` reuses the existing per-collection query helpers (`_hybrid_query_collection`, `_rrf_merge_collections`, `_visual_collection_ready`) but scopes every Qdrant call with a `file_path` payload filter, forces dedup off, disables the visual cap, and attaches a rendered page PNG to visual hits. Two surfaces wrap it: a `carta_focus` MCP tool (base64 images inline) and a `carta focus` CLI subcommand (writes PNGs to cache, prints paths). A small shared change surfaces `page`/`section_heading`, already in the Qdrant payload, on all search results.
+
+**Tech Stack:** Python 3.10+, qdrant-client (`query_points`/`scroll`/`create_payload_index`, `models.Filter`), PyMuPDF (`fitz`) for page rendering, pytest + unittest.mock for tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-carta-focus-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `carta/embed/pipeline.py` — add `page`/`section_heading` to `run_search` result builders; add `query_filter` param to `_hybrid_query_collection`; add new helpers `_normalize_source`, `_file_filter`, `_ensure_file_path_index`, `render_page_png`, `_attach_page_images`, `_focus_outline`, `_focus_deep`, and the public `run_focus`. Module constant `_FOCUS_DEFAULT_LIMIT = 15`.
+- **Modify** `carta/mcp/server.py` — import `run_focus`; add `carta_focus` tool.
+- **Modify** `carta/cli.py` — add `cmd_focus`, the `focus` subparser, and the dispatch entry.
+- **Modify** `carta/tests/test_pipeline.py` — unit/integration tests for all new pipeline functions.
+- **Modify** `carta/tests/test_mcp_server.py` — test for `carta_focus`.
+- **Modify** `carta/tests/test_cli.py` — test for `cmd_focus`.
+- **Modify** `CLAUDE.md`, `README.md`, `AGENTS.md` — document the new surface.
+
+> Conventions verified in-repo: text chunks store `page` + `section_heading` in the Qdrant payload (`carta/embed/parse.py:204` → `carta/embed/embed.py:256`). `run_search` currently drops them (`pipeline.py:1930-1938`). The MCP `carta_search` bypasses `run_search` with its own logic — **`carta_focus` deliberately calls the real `run_focus` instead.** qdrant-client filter param names differ by call: `query_points(..., query_filter=...)`, `scroll(..., scroll_filter=...)`, `Prefetch(..., filter=...)`.
+
+---
+
+## Phase 1 — Anchor surfacing (shared foundation)
+
+### Task 1: Surface `page` + `section_heading` on every search result
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (text builder ~1930-1938; visual builder ~1881-1889)
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `carta/tests/test_pipeline.py`, in the `TestRunSearch` class:
+
+```python
+    def test_results_carry_page_and_section_anchors(self):
+        """run_search surfaces page + section_heading from the payload on each hit."""
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_search
+
+        cfg = {
+            "project_name": "test-project",
+            "qdrant_url": "http://localhost:6333",
+            "embed": {"ollama_url": "http://localhost:11434",
+                      "ollama_model": "nomic-embed-text", "colpali_enabled": False},
+            "search": {"top_n": 5},
+            "modules": {"doc_search": True},
+        }
+
+        point = MagicMock()
+        point.score = 0.91
+        point.payload = {"file_path": "docs/imu.pdf", "text": "sensitivity register",
+                         "page": 47, "section_heading": "6.3 Gyro Config", "doc_type": ""}
+        resp = MagicMock(); resp.points = [point]
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = resp
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=mock_client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_search("imu sensitivity", cfg)
+
+        assert results, "expected at least one hit"
+        assert results[0]["page"] == 47
+        assert results[0]["section_heading"] == "6.3 Gyro Config"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRunSearch::test_results_carry_page_and_section_anchors -v`
+Expected: FAIL — `KeyError: 'page'` (run_search does not yet surface it).
+
+- [ ] **Step 3: Add the keys to both result builders**
+
+In `carta/embed/pipeline.py`, the **text** builder (~1932-1938) becomes:
+
+```python
+                for r in response.points:
+                    payload = r.payload or {}
+                    coll_results.append({
+                        "score": r.score,
+                        "source": payload.get("file_path", payload.get("slug", "")),
+                        "excerpt": payload.get("text", ""),
+                        "type": "text",
+                        "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page"),
+                        "section_heading": payload.get("section_heading", ""),
+                    })
+```
+
+The **visual** builder (~1883-1889) becomes:
+
+```python
+                    for r in response.points:
+                        payload = r.payload or {}
+                        coll_results.append({
+                            "score": r.score,
+                            "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
+                            "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
+                            "type": "visual",
+                            "doc_type": payload.get("doc_type", ""),
+                            "page": payload.get("page_num"),
+                            "section_heading": "",
+                        })
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRunSearch -v`
+Expected: PASS (new test green, existing `TestRunSearch` tests still green).
+
+- [ ] **Step 5: Verify no consumer breaks on the new keys**
+
+Run: `python -m pytest carta/tests/test_pipeline.py carta/tests/test_cli.py carta/tests/test_mcp_server.py -q`
+Expected: PASS. (Consumers read results by key; added keys are inert. If any test asserts exact dict equality on a result, update it to include the new keys.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): surface page + section_heading on all search results"
+```
+
+---
+
+## Phase 2 — Focus engine
+
+### Task 2: Add a `query_filter` parameter to `_hybrid_query_collection`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py:1610-1636`
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new class to `carta/tests/test_pipeline.py`:
+
+```python
+class TestHybridQueryFilter:
+    """_hybrid_query_collection threads an optional Qdrant filter into each prefetch lane."""
+
+    def test_query_filter_applied_to_prefetch(self):
+        from unittest.mock import MagicMock, patch
+        from carta.embed.pipeline import _hybrid_query_collection
+        from qdrant_client.models import Filter, FieldCondition, MatchValue
+
+        client = MagicMock()
+        client.query_points.return_value = MagicMock(points=[])
+        ff = Filter(must=[FieldCondition(key="file_path", match=MatchValue(value="a.pdf"))])
+
+        with patch("carta.embed.pipeline.embed_sparse_query",
+                   return_value=MagicMock(indices=[1], values=[1.0])):
+            _hybrid_query_collection(client, "c", "q", [0.0] * 768, 10,
+                                     prefetch_limit=40, bm25_model="Qdrant/bm25",
+                                     query_filter=ff)
+
+        kwargs = client.query_points.call_args.kwargs
+        prefetches = kwargs["prefetch"]
+        assert all(p.filter is ff for p in prefetches), "filter must reach every prefetch lane"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestHybridQueryFilter -v`
+Expected: FAIL — `TypeError: _hybrid_query_collection() got an unexpected keyword argument 'query_filter'`.
+
+- [ ] **Step 3: Add the parameter**
+
+Replace `_hybrid_query_collection` (`pipeline.py:1610-1636`) with:
+
+```python
+def _hybrid_query_collection(client, coll_name, query, dense_vec, top_n,
+                              prefetch_limit, bm25_model, query_filter=None):
+    """Run a hybrid BM25+dense query with Qdrant RRF fusion.
+
+    Fetches `prefetch_limit` candidates from each of the dense and sparse
+    indexes, then fuses them with Reciprocal Rank Fusion and returns the
+    top `top_n` results.
+
+    `top_n` controls the Qdrant fusion `limit` (i.e. how many fused results
+    to return).  When reranking is enabled, callers should pass `fetch_limit`
+    (= candidate_pool) here so that the reranker has a wide enough pool to
+    promote lower-ranked relevant documents.
+
+    `query_filter` (optional) is applied to BOTH prefetch lanes so the filter
+    takes effect before fusion (used by run_focus to scope to one file).
+    """
+    sv = embed_sparse_query(query, model_name=bm25_model)
+    return client.query_points(
+        collection_name=coll_name,
+        prefetch=[
+            qmodels.Prefetch(query=dense_vec, using=DENSE_VECTOR_NAME,
+                             limit=prefetch_limit, filter=query_filter),
+            qmodels.Prefetch(
+                query=qmodels.SparseVector(indices=sv.indices, values=sv.values),
+                using=SPARSE_VECTOR_NAME, limit=prefetch_limit, filter=query_filter,
+            ),
+        ],
+        query=qmodels.FusionQuery(fusion=qmodels.Fusion.RRF),
+        limit=top_n,
+        with_payload=True,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestHybridQueryFilter -v`
+Expected: PASS. (Default `query_filter=None` keeps every existing caller unchanged.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): thread optional query_filter through _hybrid_query_collection"
+```
+
+---
+
+### Task 3: Source helpers — `_normalize_source`, `_file_filter`, `_ensure_file_path_index`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (add near the other search helpers, after `_apply_visual_cap`)
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestFocusSourceHelpers:
+    def test_normalize_strips_visual_page_suffix(self):
+        from carta.embed.pipeline import _normalize_source
+        assert _normalize_source("docs/imu.pdf (page 12)") == "docs/imu.pdf"
+        assert _normalize_source("docs/imu.pdf") == "docs/imu.pdf"
+        assert _normalize_source("  a/b.md  ") == "a/b.md"
+
+    def test_file_filter_matches_file_path(self):
+        from carta.embed.pipeline import _file_filter
+        ff = _file_filter("docs/imu.pdf")
+        cond = ff.must[0]
+        assert cond.key == "file_path"
+        assert cond.match.value == "docs/imu.pdf"
+
+    def test_ensure_index_swallows_errors(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _ensure_file_path_index
+        client = MagicMock()
+        client.create_payload_index.side_effect = Exception("already exists")
+        # Must not raise.
+        _ensure_file_path_index(client, "test-project_doc")
+        client.create_payload_index.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestFocusSourceHelpers -v`
+Expected: FAIL — `ImportError: cannot import name '_normalize_source'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `carta/embed/pipeline.py` (after `_apply_visual_cap`, ~line 1681). Note `re`, `Filter`, and `qmodels` are already imported at the top of the module:
+
+```python
+_FOCUS_DEFAULT_LIMIT = 15  # passages returned by a deep focus query
+
+
+def _normalize_source(source: str) -> str:
+    """Strip a trailing ' (page N)' suffix (the visual-hit source form) to the bare file_path."""
+    return re.sub(r"\s*\(page\s+\S+\)\s*$", "", source).strip()
+
+
+def _file_filter(source: str) -> Filter:
+    """Qdrant filter matching points whose file_path payload equals `source`."""
+    return Filter(must=[qmodels.FieldCondition(
+        key="file_path", match=qmodels.MatchValue(value=source))])
+
+
+def _ensure_file_path_index(client, coll_name: str) -> None:
+    """Idempotently create a keyword payload index on file_path to speed the focus filter.
+
+    Fail-open: an existing index, a missing collection, or an older server all just mean
+    the filter runs unindexed (correct, slower) — never an error to the caller.
+    """
+    try:
+        client.create_payload_index(
+            collection_name=coll_name,
+            field_name="file_path",
+            field_schema=qmodels.PayloadSchemaType.KEYWORD,
+        )
+    except Exception:
+        pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestFocusSourceHelpers -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): add focus source helpers (normalize, file filter, payload index)"
+```
+
+---
+
+### Task 4: Page rendering — `render_page_png` + `_attach_page_images`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (add after the Task 3 helpers)
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestRenderPageImages:
+    def test_non_pdf_returns_none(self, tmp_path):
+        from carta.embed.pipeline import render_page_png
+        md = tmp_path / "a.md"; md.write_text("hello")
+        assert render_page_png(md, 1, tmp_path) is None
+
+    def test_cache_hit_returns_cached_bytes(self, tmp_path):
+        from carta.embed.pipeline import render_page_png
+        pdf = tmp_path / "imu.pdf"; pdf.write_bytes(b"%PDF-1.4 fake")
+        cache = tmp_path / ".carta" / "visual_cache" / "imu"
+        cache.mkdir(parents=True)
+        (cache / "page_0007.png").write_bytes(b"CACHEDPNG")
+        assert render_page_png(pdf, 7, tmp_path) == b"CACHEDPNG"
+
+    def test_real_render_and_out_of_range(self, tmp_path):
+        import fitz
+        from carta.embed.pipeline import render_page_png
+        pdf = tmp_path / "doc.pdf"
+        doc = fitz.open()
+        doc.new_page(); doc.new_page()
+        doc.save(str(pdf)); doc.close()
+        png = render_page_png(pdf, 1, tmp_path)
+        assert png is not None and png[:8] == b"\x89PNG\r\n\x1a\n"
+        assert render_page_png(pdf, 99, tmp_path) is None  # out of range
+
+    def test_attach_images_only_to_visual_hits(self, tmp_path):
+        from unittest.mock import patch
+        from carta.embed.pipeline import _attach_page_images
+        hits = [
+            {"type": "text", "page": 3},
+            {"type": "visual", "page": 7},
+            {"type": "visual", "page": None},
+        ]
+        with patch("carta.embed.pipeline.render_page_png", return_value=b"PNGBYTES"):
+            out = _attach_page_images(hits, tmp_path / "imu.pdf", tmp_path)
+        assert "image_b64" not in out[0]            # text untouched
+        assert out[1]["image_b64"]                  # visual w/ page rendered
+        assert "image_b64" not in out[2]            # visual w/o page skipped
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRenderPageImages -v`
+Expected: FAIL — `ImportError: cannot import name 'render_page_png'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `carta/embed/pipeline.py` after the Task 3 helpers:
+
+```python
+_FOCUS_RENDER_DPI = 150  # page-image resolution for focus visual hits
+
+
+def render_page_png(abs_file_path: Path, page: int, repo_root: Path) -> bytes | None:
+    """Return PNG bytes for a 1-indexed PDF page, or None if it can't be produced.
+
+    Fast path: a ColPali cache PNG at .carta/visual_cache/<stem>/page_NNNN.png.
+    Fallback: render on demand with PyMuPDF. Non-PDF, out-of-range page, or any
+    failure returns None so the caller degrades to anchors-only for that hit.
+    """
+    try:
+        if abs_file_path.suffix.lower() != ".pdf":
+            return None
+        cached = (repo_root / ".carta" / "visual_cache" /
+                  abs_file_path.stem / f"page_{page:04d}.png")
+        if cached.is_file():
+            return cached.read_bytes()
+        import fitz  # PyMuPDF, imported lazily
+        with fitz.open(str(abs_file_path)) as doc:
+            if page < 1 or page > len(doc):
+                return None
+            pix = doc[page - 1].get_pixmap(dpi=_FOCUS_RENDER_DPI)
+            return pix.tobytes("png")
+    except Exception:
+        return None
+
+
+def _attach_page_images(hits: list[dict], abs_source_path: Path, repo_root: Path) -> list[dict]:
+    """Attach a base64 page PNG to each visual hit that has a page number. Mutates + returns hits."""
+    import base64
+    for hit in hits:
+        if hit.get("type") == "visual" and hit.get("page"):
+            png = render_page_png(abs_source_path, hit["page"], repo_root)
+            if png is not None:
+                hit["image_b64"] = base64.b64encode(png).decode("ascii")
+    return hits
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRenderPageImages -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): add render_page_png + _attach_page_images helpers"
+```
+
+---
+
+### Task 5: Outline mode — `_focus_outline`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (add after Task 4 helpers)
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestFocusOutline:
+    def test_outline_returns_distinct_sections_in_page_order(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+
+        def mk(page, heading):
+            p = MagicMock(); p.payload = {"page": page, "section_heading": heading}; return p
+
+        client = MagicMock()
+        # Unordered, with a duplicate (3,"Intro") that must collapse.
+        client.scroll.return_value = (
+            [mk(3, "Intro"), mk(1, "Cover"), mk(3, "Intro"), mk(2, "Setup")], None)
+
+        rows = _focus_outline(client, ["test-project_doc"], _file_filter("imu.pdf"), "imu.pdf")
+
+        assert [(r["page"], r["section_heading"]) for r in rows] == [
+            (1, "Cover"), (2, "Setup"), (3, "Intro")]
+        assert all(r["type"] == "outline" and r["source"] == "imu.pdf" for r in rows)
+        # Outline must not embed anything — it scrolls payloads only.
+        client.scroll.assert_called_once()
+
+    def test_outline_skips_visual_collections(self):
+        from unittest.mock import MagicMock
+        from carta.embed.pipeline import _focus_outline, _file_filter
+        client = MagicMock(); client.scroll.return_value = ([], None)
+        _focus_outline(client, ["test-project_visual"], _file_filter("imu.pdf"), "imu.pdf")
+        client.scroll.assert_not_called()  # visual collections are skipped
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestFocusOutline -v`
+Expected: FAIL — `ImportError: cannot import name '_focus_outline'`.
+
+- [ ] **Step 3: Implement `_focus_outline`**
+
+Add to `carta/embed/pipeline.py`:
+
+```python
+def _focus_outline(client, collections: list[str], ff: Filter, source: str) -> list[dict]:
+    """Return the file's distinct (section_heading, page) rows in page order — a synthetic TOC.
+
+    Scrolls text-collection payloads only (no embedding); pages with no number sort last.
+    """
+    seen: set = set()
+    rows: list[tuple] = []
+    for coll in collections:
+        if coll.endswith("_visual"):
+            continue
+        try:
+            points, _ = client.scroll(
+                collection_name=coll, scroll_filter=ff,
+                with_payload=True, limit=10_000,
+            )
+        except Exception:
+            continue
+        for p in points:
+            payload = p.payload or {}
+            page = payload.get("page")
+            heading = payload.get("section_heading", "")
+            key = (page, heading)
+            if key in seen:
+                continue
+            seen.add(key)
+            sort_page = page if isinstance(page, int) else 1_000_000
+            rows.append((sort_page, page, heading))
+    rows.sort(key=lambda r: r[0])
+    return [{"score": 0.0, "source": source, "page": page,
+             "section_heading": heading, "excerpt": "", "type": "outline",
+             "doc_type": ""} for _sort, page, heading in rows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestFocusOutline -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): add _focus_outline (file section/page map)"
+```
+
+---
+
+### Task 6: Deep mode + orchestrator — `_focus_deep` and `run_focus`
+
+**Files:**
+- Modify: `carta/embed/pipeline.py` (add after Task 5)
+- Test: `carta/tests/test_pipeline.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRunFocus:
+    BASE_CFG = {
+        "project_name": "test-project",
+        "qdrant_url": "http://localhost:6333",
+        "embed": {"ollama_url": "http://localhost:11434",
+                  "ollama_model": "nomic-embed-text", "colpali_enabled": False},
+        "search": {"top_n": 5},
+        "modules": {"doc_search": True},
+    }
+
+    def test_deep_filters_to_file_and_keeps_all_chunks(self):
+        """Deep mode applies the file filter and does NOT dedup (multiple chunks, one source)."""
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_focus
+
+        def mk(page):
+            p = MagicMock(); p.score = 1.0 / page
+            p.payload = {"file_path": "docs/imu.pdf", "text": f"chunk p{page}",
+                         "page": page, "section_heading": f"S{page}", "doc_type": ""}
+            return p
+        resp = MagicMock(); resp.points = [mk(10), mk(11), mk(12)]
+        client = MagicMock(); client.query_points.return_value = resp
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=client), \
+             patch("carta.embed.pipeline.get_embedding", return_value=[0.0] * 768), \
+             patch("carta.embed.pipeline.collection_is_hybrid", return_value=False), \
+             patch("carta.embed.pipeline._ensure_file_path_index"), \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_focus("docs/imu.pdf (page 10)", self.BASE_CFG, query="sensitivity")
+
+        # All three chunks of the one file survive (dedup is off in focus).
+        assert len(results) == 3
+        assert {r["page"] for r in results} == {10, 11, 12}
+        assert all(r["source"] == "docs/imu.pdf" for r in results)
+        # Filter reached Qdrant (normalized — no '(page 10)' suffix).
+        ff = client.query_points.call_args.kwargs["query_filter"]
+        assert ff.must[0].match.value == "docs/imu.pdf"
+
+    def test_empty_query_returns_outline(self):
+        from unittest.mock import patch, MagicMock
+        from carta.embed.pipeline import run_focus
+
+        def mk(page, heading):
+            p = MagicMock(); p.payload = {"page": page, "section_heading": heading}; return p
+        client = MagicMock(); client.scroll.return_value = ([mk(1, "Cover"), mk(2, "Setup")], None)
+
+        with patch("carta.embed.pipeline.QdrantClient", return_value=client), \
+             patch("carta.embed.pipeline._ensure_file_path_index"), \
+             patch("carta.embed.pipeline.get_embedding") as mock_embed, \
+             patch("carta.search.scoped.get_search_collections", return_value=["test-project_doc"]), \
+             patch("carta.embed.pipeline.find_config", return_value="/fake/.carta/config.yaml"):
+            results = run_focus("docs/imu.pdf", self.BASE_CFG)  # no query
+
+        assert [r["type"] for r in results] == ["outline", "outline"]
+        assert [r["page"] for r in results] == [1, 2]
+        mock_embed.assert_not_called()  # outline does no embedding
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRunFocus -v`
+Expected: FAIL — `ImportError: cannot import name 'run_focus'`.
+
+- [ ] **Step 3: Implement `_focus_deep` and `run_focus`**
+
+Add to `carta/embed/pipeline.py`:
+
+```python
+def _focus_deep(client, collections: list[str], ff: Filter, query: str,
+                cfg: dict, repo_root: Path, source: str, limit: int) -> list[dict]:
+    """File-scoped deep retrieval: filtered per-collection queries, RRF fused, NO dedup,
+    NO visual cap, NO graph expansion; visual hits get a rendered page image."""
+    per_collection: list[list[dict]] = []
+    for coll_name in collections:
+        coll_results: list[dict] = []
+        try:
+            if coll_name.endswith("_visual"):
+                embed_cfg = cfg.get("embed", {})
+                if embed_cfg.get("colpali_enabled", None) is False:
+                    continue
+                from carta.embed.colpali import is_colpali_available, ColPaliEmbedder
+                if not is_colpali_available():
+                    continue
+                if not _visual_collection_ready(client, coll_name):
+                    continue
+                embedder = ColPaliEmbedder(
+                    model_name=embed_cfg.get("colpali_model", "vidore/colqwen2-v1.0-hf"),
+                    device=embed_cfg.get("colpali_device", "cpu"), batch_size=1)
+                qv = embedder.embed_query(query)
+                qv = qv.tolist() if hasattr(qv, "tolist") else list(qv)
+                response = client.query_points(
+                    collection_name=coll_name, query=qv, using="colpali",
+                    limit=limit, with_payload=True, query_filter=ff)
+                for r in response.points:
+                    payload = r.payload or {}
+                    coll_results.append({
+                        "score": r.score,
+                        "source": f"{payload.get('file_path', payload.get('slug', ''))} (page {payload.get('page_num', '?')})",
+                        "excerpt": f"[Visual result] Page {payload.get('page_num', '?')} - {payload.get('file_path', '')}",
+                        "type": "visual", "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page_num"), "section_heading": ""})
+            else:
+                ollama_url = cfg["embed"]["ollama_url"]
+                model = cfg["embed"]["ollama_model"]
+                query_vec = get_embedding(query, ollama_url=ollama_url, model=model,
+                                          prefix="search_query: ")
+                hybrid_cfg = cfg.get("search", {}).get("hybrid", {})
+                is_hybrid = collection_is_hybrid(client, coll_name)
+                if hybrid_cfg.get("enabled", False) and is_hybrid:
+                    response = _hybrid_query_collection(
+                        client, coll_name, query, query_vec, limit,
+                        prefetch_limit=hybrid_cfg.get("prefetch_limit", 40),
+                        bm25_model=hybrid_cfg.get("bm25_model", "Qdrant/bm25"),
+                        query_filter=ff)
+                elif is_hybrid:
+                    response = client.query_points(
+                        collection_name=coll_name, query=query_vec, using=DENSE_VECTOR_NAME,
+                        limit=limit, with_payload=True, query_filter=ff)
+                else:
+                    response = client.query_points(
+                        collection_name=coll_name, query=query_vec,
+                        limit=limit, with_payload=True, query_filter=ff)
+                for r in response.points:
+                    payload = r.payload or {}
+                    coll_results.append({
+                        "score": r.score,
+                        "source": payload.get("file_path", payload.get("slug", "")),
+                        "excerpt": payload.get("text", ""), "type": "text",
+                        "doc_type": payload.get("doc_type", ""),
+                        "page": payload.get("page"),
+                        "section_heading": payload.get("section_heading", "")})
+            per_collection.append(coll_results)
+        except Exception as e:
+            err_str = str(e).lower()
+            if "404" in err_str or "not found" in err_str or "doesn't exist" in err_str:
+                continue
+            if any(kw in err_str for kw in ("connection refused", "connection error",
+                                            "network", "timeout", "unreachable")):
+                raise RuntimeError(
+                    f"Cannot reach Qdrant — is it running? "
+                    f"Start it with: carta doctor --fix\n(Detail: {e})") from e
+            continue
+
+    # RRF fuse across lanes; visual_max_ratio=1.0 disables the cap (we WANT the file's pages).
+    fused = _rrf_merge_collections(per_collection, limit, visual_max_ratio=1.0)
+    fused = _attach_page_images(fused, repo_root / source, repo_root)
+    return fused[:limit]
+
+
+def run_focus(source: str, cfg: dict, *, query: str = "",
+              limit: int = _FOCUS_DEFAULT_LIMIT) -> list[dict]:
+    """Deep, file-scoped retrieval over a single source file.
+
+    Modes:
+      - query == "" : outline — the file's distinct (section_heading, page) rows in page order.
+      - query set   : deep — up to `limit` page-anchored passages from the file (dedup off,
+                      no graph expansion, visual cap off); visual hits carry image_b64.
+
+    Returns list of dicts: {score, source, page, section_heading, excerpt, type, doc_type, image_b64?}.
+    Fail-open: an unknown/never-embedded file yields []. Raises RuntimeError only on Qdrant transport failure.
+    """
+    from carta.search.scoped import get_search_collections
+
+    source = _normalize_source(source)
+    repo_root = Path(find_config()).parent.parent
+    try:
+        client = QdrantClient(url=cfg["qdrant_url"], timeout=10)
+    except Exception as e:
+        raise RuntimeError(f"Cannot connect to Qdrant: {e}") from e
+
+    try:
+        collections = get_search_collections(cfg, "repo")
+    except ValueError:
+        collections = [collection_name(cfg, "doc")]
+        if cfg.get("embed", {}).get("colpali_enabled", None) is not False:
+            collections.append(f"{cfg['project_name']}_visual")
+
+    ff = _file_filter(source)
+    for coll in collections:
+        _ensure_file_path_index(client, coll)
+
+    if not query:
+        return _focus_outline(client, collections, ff, source)
+    return _focus_deep(client, collections, ff, query, cfg, repo_root, source, limit)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest carta/tests/test_pipeline.py::TestRunFocus -v`
+Expected: PASS (both deep and outline modes).
+
+- [ ] **Step 5: Run the whole pipeline test module**
+
+Run: `python -m pytest carta/tests/test_pipeline.py -q`
+Expected: PASS (all Phase 1–2 tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add carta/embed/pipeline.py carta/tests/test_pipeline.py
+git commit -m "feat(search): add run_focus engine (deep file-scoped retrieval + outline)"
+```
+
+---
+
+## Phase 3 — Surfaces & docs
+
+### Task 7: MCP tool — `carta_focus`
+
+**Files:**
+- Modify: `carta/mcp/server.py` (import at line 19; add tool after `carta_search`, ~line 138)
+- Test: `carta/tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `carta/tests/test_mcp_server.py`:
+
+```python
+class TestCartaFocus:
+    def test_formats_results_and_passes_through_image(self):
+        from unittest.mock import patch
+        import carta.mcp.server as server
+
+        fake = [
+            {"score": 0.876543, "source": "docs/imu.pdf", "page": 47,
+             "section_heading": "6.3 Gyro", "excerpt": "x" * 400, "type": "text"},
+            {"score": 0.5, "source": "docs/imu.pdf (page 47)", "page": 47,
+             "section_heading": "", "excerpt": "[Visual]", "type": "visual",
+             "image_b64": "QkFTRTY0"},
+        ]
+        with patch.object(server, "_load_cfg", return_value={"x": 1}), \
+             patch.object(server, "run_focus", return_value=fake) as mock_focus:
+            out = server.carta_focus(source="docs/imu.pdf (page 47)", query="sensitivity", top_k=15)
+
+        mock_focus.assert_called_once_with("docs/imu.pdf (page 47)", {"x": 1},
+                                           query="sensitivity", limit=15)
+        assert out[0]["score"] == 0.8765          # rounded to 4dp
+        assert out[0]["page"] == 47
+        assert len(out[0]["excerpt"]) == 300       # truncated
+        assert out[1]["image_b64"] == "QkFTRTY0"   # passed through on visual hits
+
+    def test_returns_error_dict_on_config_failure(self):
+        from unittest.mock import patch
+        import carta.mcp.server as server
+        from carta.config import ConfigError
+        with patch.object(server, "_load_cfg", side_effect=ConfigError("no config")):
+            out = server.carta_focus(source="x.pdf")
+        assert out["error"] == "service_unavailable"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_mcp_server.py::TestCartaFocus -v`
+Expected: FAIL — `AttributeError: module 'carta.mcp.server' has no attribute 'carta_focus'`.
+
+- [ ] **Step 3: Add the import and the tool**
+
+In `carta/mcp/server.py`, extend the pipeline import (line 19) to include `run_focus`:
+
+```python
+from carta.embed.pipeline import run_search, run_focus, run_embed_file, discover_stale_files, run_embed, FILE_TIMEOUT_S
+```
+
+Add this tool immediately after `carta_search` returns (after ~line 138):
+
+```python
+@mcp_server.tool()
+def carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict] | dict:
+    """Go deep in ONE already-located file: page-anchored passages, an outline, and
+    table/figure pages returned as images.
+
+    Use AFTER carta_search has identified the relevant file — pass that result's `source`
+    string here. With an EMPTY query, returns the file's section/page outline (a synthetic
+    table of contents) so you can choose where to read.
+
+    Args:
+        source: Repo-relative file path (the `source` from a carta_search result; a
+                trailing " (page N)" from a visual result is fine — it is stripped).
+        query: Natural-language query. Empty string => outline mode.
+        top_k: Maximum passages to return (default 15).
+
+    Returns:
+        List of dicts: {score, source, page, section_heading, excerpt, type, image_b64?}.
+        `image_b64` is present on visual (table/figure) hits. On failure:
+        {"error": "<type>", "detail": "<message>"}.
+    """
+    try:
+        cfg = _load_cfg()
+    except (ConfigError, FileNotFoundError) as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+
+    try:
+        results = run_focus(source, cfg, query=query, limit=top_k)
+    except RuntimeError as e:
+        return {"error": "service_unavailable", "detail": str(e)}
+    except Exception as e:
+        _logger.warning("carta_focus unexpected error: %s", e)
+        return {"error": "service_unavailable", "detail": str(e)}
+
+    formatted = []
+    for r in results:
+        item = {
+            "score": round(r.get("score", 0.0), 4),
+            "source": r["source"],
+            "page": r.get("page"),
+            "section_heading": r.get("section_heading", ""),
+            "excerpt": (r.get("excerpt") or "")[:300],
+            "type": r.get("type", "text"),
+        }
+        if r.get("image_b64"):
+            item["image_b64"] = r["image_b64"]
+        formatted.append(item)
+    return formatted
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_mcp_server.py::TestCartaFocus -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add carta/mcp/server.py carta/tests/test_mcp_server.py
+git commit -m "feat(mcp): add carta_focus tool (file-scoped deep retrieval)"
+```
+
+---
+
+### Task 8: CLI subcommand — `carta focus`
+
+**Files:**
+- Modify: `carta/cli.py` (add `cmd_focus` after `cmd_search` ~line 330; subparser after `search_p` ~line 947; dispatch entry ~line 1054)
+- Test: `carta/tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `carta/tests/test_cli.py`:
+
+```python
+class TestCmdFocus:
+    def _cfg(self, tmp_path):
+        return {"modules": {"doc_search": True}, "project_name": "p",
+                "qdrant_url": "http://localhost:6333", "embed": {}}
+
+    def test_outline_mode_prints_sections(self, tmp_path, capsys):
+        import argparse
+        from unittest.mock import patch
+        from carta import cli
+        outline = [{"score": 0.0, "source": "imu.pdf", "page": 1,
+                    "section_heading": "Cover", "excerpt": "", "type": "outline"}]
+        args = argparse.Namespace(source="imu.pdf", query=[], limit=15)
+        with patch("carta.cli.find_config", return_value=tmp_path / ".carta" / "config.yaml"), \
+             patch("carta.config.load_config", return_value=self._cfg(tmp_path)), \
+             patch("carta.embed.pipeline.run_focus", return_value=outline):
+            cli.cmd_focus(args)
+        out = capsys.readouterr().out
+        assert "Outline of imu.pdf" in out and "Cover" in out
+
+    def test_deep_mode_writes_image_and_prints_path(self, tmp_path, capsys):
+        import argparse, base64
+        from unittest.mock import patch
+        from carta import cli
+        (tmp_path / ".carta").mkdir()
+        hits = [{"score": 0.9, "source": "imu.pdf", "page": 47,
+                 "section_heading": "Gyro", "excerpt": "regs",
+                 "type": "visual", "image_b64": base64.b64encode(b"PNG").decode()}]
+        args = argparse.Namespace(source="imu.pdf", query=["gyro", "regs"], limit=15)
+        with patch("carta.cli.find_config", return_value=tmp_path / ".carta" / "config.yaml"), \
+             patch("carta.config.load_config", return_value=self._cfg(tmp_path)), \
+             patch("carta.embed.pipeline.run_focus", return_value=hits):
+            cli.cmd_focus(args)
+        out = capsys.readouterr().out
+        assert "p.47" in out and "Gyro" in out
+        img = tmp_path / ".carta" / "cache" / "focus" / "imu-p47.png"
+        assert img.is_file() and img.read_bytes() == b"PNG"
+        assert str(img) in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest carta/tests/test_cli.py::TestCmdFocus -v`
+Expected: FAIL — `AttributeError: module 'carta.cli' has no attribute 'cmd_focus'`.
+
+- [ ] **Step 3: Implement `cmd_focus`, the subparser, and dispatch**
+
+Add `cmd_focus` after `cmd_search` in `carta/cli.py` (`Path` is already imported at the top of the module):
+
+```python
+def cmd_focus(args):
+    from carta.config import load_config
+    cfg_path = find_config()
+    cfg = load_config(cfg_path)
+    if not cfg["modules"].get("doc_search"):
+        print("doc_search module is disabled in config.", file=sys.stderr)
+        sys.exit(1)
+    from carta.embed.pipeline import run_focus
+    repo_root = cfg_path.parent.parent
+    query = " ".join(args.query) if args.query else ""
+    try:
+        results = run_focus(args.source, cfg, query=query, limit=args.limit)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not results:
+        print(f"No focus results for {args.source!r}. Is the file embedded? "
+              f"Use `carta search` to find the exact source path.")
+        return
+
+    if not query:
+        print(f"Outline of {args.source} ({len(results)} sections):")
+        for r in results:
+            page = r.get("page")
+            page_s = f"p.{page}" if page is not None else "p.?"
+            heading = r.get("section_heading") or "(no heading)"
+            print(f"  {page_s:>6}  {heading}")
+        return
+
+    cache_dir = repo_root / ".carta" / "cache" / "focus"
+    stem = Path(args.source).stem
+    for r in results:
+        page = r.get("page")
+        page_s = f"p.{page}" if page is not None else "p.?"
+        heading = r.get("section_heading") or ""
+        head_s = f" §{heading}" if heading else ""
+        print(f"[{r['score']:.2f}] {r['source']} {page_s}{head_s} — {r['excerpt']}")
+        if r.get("image_b64"):
+            import base64
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            img_path = cache_dir / f"{stem}-p{page}.png"
+            img_path.write_bytes(base64.b64decode(r["image_b64"]))
+            print(f"        ↳ page image: {img_path}")
+```
+
+Add the subparser after the `search_p` block (~line 947):
+
+```python
+    focus_p = sub.add_parser(
+        "focus",
+        help="Go deep in one file: page-anchored passages, or an outline (omit the query)")
+    focus_p.add_argument("query", nargs="*",
+                         help="Query to search within the file; omit for a section/page outline")
+    focus_p.add_argument("--source", required=True, metavar="PATH",
+                         help="Repo-relative file path (the 'source' from a carta search result)")
+    focus_p.add_argument("--limit", type=int, default=15,
+                         help="Max passages to return (default 15)")
+```
+
+Add to the `dispatch` dict (~line 1044):
+
+```python
+        "focus": cmd_focus,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest carta/tests/test_cli.py::TestCmdFocus -v`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke-test argparse wiring**
+
+Run: `python -m carta focus --help`
+Expected: prints focus usage with `--source` and `--limit`; exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add carta/cli.py carta/tests/test_cli.py
+git commit -m "feat(cli): add carta focus subcommand (deep file search + outline)"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (Carta surface CLI table + MCP tools line), `README.md`, `AGENTS.md`
+
+- [ ] **Step 1: Update the CLAUDE.md surface table**
+
+In `CLAUDE.md`, add a row to the CLI table (after the `search` row):
+
+```markdown
+| `focus` | Deep retrieval scoped to **one file**: page-anchored passages, an outline (omit query), and table/figure pages as images. Two-step partner to `search` (locate → go deep) |
+```
+
+Update the MCP tools line to list the new tool:
+
+```markdown
+Claude-initiated tools: `carta_search`, `carta_focus`, `carta_embed`, `carta_scan`, `carta_remember`.
+```
+
+- [ ] **Step 2: Update README.md and AGENTS.md**
+
+Mirror the same one-line description of `carta focus` / `carta_focus` wherever `carta search` / `carta_search` is documented in `README.md` and `AGENTS.md` (search each file for "carta search" and add the focus partner alongside, noting: file-scoped, outline via empty query, images for table/figure pages).
+
+- [ ] **Step 3: Verify references**
+
+Run: `grep -rn "carta_focus\|carta focus" CLAUDE.md README.md AGENTS.md`
+Expected: each file shows the new entries.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md AGENTS.md
+git commit -m "docs: document carta focus (CLI) and carta_focus (MCP)"
+```
+
+---
+
+### Task 10: Acceptance — full suite + broad-eval no-regression
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `python -m pytest carta -q`
+Expected: PASS (all green, including the new focus tests). If any pre-existing test asserted an exact result-dict shape, fix it to include `page`/`section_heading` (Task 1) and re-run.
+
+- [ ] **Step 2: Broad-eval no-regression gate**
+
+Confirm the eval set path, then run the default (rerank-off) eval:
+
+Run: `carta eval .carta/eval/et-embed.yaml -k 5`
+Expected: recall@5 **≥ 0.984** (the v0.12.4 baseline). Anchor surfacing is pure metadata and `run_focus` is new surface area, so broad recall must be unchanged. If the local eval set lives elsewhere, use that path; if it is unavailable in this environment, record that the gate was skipped and why.
+
+- [ ] **Step 3: Manual end-to-end smoke (if a populated project is available)**
+
+```bash
+carta focus --source <a-real-embedded-pdf>            # outline mode
+carta focus --source <a-real-embedded-pdf> register sensitivity   # deep mode
+```
+Expected: outline lists sections with page numbers; deep mode prints page-anchored passages and, for any visual hit, writes a PNG under `.carta/cache/focus/` and prints its path.
+
+- [ ] **Step 4: Final commit (if Step 1 required test fixes)**
+
+```bash
+git add -A
+git commit -m "test: align result-shape assertions with page/section anchors"
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Spec coverage:** Piece 1 → Task 1. Piece 2 (filter, dedup-off, visual-cap-off, outline, deep) → Tasks 2–6. Piece 3 (render helper) → Task 4. Surfaces → Tasks 7–8. Docs + acceptance → Tasks 9–10. Mode C is intentionally **out of scope** (no `pages` param) per the spec.
+- **Type consistency:** every hit dict uses the keys `{score, source, page, section_heading, excerpt, type, doc_type, image_b64?}`. `run_focus(source, cfg, *, query="", limit=...)` is called identically from the MCP tool (`limit=top_k`) and CLI (`limit=args.limit`). Filter param names are deliberately different per qdrant-client API: `query_filter` (query_points), `scroll_filter` (scroll), `filter` (Prefetch).
+- **No silent caps:** outline scroll uses `limit=10_000`; if a single file ever exceeds that, raise it — do not let it silently truncate the TOC.

--- a/docs/superpowers/specs/2026-06-18-carta-focus-design.md
+++ b/docs/superpowers/specs/2026-06-18-carta-focus-design.md
@@ -1,0 +1,267 @@
+# `carta focus` — focused, file-scoped retrieval — design
+
+- **Date:** 2026-06-18
+- **Status:** approved (pending spec review)
+- **Issue:** follow-up from the search-result-dedup work (#73) and the first-stage-recall thread (#19) — the broad search now finds the right *file*; this adds the "go deep in that file" half.
+- **Scope owner:** Ian
+
+## Context
+
+Carta has exactly **one** retrieval surface today: `run_search` (`carta/embed/pipeline.py:1776`)
+fans a query across every project collection (text + visual), fuses by RRF, and — since
+the v0.12.4 dedup default (#73) — collapses results to **one chunk per file**. That
+default is tuned for **breadth** ("which documents are relevant"), which is the *opposite*
+of what an agent needs once it has located the right file and must extract a specific
+answer from it (**depth** — several passages, a register table, a circuit figure, all from
+the *same* doc).
+
+Three concrete gaps motivate a focused mode:
+
+1. **No way to aim at one file.** There is zero payload filtering anywhere in the pipeline
+   (verified). An agent cannot say "search, but only inside `datasheet.pdf`."
+2. **Page anchors are computed but dropped.** Every chunk is stamped with `page` and
+   `section_heading` at chunk time (`carta/embed/parse.py:204`), and the upsert stores
+   *all* chunk keys except the raw text (`carta/embed/embed.py:256`) — so `page` and
+   `section_heading` are sitting in the Qdrant payload right now. But `run_search` returns
+   only `{score, source, excerpt, type, doc_type}` (`pipeline.py:1930`), dropping them.
+   The agent is told *which file* but not *which page*.
+3. **Tables/figures extract poorly as text.** A register bit-field table or pin-out
+   extracts as scrambled linear text (column order and merged cells collapse), so even a
+   correctly-retrieved table chunk is untrustworthy as text. The agent wants to *see* the
+   page. Carta already renders and caches page PNGs for ColPali
+   (`carta/embed/colpali.py:443`), and PyMuPDF (an existing dependency) can render any
+   page on demand.
+
+### The agent workflow this serves
+
+The realistic agent loop for a technical datasheet is two-step, and step 3 is the missing
+rung:
+
+1. **Locate** — `carta search "gyro sensitivity"` → returns the relevant file.
+2. **Orient/Deepen** — focus on that file: get many page-anchored passages, an outline of
+   its sections, and the register-table page *as an image*.
+3. **Verify** — open the exact page(s) at full fidelity (the agent's own PDF reader, or
+   the image Carta returns) and answer.
+
+Carta's highest-leverage role is **routing the agent to the exact page**, not
+re-implementing PDF reading. The data to do so already exists; this feature surfaces it.
+
+## Goal
+
+Add a distinct **focus** capability — `carta focus` (CLI) and `carta_focus` (MCP) — that,
+given a file, returns deep, page-anchored results from *that file only*, with table/figure
+pages delivered as images. Plus a shared foundation: surface `page` + `section_heading` on
+**every** search result (broad included).
+
+### Non-goals
+
+- **No re-embed, no chunking/embedding changes.** This is a read-path feature over the
+  existing index.
+- **No table-vs-prose classifier for text chunks.** "Is this text chunk a table?" is not
+  detectable without new analysis; the visual lane already isolates image-heavy pages and
+  that is the signal we use (see Mechanism). The residual "table embedded only as text"
+  case is a known limitation (Follow-ups).
+- **No broad-search ranking changes.** Anchor surfacing is pure metadata; selection/order
+  is untouched.
+- **No fuzzy file resolution in v1.** `source` is matched exactly (with one normalization,
+  below). Substring resolution for human CLI use is a noted follow-up.
+
+## Mechanism
+
+Two independently-shippable pieces. The engine is shared; focus is a thin orchestration
+over the same per-collection query/scroll helpers `run_search` already uses, with a file
+filter and dedup off.
+
+### Piece 1 — Anchor surfacing (shared foundation, benefits all search)
+
+In the per-collection result builders inside `run_search`, add `page` and
+`section_heading` to each result dict, read straight from the payload:
+
+- Text hits (`pipeline.py:1930-1938`): `"page": payload.get("page")`,
+  `"section_heading": payload.get("section_heading", "")`.
+- Visual hits (`pipeline.py:1881-1889`): `"page": payload.get("page_num")` (already read
+  for the `source` string), `"section_heading": ""`.
+
+Purely additive — existing consumers read results by key, so extra keys are inert. Broad
+search immediately gains "≈ p.47, §6.3" context. No ranking, selection, or count change.
+
+### Piece 2 — `run_focus` (the focused engine) with three modes
+
+`run_focus(source, cfg, *, query="", limit=_FOCUS_DEFAULT_LIMIT)` resolves the
+collections exactly like `run_search` (`get_search_collections(cfg, "repo")`), but every
+Qdrant call carries a **file filter** on the `file_path` payload key
+(`models.Filter(must=[FieldCondition(key="file_path", match=MatchValue(value=source))])`).
+The same key exists on both text and visual points, so one filter scopes both lanes.
+
+- **Mode A — Outline (`query` empty, `pages` None).** `client.scroll` each collection with
+  the file filter and `with_payload=True` (no embedding call), collect
+  `(page, section_heading, chunk_index)`, and return the distinct sections in page order —
+  a synthetic table of contents straight from the payloads. This is the cheapest possible
+  fix for "which page?": the agent pulls the structure, then picks where to read.
+
+- **Mode B — Deep query (`query` set).** Same retrieval path as `run_search` (hybrid
+  BM25+dense with RRF, optional rerank), but: file filter on; **dedup forced off** (every
+  text passage of one file shares the same `source`=`file_path`, so dedup would collapse
+  all of them to one — off is mandatory, not a tuning choice); limit defaults to
+  `_FOCUS_DEFAULT_LIMIT` (**15**); **no cross-file graph expansion** (a single file makes
+  it a no-op); and the **visual cap is disabled** (`visual_max_ratio=1.0`) so the file's
+  table/figure pages are *not* throttled the way broad search suppresses them — surfacing
+  those pages is the entire point. Returns up to `limit` page-anchored passages from the
+  one file; visual-lane hits (the file's image-heavy pages — exactly its tables/figures)
+  carry a rendered page image (see Piece 3). Mode B is only *legible* once Piece 1 ships:
+  with one shared `source`, `page`/`section_heading` are what distinguish the passages —
+  so anchor surfacing is a hard prerequisite, not just a nicety.
+
+- **Mode C — Explicit page render, DEFERRED to a follow-up.** Adds a `pages` parameter
+  (e.g. `pages="47-48"`) → render those pages + return their extracted text/anchors
+  regardless of lane. Closes the "table embedded only as text, agent has no file access"
+  case for remote MCP clients. Specified here for completeness; **not in the v1 build, and
+  the `pages` param is not added until then** (YAGNI — Modes A/B cover the primary
+  local-agent flow). Pulled in only if the remote case proves it necessary.
+
+`source` normalization: a trailing `" (page N)"` suffix (the shape of a *visual* hit's
+`source` from broad search) is stripped to recover the bare `file_path` before filtering,
+so an agent can pass back either form verbatim.
+
+### Piece 3 — Page-image rendering (shared helper)
+
+`render_page_png(file_path: Path, page: int, cfg) -> bytes | None`:
+
+1. Fast path: if a ColPali cache PNG exists (`colpali.py:443` naming,
+   `pdf_cache_dir / f"page_{page:04d}.png"`), read and return it.
+2. Else render on demand via PyMuPDF at the configured DPI.
+3. Non-PDF source, page out of range, or render failure → `None` (caller degrades to
+   anchors-only for that hit). Pure of project state beyond reading the source file.
+
+This makes images work even on text-only projects that never ran ColPali; the cache is an
+optimization, not a requirement.
+
+## Components & interfaces
+
+### `run_search` change (Piece 1)
+Add `page` + `section_heading` to both result builders. ~2 lines each. No signature change.
+
+### `run_focus(...)` (new, `carta/embed/pipeline.py`)
+Returns `list[dict]`; each hit:
+`{score, source, page, section_heading, excerpt, type, doc_type, image_b64?}`.
+- `image_b64` present only on visual hits (Mode B) and only when `render_page_png`
+  succeeded. The **engine** produces base64 (a transport-neutral form); the CLI surface
+  rewrites it to a file path (below).
+- Outline mode (A) returns hits with `excerpt=""`, `type="outline"`, populated
+  `page`/`section_heading`.
+
+### `render_page_png(...)` (new, `carta/embed/pipeline.py` or `carta/embed/parse.py`)
+As specified in Piece 3.
+
+### `file_path` payload index (new, lazy + idempotent)
+Filtering is *correct* without an index (Qdrant full-scans), but a keyword payload index
+makes it fast. `run_focus` lazily ensures it
+(`create_payload_index(..., field_name="file_path", field_schema="keyword")`, ignoring
+"already exists") on existing collections — no re-embed — and collection creation adds it
+going forward.
+
+### MCP — `carta_focus` (new tool, `carta/mcp/server.py`)
+`carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict]`. Returns the
+`run_focus` shape with `image_b64` inline for visual hits — the calling agent sees the
+page without any filesystem access. Tool description explicitly frames it as the
+go-deep-in-one-file companion to `carta_search`, and notes the no-query outline mode.
+Mirrors the existing tool registration pattern (`carta_search`/`carta_embed`/`carta_scan`/
+`carta_remember`).
+
+### CLI — `carta focus` (new subcommand, `carta/cli.py`)
+`carta focus --source PATH [query ...] [--limit N]`. `cmd_focus` calls `run_focus`, then:
+- prints score / page / section / excerpt per hit;
+- for visual hits, **writes the PNG bytes to `.carta/cache/focus/<slug>-p<N>.png` and
+  prints the path** (terminals can't render inline images; a path is exactly what an agent
+  consumes — it `Read`s the PNG at full fidelity). The transient `image_b64` is not printed
+  raw.
+- Respects the `doc_search` module flag, matching `cmd_search` (`cli.py:289`).
+
+## Result shapes (summary)
+
+| Mode | Trigger | Per-hit keys | Image |
+|------|---------|--------------|-------|
+| Broad (existing) | `carta search` | `+ page, section_heading` (new) | none |
+| Outline (A) | `focus`, no query | `page, section_heading, type="outline"` | none |
+| Deep (B) | `focus` + query | full + anchors | visual hits: `image_b64` (MCP) / path (CLI) |
+
+## Error handling (fail-open, house style)
+
+- `source` not found / file never embedded → empty list + a clear stderr/`note` line, not
+  an exception.
+- File deleted since embed → anchors still returned from the index; `render_page_png`
+  returns `None`, image silently omitted.
+- PyMuPDF render failure / page out of range → anchors-only for that hit.
+- Non-PDF (markdown) source → no images; passages + anchors only.
+- Per-collection fetch errors reuse `run_search`'s existing skip-on-404 /
+  raise-on-transport handling.
+
+## No-regression argument
+
+- **Broad eval (62-query ET-embed, recall@5 ≥ 0.984).** Piece 1 adds payload-derived keys
+  to result dicts without touching fetch depth, fusion, dedup, cap, or truncation —
+  ranking and the returned doc set are identical. Recall is therefore unchanged by
+  construction; confirmed by re-running `carta eval .carta/eval/et-embed.yaml -k 5`.
+- **Consumers tolerate extra keys.** The hook, eval, and MCP/CLI formatters read results
+  by key, not by exact dict shape; added keys are inert. Verified during Phase 1.
+- **`run_focus` is new and additive** — no existing call path changes behavior.
+
+## Config & defaults
+
+No new config section required.
+- `_FOCUS_DEFAULT_LIMIT = 15` — module constant in `pipeline.py` (overridable per call via
+  `top_k` / `--limit`; promote to config only if a tuning need appears — YAGNI).
+- Image cache under `.carta/cache/focus/` (CLI only).
+- Focus honors the existing `modules.doc_search` flag; no new toggle.
+
+## Testing (TDD)
+
+1. **Piece 1 (unit, mocked Qdrant):** text and visual result builders surface
+   `page`/`section_heading` from payload; absent keys degrade to `None`/`""`; broad
+   `run_search` output is otherwise byte-identical (selection/order unchanged).
+2. **`run_focus` file filter (integration, mocked Qdrant):** results come only from
+   `source`; dedup is off (multiple chunks of one file returned); `_FOCUS_DEFAULT_LIMIT`
+   honored; cross-file graph expansion not invoked.
+3. **Outline mode (A):** empty query → distinct `(section_heading, page)` in page order via
+   `scroll`, no embedding call issued.
+4. **`render_page_png` (unit):** ColPali cache hit returns cached bytes; cache miss renders
+   via PyMuPDF; non-PDF / out-of-range / failure → `None`.
+5. **`source` normalization:** `"foo.pdf (page 12)"` and `"foo.pdf"` both filter to
+   `foo.pdf`.
+6. **Surfaces:** `carta_focus` MCP returns `image_b64` for a visual hit; `carta focus` CLI
+   writes a PNG to cache and prints its path; both respect `doc_search` disabled.
+7. **Acceptance:** broad eval recall@5 unchanged (≥ 0.984); a focused fixture
+   (answer-spans-multiple-chunks; answer-in-a-table) returns the relevant passages with
+   correct page anchors and an image for the table page.
+
+## Phasing
+
+1. **Anchor surfacing** on all search results + tests (tiny; independently shippable; the
+   broad search benefits immediately).
+2. **Focus engine** — `run_focus` Modes A/B, `render_page_png`, lazy `file_path` payload
+   index + tests.
+3. **Surfaces** — `carta_focus` MCP tool + `carta focus` CLI + tests + docs (CLAUDE.md
+   "Carta surface" table, README, AGENTS.md).
+
+## Risk & rollback
+
+- **Risk:** unindexed `file_path` filter is slow on large collections. *Mitigation:* lazy
+  keyword index; filtering is correct (if slower) even before it exists.
+- **Risk:** on-demand PyMuPDF render adds latency on image hits. *Mitigation:* ColPali
+  cache fast-path; render only visual-lane hits (≤ the visual share of `limit`), lazily.
+- **Risk:** extra result keys break a consumer. *Mitigation:* Phase 1 audit of hook/eval/
+  formatters; keys are additive.
+- **Rollback:** the feature is new surface area — removing the `carta focus` / `carta_focus`
+  entry points disables it with no effect on broad search. Piece 1 is a metadata add with
+  no behavioral coupling.
+
+## Out of scope / follow-ups (tracked, not in this build)
+
+- **Mode C — explicit `--pages` render** (remote-MCP agent needs a text-only table page as
+  an image). Cheap to add; deferred until the remote case demands it.
+- **Substring / fuzzy `source` resolution** for human CLI use (resolve a unique substring
+  against indexed `file_path`s).
+- **Broad search → focus hint**: have `carta search` results suggest the focus follow-up
+  (e.g. an injected "↳ `carta focus --source X` to go deeper").
+- **Table-aware text chunks**: a classifier flagging table chunks so text-lane table hits
+  can auto-attach images (needs new analysis at embed time).


### PR DESCRIPTION
## Summary
Adds **`carta focus`** (CLI) and **`carta_focus`** (MCP) — file-scoped deep retrieval, the two-step partner to `carta search`: locate the file with search, then go *deep* in it with focus.

- **Outline mode** (empty query) → the file's section/page map (a synthetic TOC, no embedding — pure Qdrant scroll).
- **Deep mode** (query) → up to 15 page-anchored passages from that *one* file (dedup off, visual cap off, no graph expansion), so multi-part answers and register tables aren't collapsed away.
- **Table/figure pages as images** → visual-lane hits carry the rendered page PNG (MCP: base64 inline; CLI: written to `.carta/cache/focus/` with the path printed). Rendered on demand via PyMuPDF, with the ColPali cache as a fast path.
- **Shared foundation:** every search result now surfaces `page` + `section_heading` (the data was already in the payload; broad search benefits too).

Read-path only — **no re-embed**, and **no change to broad-search ranking/selection** (Phase 1 is additive metadata; `run_focus` is entirely new surface). The MCP tool calls the real `run_focus` engine (not `carta_search`'s bespoke path). Deferred follow-up: explicit `--pages` render ("Mode C") for the remote-MCP table-as-text case.

Spec: `docs/superpowers/specs/2026-06-18-carta-focus-design.md` · Plan: `docs/superpowers/plans/2026-06-18-carta-focus.md`

## Test Plan
- [x] Full suite green: **1059 passed, 1 skipped**
- [x] Live smoke vs. the real `ET-embed` IMU datasheet (`LSM6DSV320X`): outline returned 210 page-anchored sections; deep mode returned 6 passages **all from the one file** (surfacing the `CTRL2`/`CTRL_EIS` gyro register pages + sensitivity); broad search unaffected and now carries anchors. Confirms the real Qdrant `file_path` filter, lazy payload index, and scroll all work.
- [ ] Formal `carta eval .carta/eval/et-embed.yaml -k 5` recall@5 ≥ 0.984 — run in the ET-embed project with this branch (corpus/YAML live there). No-regression is structural: Phase 1 is additive metadata, `run_focus` is new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)