### PR TITLE
feat(search): surface page + section anchors in broad search output

### DIFF
--- a/carta/cli.py
+++ b/carta/cli.py
@@ -306,7 +306,12 @@ def cmd_search(args):
     from carta.config import NOTE_DOC_TYPES
     for r in results:
         tag = f"[{r['doc_type']}] " if r.get("doc_type") in NOTE_DOC_TYPES else ""
-        print(f"[{r['score']:.2f}] {tag}{r['source']} — {r['excerpt']}")
+        page = r.get("page")
+        loc = f" p.{page}" if page is not None else ""
+        heading = r.get("section_heading") or ""
+        if heading:
+            loc += f" §{heading}"
+        print(f"[{r['score']:.2f}] {tag}{r['source']}{loc} — {r['excerpt']}")
 
     hops = getattr(args, "hops", 0)
     if hops > 0:

--- a/carta/mcp/server.py
+++ b/carta/mcp/server.py
@@ -50,6 +50,23 @@ def _repo_root_from_cfg() -> Path:
     return find_config().parent.parent
 
 
+def _format_search_result(r: dict) -> dict:
+    """Shape a raw search hit into the MCP wire dict: rounded score, page/section anchors,
+    truncated excerpt, and (for visual hits) the page image. Defensive .get() throughout."""
+    item = {
+        "score": round(r.get("score", 0.0), 4),
+        "source": r.get("source", ""),
+        "page": r.get("page"),
+        "section_heading": r.get("section_heading", ""),
+        "excerpt": (r.get("excerpt") or "")[:300],
+    }
+    if r.get("type") == "visual":
+        item["type"] = "visual"
+        if r.get("image_b64"):
+            item["image_b64"] = r["image_b64"]
+    return item
+
+
 # ---------------------------------------------------------------------------
 # Tool handlers
 # ---------------------------------------------------------------------------
@@ -73,8 +90,8 @@ def carta_search(
                permitted cross-project), or "global" (global collections only).
 
     Returns:
-        List of result dicts. Text results: {score, source, excerpt}.
-        Visual results: {score, source, type, image_b64, excerpt}.
+        List of result dicts: {score, source, page, section_heading, excerpt}.
+        Visual results also include {type: "visual", image_b64}.
         On failure, returns {"error": "<type>", "detail": "<message>"}.
     """
     try:
@@ -120,22 +137,8 @@ def carta_search(
         _logger.warning("carta_search unexpected error: %s", e)
         return {"error": "service_unavailable", "detail": str(e)}
     
-    # Format results for return
-    formatted = []
-    for r in results:
-        result = {
-            "score": round(r["score"], 4),
-            "source": r["source"],
-            "excerpt": r["excerpt"][:300],
-        }
-        # Include type if present
-        if r.get("type") == "visual":
-            result["type"] = "visual"
-            if r.get("image_b64"):
-                result["image_b64"] = r["image_b64"]
-        formatted.append(result)
-    
-    return formatted
+    # Format results for return (page/section anchors + visual image passthrough)
+    return [_format_search_result(r) for r in results]
 
 
 def carta_focus(source: str, query: str = "", top_k: int = 15) -> list[dict] | dict:
@@ -205,7 +208,8 @@ def _run_search_collection(query: str, cfg: dict, collection_name: str, top_n: i
         top_n: Maximum number of results.
     
     Returns:
-        List of dicts: {"score": float, "source": str, "excerpt": str}
+        List of dicts: {"score": float, "source": str, "excerpt": str,
+        "page": int|None, "section_heading": str}
     """
     from qdrant_client import QdrantClient
     from carta.embed.embed import get_embedding
@@ -233,6 +237,8 @@ def _run_search_collection(query: str, cfg: dict, collection_name: str, top_n: i
             "score": r.score,
             "source": payload.get("file_path", payload.get("slug", "")),
             "excerpt": payload.get("text", ""),
+            "page": payload.get("page"),
+            "section_heading": payload.get("section_heading", ""),
         })
     return hits
 
@@ -319,7 +325,8 @@ def _run_search_visual_collection(
                 "excerpt": f"Visual match from page {payload.get('page_num', '?')}",
                 "type": "visual",
                 "image_b64": image_b64,
-                "page_num": payload.get("page_num"),
+                "page": payload.get("page_num"),
+                "section_heading": "",
                 "png_path": png_path_str,
             })
         

--- a/carta/tests/test_cli.py
+++ b/carta/tests/test_cli.py
@@ -971,3 +971,24 @@ class TestCmdFocus:
         img = tmp_path / ".carta" / "cache" / "focus" / "imu-p47.png"
         assert img.is_file() and img.read_bytes() == b"PNG"
         assert str(img) in out
+
+
+class TestCmdSearchAnchors:
+    def test_search_shows_page_when_present_omits_when_absent(self, tmp_path, capsys):
+        import argparse
+        from unittest.mock import patch
+        from carta import cli
+        results = [
+            {"score": 0.8, "source": "docs/imu.pdf", "excerpt": "regs",
+             "doc_type": "", "type": "text", "page": 47, "section_heading": "6.3 Gyro"},
+            {"score": 0.7, "source": "docs/readme.md", "excerpt": "intro",
+             "doc_type": "", "type": "text", "page": None, "section_heading": ""},
+        ]
+        args = argparse.Namespace(query=["gyro"], hops=0)
+        with patch("carta.cli.find_config", return_value=tmp_path / ".carta" / "config.yaml"), \
+             patch("carta.config.load_config", return_value={"modules": {"doc_search": True}}), \
+             patch("carta.embed.pipeline.run_search", return_value=results):
+            cli.cmd_search(args)
+        lines = [l for l in capsys.readouterr().out.splitlines() if l.startswith("[")]
+        assert "p.47" in lines[0] and "6.3 Gyro" in lines[0]
+        assert "p." not in lines[1]   # no page -> no "p.N" noise on broad results

--- a/carta/tests/test_mcp_server.py
+++ b/carta/tests/test_mcp_server.py
@@ -183,3 +183,41 @@ class TestCartaFocus:
             out = server.carta_focus(source="x.pdf")
         assert out["error"] == "service_unavailable"
         assert "Qdrant down" in out["detail"]
+
+
+class TestSearchAnchors:
+    def test_run_search_collection_includes_page_and_section(self):
+        from unittest.mock import patch, MagicMock
+        import carta.mcp.server as server
+        point = MagicMock(); point.score = 0.9
+        point.payload = {"file_path": "docs/imu.pdf", "text": "regs",
+                         "page": 47, "section_heading": "6.3 Gyro"}
+        resp = MagicMock(); resp.points = [point]
+        client = MagicMock(); client.query_points.return_value = resp
+        cfg = {"qdrant_url": "http://localhost:6333",
+               "embed": {"ollama_url": "x", "ollama_model": "m"}}
+        with patch("qdrant_client.QdrantClient", return_value=client), \
+             patch("carta.embed.embed.get_embedding", return_value=[0.0] * 768):
+            hits = server._run_search_collection("gyro", cfg, "p_doc", 5)
+        assert hits[0]["page"] == 47
+        assert hits[0]["section_heading"] == "6.3 Gyro"
+
+    def test_format_search_result_surfaces_page_section_truncates(self):
+        import carta.mcp.server as server
+        out = server._format_search_result(
+            {"score": 0.87654, "source": "docs/imu.pdf", "excerpt": "x" * 400,
+             "page": 47, "section_heading": "6.3 Gyro", "type": "text"})
+        assert out["page"] == 47
+        assert out["section_heading"] == "6.3 Gyro"
+        assert out["score"] == 0.8765
+        assert len(out["excerpt"]) == 300
+        assert "image_b64" not in out
+
+    def test_format_search_result_passes_through_visual_image(self):
+        import carta.mcp.server as server
+        out = server._format_search_result(
+            {"score": 0.5, "source": "docs/imu.pdf (page 47)", "excerpt": "[Visual]",
+             "page": 47, "section_heading": "", "type": "visual", "image_b64": "QkE="})
+        assert out["type"] == "visual"
+        assert out["image_b64"] == "QkE="
+        assert out["page"] == 47


### PR DESCRIPTION
## Summary
Phase 1 of carta-focus (#74) put `page` + `section_heading` into `run_search`'s result dicts, but neither display surface actually showed them. This wires them through:

- **`carta search` (CLI)** now prints ` p.N §heading` when present (omitted for page-less hits, so markdown results stay clean).
- **`carta_search` (MCP)** now returns `page` + `section_heading`. `_run_search_collection` and the visual builder carry them, and the formatting is extracted into a small testable `_format_search_result` helper (the tool itself is decorator-wrapped and not directly callable in the mocked-mcp test env).

Read-path only; no ranking change.

## Test Plan
- [x] TDD: `TestCmdSearchAnchors` (CLI) + `TestSearchAnchors` (MCP) — RED→GREEN.
- [x] Full suite: **1063 passed, 1 skipped**.
- [x] Verified live vs. ET-embed: `carta search "…sensitivity register"` → `…LSM6DSV320X_datasheet.pdf p.123 …` and a markdown hit showing `p.7 §…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)